### PR TITLE
fix: use MediaStreamRecorder for valid WebM/Opus chunks (#11)

### DIFF
--- a/src/lib/recorder.ts
+++ b/src/lib/recorder.ts
@@ -32,12 +32,12 @@ export class CozyRecorder {
     this.chunkIndex = 0;
     this.allChunks = [];
 
-    const { default: RecordRTC, StereoAudioRecorder } = await import("recordrtc");
+    const { default: RecordRTC, MediaStreamRecorder } = await import("recordrtc");
 
     this.recorder = new RecordRTC(this.stream, {
       type: "audio",
-      mimeType: "audio/webm",
-      recorderType: StereoAudioRecorder,
+      mimeType: "audio/webm;codecs=opus" as "audio/webm",
+      recorderType: MediaStreamRecorder,
       timeSlice,
       ondataavailable: (blob: Blob) => {
         this.allChunks.push(blob);
@@ -46,8 +46,6 @@ export class CozyRecorder {
           cb(blob, idx);
         }
       },
-      desiredSampRate: 48000,
-      numberOfAudioChannels: 1,
     });
 
     this.recorder.startRecording();

--- a/src/lib/recorder.ts
+++ b/src/lib/recorder.ts
@@ -36,7 +36,7 @@ export class CozyRecorder {
 
     this.recorder = new RecordRTC(this.stream, {
       type: "audio",
-      mimeType: "audio/webm;codecs=opus" as "audio/webm",
+      mimeType: this.mimeType as "audio/webm",
       recorderType: MediaStreamRecorder,
       timeSlice,
       ondataavailable: (blob: Blob) => {


### PR DESCRIPTION
## Summary

Fixes #11. Recordings were slowed-down and glitchy because the recorder used RecordRTC's `StereoAudioRecorder`, which emits WAV chunks. The upload pipeline treats the output as WebM/Opus (`audio/webm` Content-Type, `.webm` S3 key extensions), and concatenating WAV chunks that each carry their own header produces an invalid stream.

Switch to RecordRTC's native `MediaStreamRecorder`, which emits WebM/Opus clusters that append cleanly to the first chunk's header — so the existing `getBlob()` concatenation in `src/lib/recorder.ts` produces a valid WebM/Opus file that matches the pipeline's Content-Type and file extensions.

Changes in `src/lib/recorder.ts`:
- Import and use `MediaStreamRecorder` instead of `StereoAudioRecorder`
- Set `mimeType: "audio/webm;codecs=opus"`
- Remove `desiredSampRate` and `numberOfAudioChannels` (StereoAudioRecorder-specific; not applicable to MediaStreamRecorder)
- Keep `timeSlice` for chunked upload
- Keep the `allChunks` concatenation in `getBlob()` — correct for MediaRecorder output

No changes needed to `src/lib/s3.ts` or `src/lib/upload.ts` — `audio/webm` Content-Type and `.webm` extensions are correct for WebM/Opus.

## Testing

- [x] `npm run build` compiles cleanly
- [x] `npm run lint` — no warnings or errors
- [ ] **Manual verification required before merging:** record a session in the browser and play back the resulting audio to confirm it plays at normal speed without glitches.

Closes #11