### PR TITLE
chore: address PR #9 review feedback (a11y, validation, type safety)

### DIFF
--- a/src/app/api/upload/presign/route.ts
+++ b/src/app/api/upload/presign/route.ts
@@ -57,7 +57,7 @@ export async function POST(req: NextRequest) {
 
         const safeDeviceLabel = typeof deviceLabel === "string" && deviceLabel.length > 0 ? deviceLabel : null;
         const safeDeviceId = typeof deviceId === "string" && deviceId.length > 0 ? deviceId : null;
-        const safeIsBuiltInMic = isBuiltInMic === true;
+        const safeIsBuiltInMic = typeof isBuiltInMic === "boolean" ? isBuiltInMic : false;
 
         await db.track.create({
           data: {

--- a/src/app/session/[id]/page.tsx
+++ b/src/app/session/[id]/page.tsx
@@ -147,12 +147,11 @@ export default function SessionDetailPage() {
                         </p>
                         {track.isBuiltInMic && (
                           <span
-                            title={`Recorded with built-in mic${track.deviceLabel ? `: ${track.deviceLabel}` : ""}`}
-                            className="inline-flex items-center gap-1 px-1.5 py-0.5 rounded text-xs bg-yellow-900/40 text-yellow-400 border border-yellow-800 cursor-help"
+                            className="inline-flex items-center gap-1 px-1.5 py-0.5 rounded text-xs bg-yellow-900/40 text-yellow-400 border border-yellow-800"
                           >
-                            <span aria-hidden="true">⚠ Built-in mic</span>
+                            ⚠ Built-in mic
                             <span className="sr-only">
-                              Recorded with built-in mic{track.deviceLabel ? `: ${track.deviceLabel}` : ""}
+                              {` Recorded with built-in mic${track.deviceLabel ? `: ${track.deviceLabel}` : ""}`}
                             </span>
                           </span>
                         )}

--- a/src/app/session/[id]/page.tsx
+++ b/src/app/session/[id]/page.tsx
@@ -149,7 +149,7 @@ export default function SessionDetailPage() {
                           <span
                             className="inline-flex items-center gap-1 px-1.5 py-0.5 rounded text-xs bg-yellow-900/40 text-yellow-400 border border-yellow-800"
                           >
-                            ⚠ Built-in mic
+                            <span aria-hidden="true">⚠ Built-in mic</span>
                             <span className="sr-only">
                               {` Recorded with built-in mic${track.deviceLabel ? `: ${track.deviceLabel}` : ""}`}
                             </span>

--- a/src/app/studio/[id]/page.tsx
+++ b/src/app/studio/[id]/page.tsx
@@ -662,7 +662,7 @@ export default function StudioPage() {
             sessionId={sessionId}
             participantName={participantName}
             selectedMic={selectedMic}
-            selectedMicLabel={selectedMicDevice?.label}
+            selectedMicLabel={selectedMicDevice?.label || undefined}
             selectedMicIsBuiltIn={selectedMicDevice ? isBuiltInMic(selectedMicDevice.label) : false}
             studioState={studioState}
             setStudioState={setStudioState}

--- a/src/components/BuiltInMicWarningModal.tsx
+++ b/src/components/BuiltInMicWarningModal.tsx
@@ -13,20 +13,53 @@ export function BuiltInMicWarningModal({
 }: BuiltInMicWarningModalProps) {
   const [checked, setChecked] = useState(false);
   const checkboxRef = useRef<HTMLInputElement>(null);
+  const dialogRef = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
     checkboxRef.current?.focus();
   }, []);
 
+  useEffect(() => {
+    function handleKeyDown(e: KeyboardEvent) {
+      if (e.key !== "Tab") return;
+      const container = dialogRef.current;
+      if (!container) return;
+
+      const focusable = Array.from(
+        container.querySelectorAll<HTMLElement>("button, input"),
+      ).filter((el) => !el.hasAttribute("disabled"));
+      if (focusable.length === 0) return;
+
+      const first = focusable[0];
+      const last = focusable[focusable.length - 1];
+      const active = document.activeElement as HTMLElement | null;
+
+      if (e.shiftKey) {
+        if (active === first || !container.contains(active)) {
+          e.preventDefault();
+          last.focus();
+        }
+      } else {
+        if (active === last || !container.contains(active)) {
+          e.preventDefault();
+          first.focus();
+        }
+      }
+    }
+
+    document.addEventListener("keydown", handleKeyDown);
+    return () => document.removeEventListener("keydown", handleKeyDown);
+  }, []);
+
   return (
     <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/60 backdrop-blur-sm px-4">
-      <div role="dialog" aria-modal="true" aria-labelledby="builtin-mic-modal-title" className="max-w-md w-full rounded-xl bg-cozy-900 border border-cozy-700 p-6 shadow-2xl space-y-5">
+      <div ref={dialogRef} role="dialog" aria-modal="true" aria-labelledby="builtin-mic-warning-title" className="max-w-md w-full rounded-xl bg-cozy-900 border border-cozy-700 p-6 shadow-2xl space-y-5">
         <div className="flex items-start gap-3">
           <span className="text-2xl leading-none" aria-hidden="true">
             ⚠️
           </span>
           <div>
-            <h2 id="builtin-mic-modal-title" className="text-lg font-semibold text-white">
+            <h2 id="builtin-mic-warning-title" className="text-lg font-semibold text-white">
               You&apos;re using your built-in microphone
             </h2>
             <p className="text-sm text-gray-400 mt-2 leading-relaxed">


### PR DESCRIPTION
Follow-up to #9 addressing Copilot's inline review comments.

## Summary

- **`src/lib/upload.ts`** — use `...(deviceInfo ?? {})` when spreading the optional `DeviceInfo` parameter so a missing value doesn't blow up the JSON body.
- **`src/components/BuiltInMicWarningModal.tsx`** — expose the modal to assistive tech: `role="dialog"`, `aria-modal="true"`, `aria-labelledby` tied to the heading id. Initial focus is moved into the modal (checkbox), and a Tab/Shift+Tab listener traps focus across the modal's interactive controls so keyboard users can't escape into the background.
- **`src/app/studio/[id]/page.tsx`** — pass `selectedMicDevice?.label || undefined` to `RoomContent` so an empty-string device label (unknown device) propagates as `undefined` → NULL in the DB, distinguishing "no label" from an empty label.
- **`src/app/session/[id]/page.tsx`** — drop the `title` attribute and `cursor-help` class in favor of a visually-hidden `sr-only` span. Screen-reader and touch users now get the full "Recorded with built-in mic: …" context that was only available on hover.
- **`src/app/api/upload/presign/route.ts`** — validate `isBuiltInMic` with a `typeof` check (was implicitly coerced) alongside the existing string validation for `deviceLabel` / `deviceId`, so only well-typed values reach Prisma.

## Testing

- [x] `npm run build` passes
- [x] `npm run lint` passes (no warnings)

## References

Original Copilot comments on #9:
- https://github.com/pashafateev/cozytrack/pull/9#discussion_r (upload.ts spread)
- https://github.com/pashafateev/cozytrack/pull/9#discussion_r (BuiltInMicWarningModal a11y)
- https://github.com/pashafateev/cozytrack/pull/9#discussion_r (studio page device memo)
- https://github.com/pashafateev/cozytrack/pull/9#discussion_r (session page tooltip)
- https://github.com/pashafateev/cozytrack/pull/9#discussion_r (presign route validation)