### PR TITLE
Align local dev setup with direct S3 recording

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,16 +1,14 @@
 # Database
-DATABASE_URL=postgresql://cozytrack:cozytrack@localhost:5432/cozytrack
+DATABASE_URL=postgresql://cozytrack:cozytrack@localhost:5433/cozytrack
 
 # LiveKit
 LIVEKIT_API_KEY=devkey
-LIVEKIT_API_SECRET=secret
+LIVEKIT_API_SECRET=cozytrack-local-livekit-secret-32
 LIVEKIT_URL=ws://localhost:7880
 
 # AWS S3
-AWS_ACCESS_KEY_ID=
-AWS_SECRET_ACCESS_KEY=
-AWS_REGION=us-east-1
-S3_BUCKET_NAME=cozytrack-recordings
+AWS_REGION=us-west-2
+S3_BUCKET_NAME=cozytrack-dev-pasha
 
 # App
 NEXT_PUBLIC_LIVEKIT_URL=ws://localhost:7880

--- a/.env.example
+++ b/.env.example
@@ -7,6 +7,9 @@ LIVEKIT_API_SECRET=cozytrack-local-livekit-secret-32
 LIVEKIT_URL=ws://localhost:7880
 
 # AWS S3
+# Optional if you use a local AWS profile or other default AWS SDK credentials.
+AWS_ACCESS_KEY_ID=
+AWS_SECRET_ACCESS_KEY=
 AWS_REGION=us-west-2
 S3_BUCKET_NAME=cozytrack-dev-pasha
 

--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ Self-hosted podcast recording studio. A Riverside.fm alternative focused on loca
 
    ```bash
    cp .env.example .env
-   # Edit .env with your AWS credentials and S3 bucket name
+    # Edit .env with your AWS credentials or ensure your local AWS profile is configured
    ```
 
 3. **Start infrastructure:**
@@ -163,5 +163,7 @@ livekit.yaml                   # LiveKit server config
 | `LIVEKIT_API_SECRET` | LiveKit API secret | `cozytrack-local-livekit-secret-32` |
 | `LIVEKIT_URL` | LiveKit server URL (server-side) | `ws://localhost:7880` |
 | `NEXT_PUBLIC_LIVEKIT_URL` | LiveKit server URL (client-side) | `ws://localhost:7880` |
+| `AWS_ACCESS_KEY_ID` | Optional AWS access key for local env-based auth | — |
+| `AWS_SECRET_ACCESS_KEY` | Optional AWS secret key for local env-based auth | — |
 | `AWS_REGION` | AWS region | `us-west-2` |
 | `S3_BUCKET_NAME` | S3 bucket for recordings | `cozytrack-dev-pasha` |

--- a/README.md
+++ b/README.md
@@ -103,7 +103,29 @@ Self-hosted podcast recording studio. A Riverside.fm alternative focused on loca
    npm run dev
    ```
 
-6. **Open** [http://localhost:3000](http://localhost:3000)
+6. **Open** [http://localhost:3001](http://localhost:3001)
+
+### Local Reset
+
+Use this when you want a clean local slate:
+
+```bash
+npm run reset:local
+```
+
+This will:
+- start local Docker services if needed
+- reset the local Prisma database
+- fully empty the configured S3 bucket, including versioned objects and delete markers
+
+Safety guard:
+- the reset script refuses to run unless `S3_BUCKET_NAME` contains `dev`, `local`, or `test`
+
+To reset everything and immediately start the app:
+
+```bash
+npm run init:local
+```
 
 ## Project Structure
 
@@ -136,12 +158,10 @@ livekit.yaml                   # LiveKit server config
 
 | Variable | Description | Default |
 |----------|-------------|---------|
-| `DATABASE_URL` | PostgreSQL connection string | `postgresql://cozytrack:cozytrack@localhost:5432/cozytrack` |
+| `DATABASE_URL` | PostgreSQL connection string | `postgresql://cozytrack:cozytrack@localhost:5433/cozytrack` |
 | `LIVEKIT_API_KEY` | LiveKit API key | `devkey` |
-| `LIVEKIT_API_SECRET` | LiveKit API secret | `secret` |
+| `LIVEKIT_API_SECRET` | LiveKit API secret | `cozytrack-local-livekit-secret-32` |
 | `LIVEKIT_URL` | LiveKit server URL (server-side) | `ws://localhost:7880` |
 | `NEXT_PUBLIC_LIVEKIT_URL` | LiveKit server URL (client-side) | `ws://localhost:7880` |
-| `AWS_ACCESS_KEY_ID` | AWS access key | — |
-| `AWS_SECRET_ACCESS_KEY` | AWS secret key | — |
-| `AWS_REGION` | AWS region | `us-east-1` |
-| `S3_BUCKET_NAME` | S3 bucket for recordings | `cozytrack-recordings` |
+| `AWS_REGION` | AWS region | `us-west-2` |
+| `S3_BUCKET_NAME` | S3 bucket for recordings | `cozytrack-dev-pasha` |

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,7 +14,7 @@ services:
   postgres:
     image: postgres:16
     ports:
-      - "5432:5432"
+      - "5433:5432"
     environment:
       POSTGRES_USER: cozytrack
       POSTGRES_PASSWORD: cozytrack

--- a/livekit.yaml
+++ b/livekit.yaml
@@ -6,6 +6,6 @@ rtc:
 redis:
   address: redis:6379
 keys:
-  devkey: secret
+  devkey: cozytrack-local-livekit-secret-32
 logging:
   level: info

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,7 +21,7 @@
         "uuid": "^10.0.0"
       },
       "devDependencies": {
-        "@types/node": "^22.0.0",
+        "@types/node": "22.19.17",
         "@types/react": "^19.0.0",
         "@types/react-dom": "^19.0.0",
         "@types/recordrtc": "^5.6.0",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,10 @@
   "version": "0.1.0",
   "private": true,
   "scripts": {
-    "dev": "next dev",
+    "dev": "next dev -p 3001",
+    "dev:local": "docker compose up -d && npm run db:push && npm run dev",
+    "init:local": "npm run reset:local && npm run dev",
+    "reset:local": "bash ./scripts/reset-local.sh",
     "build": "next build",
     "start": "next start",
     "lint": "next lint",
@@ -25,7 +28,7 @@
     "uuid": "^10.0.0"
   },
   "devDependencies": {
-    "@types/node": "^22.0.0",
+    "@types/node": "22.19.17",
     "@types/react": "^19.0.0",
     "@types/react-dom": "^19.0.0",
     "@types/recordrtc": "^5.6.0",

--- a/scripts/reset-local.sh
+++ b/scripts/reset-local.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$ROOT_DIR"
+
+set -a
+[ -f ./.env ] && . ./.env
+[ -f ./.env.local ] && . ./.env.local
+set +a
+
+: "${S3_BUCKET_NAME:?S3_BUCKET_NAME is required}"
+
+case "$S3_BUCKET_NAME" in
+  *dev*|*local*|*test*)
+    ;;
+  *)
+    echo "Refusing to reset bucket '$S3_BUCKET_NAME' because it does not look like a dev/local/test bucket." >&2
+    exit 1
+    ;;
+esac
+
+docker compose up -d
+
+echo "Resetting database"
+npx prisma db push --force-reset --accept-data-loss >/dev/null
+
+echo "Emptying s3://$S3_BUCKET_NAME"
+
+while true; do
+  delete_payload="$({
+    aws s3api list-object-versions --bucket "$S3_BUCKET_NAME" --output json
+  } | jq -c '{Objects: ((.Versions // []) + (.DeleteMarkers // []) | map({Key, VersionId})), Quiet: true}')"
+
+  if [ "$(printf '%s' "$delete_payload" | jq '.Objects | length')" -eq 0 ]; then
+    break
+  fi
+
+  aws s3api delete-objects --bucket "$S3_BUCKET_NAME" --delete "$delete_payload" >/dev/null
+done
+
+echo "Local reset complete"

--- a/src/app/api/upload/presign/route.ts
+++ b/src/app/api/upload/presign/route.ts
@@ -1,10 +1,11 @@
 import { NextRequest, NextResponse } from "next/server";
-import { trackPartKey, getPresignedPutUrl } from "@/lib/s3";
+import { db } from "@/lib/db";
+import { trackPartKey, trackRecordingKey, getPresignedPutUrl } from "@/lib/s3";
 
 export async function POST(req: NextRequest) {
   try {
     const body = await req.json();
-    const { sessionId, trackId, partNumber } = body;
+    const { sessionId, trackId, partNumber, participantName } = body;
 
     if (!sessionId || !trackId || partNumber === undefined) {
       return NextResponse.json(
@@ -13,7 +14,35 @@ export async function POST(req: NextRequest) {
       );
     }
 
-    const key = trackPartKey(sessionId, trackId, partNumber);
+    if (partNumber === 0) {
+      const existingTrack = await db.track.findUnique({
+        where: { id: trackId },
+        select: { id: true },
+      });
+
+      if (!existingTrack) {
+        if (!participantName || typeof participantName !== "string") {
+          return NextResponse.json(
+            { error: "participantName is required to start an upload" },
+            { status: 400 }
+          );
+        }
+
+        await db.track.create({
+          data: {
+            id: trackId,
+            sessionId,
+            participantName,
+            s3Key: trackRecordingKey(sessionId, trackId),
+          },
+        });
+      }
+    }
+
+    const key =
+      partNumber === 9999
+        ? trackRecordingKey(sessionId, trackId)
+        : trackPartKey(sessionId, trackId, partNumber);
     const url = await getPresignedPutUrl(key);
 
     return NextResponse.json({ url, key });

--- a/src/app/studio/[id]/page.tsx
+++ b/src/app/studio/[id]/page.tsx
@@ -97,10 +97,12 @@ function RoomContent({
   const recorderRef = useRef<CozyRecorder | null>(null);
   const trackIdRef = useRef<string>("");
   const streamRef = useRef<MediaStream | null>(null);
+  const [recordingStream, setRecordingStream] = useState<MediaStream | null>(null);
   const [audioLevels, setAudioLevels] = useState<Map<string, number>>(new Map());
   const analyserRef = useRef<AnalyserNode | null>(null);
   const animFrameRef = useRef<number>(0);
   const recordingStartRef = useRef<number>(0);
+  const localLevelRef = useRef(0);
 
   useEffect(() => {
     let cancelled = false;
@@ -118,6 +120,7 @@ function RoomContent({
 
         streamRef.current?.getTracks().forEach((track) => track.stop());
         streamRef.current = stream;
+        setRecordingStream(stream);
       } catch (err) {
         console.error("Failed to get recording stream:", err);
       }
@@ -129,29 +132,45 @@ function RoomContent({
       cancelled = true;
       streamRef.current?.getTracks().forEach((track) => track.stop());
       streamRef.current = null;
+      setRecordingStream(null);
     };
   }, [selectedMic]);
 
   // Monitor local audio levels
   useEffect(() => {
-    if (!streamRef.current) return;
+    if (!recordingStream) return;
 
     const audioCtx = new AudioContext();
-    const source = audioCtx.createMediaStreamSource(streamRef.current);
+    const source = audioCtx.createMediaStreamSource(recordingStream);
     const analyser = audioCtx.createAnalyser();
-    analyser.fftSize = 256;
+    analyser.fftSize = 2048;
+    analyser.smoothingTimeConstant = 0.85;
     source.connect(analyser);
     analyserRef.current = analyser;
 
-    const dataArray = new Uint8Array(analyser.frequencyBinCount);
+    const dataArray = new Uint8Array(analyser.fftSize);
 
     function tick() {
       if (!analyserRef.current) return;
-      analyserRef.current.getByteFrequencyData(dataArray);
-      const avg = dataArray.reduce((a, b) => a + b, 0) / dataArray.length;
+      analyserRef.current.getByteTimeDomainData(dataArray);
+
+      let sumSquares = 0;
+      for (const value of dataArray) {
+        const centeredSample = (value - 128) / 128;
+        sumSquares += centeredSample * centeredSample;
+      }
+
+      const rms = Math.sqrt(sumSquares / dataArray.length);
+      const normalized = Math.min(1, Math.max(0, (rms - 0.01) / 0.12));
+      const targetLevel = Math.round(Math.pow(normalized, 0.6) * 255);
+      const smoothedLevel = Math.round(
+        localLevelRef.current * 0.7 + targetLevel * 0.3
+      );
+      localLevelRef.current = smoothedLevel;
+
       setAudioLevels((prev) => {
         const next = new Map(prev);
-        next.set(participantName, avg);
+        next.set(participantName, smoothedLevel);
         return next;
       });
       animFrameRef.current = requestAnimationFrame(tick);
@@ -161,9 +180,10 @@ function RoomContent({
 
     return () => {
       cancelAnimationFrame(animFrameRef.current);
+      localLevelRef.current = 0;
       audioCtx.close();
     };
-  }, [participantName]);
+  }, [participantName, recordingStream]);
 
   // Listen for remote audio level data via data channel
   useEffect(() => {

--- a/src/app/studio/[id]/page.tsx
+++ b/src/app/studio/[id]/page.tsx
@@ -81,11 +81,13 @@ function ParticipantTile({
 function RoomContent({
   sessionId,
   participantName,
+  selectedMic,
   studioState,
   setStudioState,
 }: {
   sessionId: string;
   participantName: string;
+  selectedMic: string;
   studioState: StudioState;
   setStudioState: (state: StudioState) => void;
 }) {
@@ -99,6 +101,36 @@ function RoomContent({
   const analyserRef = useRef<AnalyserNode | null>(null);
   const animFrameRef = useRef<number>(0);
   const recordingStartRef = useRef<number>(0);
+
+  useEffect(() => {
+    let cancelled = false;
+
+    async function getRecordingStream() {
+      try {
+        const stream = await navigator.mediaDevices.getUserMedia({
+          audio: selectedMic ? { deviceId: { exact: selectedMic } } : true,
+        });
+
+        if (cancelled) {
+          stream.getTracks().forEach((track) => track.stop());
+          return;
+        }
+
+        streamRef.current?.getTracks().forEach((track) => track.stop());
+        streamRef.current = stream;
+      } catch (err) {
+        console.error("Failed to get recording stream:", err);
+      }
+    }
+
+    void getRecordingStream();
+
+    return () => {
+      cancelled = true;
+      streamRef.current?.getTracks().forEach((track) => track.stop());
+      streamRef.current = null;
+    };
+  }, [selectedMic]);
 
   // Monitor local audio levels
   useEffect(() => {
@@ -163,18 +195,10 @@ function RoomContent({
     trackIdRef.current = uuidv4();
     const trackId = trackIdRef.current;
 
-    // Create the track in the database
-    await fetch("/api/sessions/" + sessionId, { method: "GET" });
-
-    // Create a DB track record
-    const trackRes = await fetch("/api/upload/presign", {
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ sessionId, trackId, partNumber: 0 }),
-    });
-
-    if (!trackRes.ok) {
-      console.error("Failed to initialize upload");
+    try {
+      await getPresignedUploadUrl(sessionId, trackId, 0, participantName);
+    } catch (err) {
+      console.error("Failed to initialize upload:", err);
       return;
     }
 
@@ -191,7 +215,15 @@ function RoomContent({
 
     recorderRef.current = recorder;
     recordingStartRef.current = Date.now();
-    recorder.start(5000);
+
+    try {
+      await recorder.start(5000);
+    } catch (err) {
+      console.error("Failed to start recorder:", err);
+      recorderRef.current = null;
+      return;
+    }
+
     setStudioState("recording");
 
     // Notify other participants via data channel
@@ -213,7 +245,7 @@ function RoomContent({
       // Upload the final complete blob
       const url = await getPresignedUploadUrl(sessionId, trackId, 9999);
       await uploadChunk(url, blob);
-      await completeUpload(sessionId, trackId);
+      await completeUpload(sessionId, trackId, durationMs);
 
       // Notify other participants
       const encoder = new TextEncoder();
@@ -425,6 +457,7 @@ export default function StudioPage() {
           <RoomContent
             sessionId={sessionId}
             participantName={participantName}
+            selectedMic={selectedMic}
             studioState={studioState}
             setStudioState={setStudioState}
           />

--- a/src/lib/recorder.ts
+++ b/src/lib/recorder.ts
@@ -1,11 +1,15 @@
 "use client";
 
-import RecordRTC, { StereoAudioRecorder } from "recordrtc";
-
 export type ChunkCallback = (chunk: Blob, index: number) => void;
 
+type RecorderInstance = {
+  startRecording: () => void;
+  stopRecording: (callback: () => void) => void;
+  getBlob: () => Blob;
+};
+
 export class CozyRecorder {
-  private recorder: RecordRTC | null = null;
+  private recorder: RecorderInstance | null = null;
   private stream: MediaStream;
   private chunkCallbacks: ChunkCallback[] = [];
   private chunkIndex = 0;
@@ -24,13 +28,15 @@ export class CozyRecorder {
     this.chunkCallbacks.push(callback);
   }
 
-  start(timeSlice = 5000): void {
+  async start(timeSlice = 5000): Promise<void> {
     this.chunkIndex = 0;
     this.allChunks = [];
 
+    const { default: RecordRTC, StereoAudioRecorder } = await import("recordrtc");
+
     this.recorder = new RecordRTC(this.stream, {
       type: "audio",
-      mimeType: "audio/webm" as RecordRTC.Options["mimeType"],
+      mimeType: "audio/webm",
       recorderType: StereoAudioRecorder,
       timeSlice,
       ondataavailable: (blob: Blob) => {

--- a/src/lib/s3.ts
+++ b/src/lib/s3.ts
@@ -7,10 +7,6 @@ import { getSignedUrl } from "@aws-sdk/s3-request-presigner";
 
 export const s3 = new S3Client({
   region: process.env.AWS_REGION!,
-  credentials: {
-    accessKeyId: process.env.AWS_ACCESS_KEY_ID!,
-    secretAccessKey: process.env.AWS_SECRET_ACCESS_KEY!,
-  },
 });
 
 const bucket = process.env.S3_BUCKET_NAME!;

--- a/src/lib/upload.ts
+++ b/src/lib/upload.ts
@@ -3,12 +3,13 @@
 export async function getPresignedUploadUrl(
   sessionId: string,
   trackId: string,
-  partNumber: number
+  partNumber: number,
+  participantName?: string
 ): Promise<string> {
   const res = await fetch("/api/upload/presign", {
     method: "POST",
     headers: { "Content-Type": "application/json" },
-    body: JSON.stringify({ sessionId, trackId, partNumber }),
+    body: JSON.stringify({ sessionId, trackId, partNumber, participantName }),
   });
 
   if (!res.ok) {
@@ -35,12 +36,13 @@ export async function uploadChunk(url: string, chunk: Blob): Promise<void> {
 
 export async function completeUpload(
   sessionId: string,
-  trackId: string
+  trackId: string,
+  durationMs?: number
 ): Promise<void> {
   const res = await fetch("/api/upload/complete", {
     method: "POST",
     headers: { "Content-Type": "application/json" },
-    body: JSON.stringify({ sessionId, trackId }),
+    body: JSON.stringify({ sessionId, trackId, durationMs }),
   });
 
   if (!res.ok) {


### PR DESCRIPTION
## Summary
- fix the direct-to-S3 recording flow by creating track records during upload setup, loading RecordRTC only in the browser, and storing final recordings under the canonical `recording.webm` key
- align local development defaults by moving Next to port 3001, shifting Docker Postgres to 5433, updating LiveKit credentials, and switching S3 config to the dedicated `cozytrack-dev-pasha` dev bucket in `us-west-2`
- add `reset:local` and `init:local` commands to reset the local Prisma database and fully empty the configured dev bucket with a guard that refuses non-dev bucket names