### PR TITLE
refactor: contain livekit-client imports behind Transport abstraction

### DIFF
--- a/src/app/api/livekit-token/route.ts
+++ b/src/app/api/livekit-token/route.ts
@@ -1,3 +1,7 @@
+// Server-side JWT generation for LiveKit. Intentionally NOT wrapped by the
+// Transport abstraction — if the transport is swapped, this route gets
+// replaced by whatever auth flow the new backend requires.
+
 import { NextRequest, NextResponse } from "next/server";
 import { AccessToken } from "livekit-server-sdk";
 

--- a/src/app/studio/[id]/page.tsx
+++ b/src/app/studio/[id]/page.tsx
@@ -1,5 +1,11 @@
 "use client";
 
+// UI components from @livekit/components-react are intentionally not wrapped
+// by the Transport abstraction. If migrating off LiveKit, these components
+// (LiveKitRoom, RoomAudioRenderer, useLocalParticipant, useRemoteParticipants,
+// useSpeakingParticipants, etc.) would be replaced entirely, not adapted.
+// See src/lib/transport/ for the imperative transport wrapper.
+
 import { useEffect, useState, useRef, useCallback, useMemo } from "react";
 import { useParams } from "next/navigation";
 import {
@@ -7,9 +13,8 @@ import {
   RoomAudioRenderer,
   useRemoteParticipants,
   useLocalParticipant,
-  useRoomContext,
+  useSpeakingParticipants,
 } from "@livekit/components-react";
-import { RoomEvent, type TrackPublishOptions } from "livekit-client";
 import { v4 as uuidv4 } from "uuid";
 import { CozyRecorder } from "@/lib/recorder";
 import { getPresignedUploadUrl, uploadChunk, completeUpload } from "@/lib/upload";
@@ -35,15 +40,15 @@ interface AudioLevel {
 
 // ---------- Audio Quality Presets ----------
 
-const FULL_QUALITY_PUBLISH: TrackPublishOptions = {
+const FULL_QUALITY_PUBLISH = {
   audioPreset: { maxBitrate: 128_000 },
   dtx: false,
-};
+} as const;
 
-const BANDWIDTH_SAVING_PUBLISH: TrackPublishOptions = {
+const BANDWIDTH_SAVING_PUBLISH = {
   audioPreset: { maxBitrate: 48_000 },
   dtx: true,
-};
+} as const;
 
 // ---------- Audio Level Meter ----------
 
@@ -125,8 +130,8 @@ function RoomContent({
   onMonitorEnabledChange: (enabled: boolean) => void;
   onMonitorVolumeChange: (volume: number) => void;
 }) {
-  const room = useRoomContext();
   const remoteParticipants = useRemoteParticipants();
+  const speakingParticipants = useSpeakingParticipants();
   const { localParticipant } = useLocalParticipant();
   const recorderRef = useRef<CozyRecorder | null>(null);
   const trackIdRef = useRef<string>("");
@@ -278,29 +283,19 @@ function RoomContent({
     };
   }, [participantName, recordingStream]);
 
-  // Listen for remote audio level data via data channel
+  // Track remote audio levels via the speaking-participants hook
   useEffect(() => {
-    if (!room) return;
-
-    function handleActiveSpeakers() {
-      const speakers = room.activeSpeakers;
-      setAudioLevels((prev) => {
-        const next = new Map(prev);
-        for (const s of speakers) {
-          next.set(
-            s.identity ?? "unknown",
-            Math.round((s.audioLevel ?? 0) * 255)
-          );
-        }
-        return next;
-      });
-    }
-
-    room.on(RoomEvent.ActiveSpeakersChanged, handleActiveSpeakers);
-    return () => {
-      room.off(RoomEvent.ActiveSpeakersChanged, handleActiveSpeakers);
-    };
-  }, [room]);
+    setAudioLevels((prev) => {
+      const next = new Map(prev);
+      for (const s of speakingParticipants) {
+        next.set(
+          s.identity ?? "unknown",
+          Math.round((s.audioLevel ?? 0) * 255),
+        );
+      }
+      return next;
+    });
+  }, [speakingParticipants]);
 
   const startRecording = useCallback(async () => {
     if (!streamRef.current) return;

--- a/src/lib/transport/index.ts
+++ b/src/lib/transport/index.ts
@@ -1,0 +1,12 @@
+import { LiveKitTransport } from "./livekit-transport";
+import type { Transport } from "./types";
+
+export type { Transport, RemoteParticipant, TransportEvents } from "./types";
+
+/**
+ * Create a new Transport instance. The active transport is LiveKit.
+ * To swap transports, replace this factory with a different implementation.
+ */
+export function createTransport(): Transport {
+  return new LiveKitTransport();
+}

--- a/src/lib/transport/index.ts
+++ b/src/lib/transport/index.ts
@@ -1,3 +1,13 @@
+"use client";
+
+// `livekit-client` relies on browser/WebRTC globals. This barrel has a value
+// import of LiveKitTransport, which pulls the LiveKit client implementation
+// into any consumer that imports from "@/lib/transport". Marking this module
+// "use client" prevents Next.js from bundling `livekit-client` for the server.
+//
+// Server code that only needs types should import from "@/lib/transport/types"
+// directly, which is server-safe.
+
 import { LiveKitTransport } from "./livekit-transport";
 import type { Transport } from "./types";
 

--- a/src/lib/transport/livekit-transport.ts
+++ b/src/lib/transport/livekit-transport.ts
@@ -1,7 +1,12 @@
+"use client";
+
 // LiveKit implementation of the Transport interface.
 // This is the ONLY non-component file allowed to import from "livekit-client".
 // If the WebRTC backend is swapped, replace this file with a new implementation
 // and update the factory in ./index.ts.
+//
+// `livekit-client` relies on browser/WebRTC globals. The "use client" directive
+// above ensures this module is never bundled for server components/routes.
 
 import {
   ConnectionState,

--- a/src/lib/transport/livekit-transport.ts
+++ b/src/lib/transport/livekit-transport.ts
@@ -1,0 +1,103 @@
+// LiveKit implementation of the Transport interface.
+// This is the ONLY non-component file allowed to import from "livekit-client".
+// If the WebRTC backend is swapped, replace this file with a new implementation
+// and update the factory in ./index.ts.
+
+import {
+  ConnectionState,
+  Room,
+  RoomEvent,
+  type RemoteParticipant as LKRemoteParticipant,
+  type TrackPublishOptions,
+} from "livekit-client";
+
+import type { RemoteParticipant, Transport, TransportEvents } from "./types";
+
+function toRemoteParticipant(p: LKRemoteParticipant): RemoteParticipant {
+  return { identity: p.identity, name: p.name };
+}
+
+export class LiveKitTransport implements Transport {
+  private room: Room;
+
+  constructor() {
+    this.room = new Room();
+  }
+
+  async connect(opts: { url: string; token: string }): Promise<void> {
+    await this.room.connect(opts.url, opts.token);
+  }
+
+  async disconnect(): Promise<void> {
+    await this.room.disconnect();
+  }
+
+  async publishAudio(
+    stream: MediaStream,
+    options?: { audioBitrate?: number; dtx?: boolean },
+  ): Promise<void> {
+    const [track] = stream.getAudioTracks();
+    if (!track) {
+      throw new Error("publishAudio: MediaStream has no audio tracks");
+    }
+
+    const publishOptions: TrackPublishOptions = {};
+    if (options?.audioBitrate !== undefined) {
+      publishOptions.audioPreset = { maxBitrate: options.audioBitrate };
+    }
+    if (options?.dtx !== undefined) {
+      publishOptions.dtx = options.dtx;
+    }
+
+    await this.room.localParticipant.publishTrack(track, publishOptions);
+  }
+
+  on<K extends keyof TransportEvents>(event: K, handler: TransportEvents[K]): () => void {
+    switch (event) {
+      case "participantConnected": {
+        const fn = (p: LKRemoteParticipant) => {
+          (handler as TransportEvents["participantConnected"])(toRemoteParticipant(p));
+        };
+        this.room.on(RoomEvent.ParticipantConnected, fn);
+        return () => {
+          this.room.off(RoomEvent.ParticipantConnected, fn);
+        };
+      }
+      case "participantDisconnected": {
+        const fn = (p: LKRemoteParticipant) => {
+          (handler as TransportEvents["participantDisconnected"])(toRemoteParticipant(p));
+        };
+        this.room.on(RoomEvent.ParticipantDisconnected, fn);
+        return () => {
+          this.room.off(RoomEvent.ParticipantDisconnected, fn);
+        };
+      }
+      case "connected": {
+        const fn = () => {
+          (handler as TransportEvents["connected"])();
+        };
+        this.room.on(RoomEvent.Connected, fn);
+        return () => {
+          this.room.off(RoomEvent.Connected, fn);
+        };
+      }
+      case "disconnected": {
+        const fn = () => {
+          (handler as TransportEvents["disconnected"])();
+        };
+        this.room.on(RoomEvent.Disconnected, fn);
+        return () => {
+          this.room.off(RoomEvent.Disconnected, fn);
+        };
+      }
+      default: {
+        const exhaustive: never = event;
+        throw new Error(`Unhandled transport event: ${String(exhaustive)}`);
+      }
+    }
+  }
+
+  isConnected(): boolean {
+    return this.room.state === ConnectionState.Connected;
+  }
+}

--- a/src/lib/transport/types.ts
+++ b/src/lib/transport/types.ts
@@ -1,0 +1,44 @@
+// Minimal transport abstraction for Cozytrack's WebRTC needs.
+// Only covers the imperative operations used outside of React components.
+// UI-facing components from @livekit/components-react are NOT wrapped.
+
+export interface RemoteParticipant {
+  identity: string;
+  name?: string;
+}
+
+export interface TransportEvents {
+  participantConnected: (participant: RemoteParticipant) => void;
+  participantDisconnected: (participant: RemoteParticipant) => void;
+  connected: () => void;
+  disconnected: () => void;
+  // Add more events here as the codebase actually needs them — do not add speculatively.
+}
+
+export interface Transport {
+  /**
+   * Connect to a room with a token. Returns when connected.
+   */
+  connect(opts: { url: string; token: string }): Promise<void>;
+
+  /**
+   * Disconnect and clean up all resources.
+   */
+  disconnect(): Promise<void>;
+
+  /**
+   * Publish a microphone audio track from a MediaStream.
+   * Options intentionally kept small — add fields only as the codebase needs them.
+   */
+  publishAudio(stream: MediaStream, options?: { audioBitrate?: number; dtx?: boolean }): Promise<void>;
+
+  /**
+   * Subscribe to lifecycle events. Returns an unsubscribe function.
+   */
+  on<K extends keyof TransportEvents>(event: K, handler: TransportEvents[K]): () => void;
+
+  /**
+   * Is currently connected.
+   */
+  isConnected(): boolean;
+}


### PR DESCRIPTION
## Summary

Thin wrapper around the imperative WebRTC transport API so the backend can be swapped in the future without rewriting the studio page. Pure refactor — no behavioral changes.

## Rationale

The studio needs imperative WebRTC operations (connect, publish mic track, lifecycle events) in addition to the declarative React components. Today those imperative calls reach into `livekit-client` directly, which makes the backend hard to swap. A minimal `Transport` interface isolates those calls behind a seam — swap-able later without over-engineering today.

## What was wrapped

Imperative transport operations only:

- `connect({ url, token })` → `room.connect(...)`
- `disconnect()` → `room.disconnect()`
- `publishAudio(stream, { audioBitrate, dtx })` → `localParticipant.publishTrack(...)` with `TrackPublishOptions`
- `on(event, handler)` → lifecycle events (`participantConnected`, `participantDisconnected`, `connected`, `disconnected`)
- `isConnected()` → `room.state === ConnectionState.Connected`

Only `src/lib/transport/livekit-transport.ts` imports from `livekit-client`. Only LiveKit is implemented — no second transport. The abstraction is what enables a future swap.

## What was deliberately NOT wrapped

- **`@livekit/components-react` JSX / hooks** (`LiveKitRoom`, `RoomAudioRenderer`, `useLocalParticipant`, `useRemoteParticipants`, `useSpeakingParticipants`). If LiveKit is ever swapped out, these would be replaced entirely, not adapted — wrapping them would just create a translation layer no other implementation could match. A file-header comment in the studio page documents this.
- **Server-side token route (`/api/livekit-token`)**: Backend-specific auth flow. If the transport is swapped, this route gets replaced. A one-line comment notes the intent.

## Studio page changes

The studio page had one `livekit-client` import (`RoomEvent`, `TrackPublishOptions`). To keep the grep invariant clean (only the transport file imports from `livekit-client`):

- Replaced the manual `room.on(RoomEvent.ActiveSpeakersChanged, ...)` listener with the `useSpeakingParticipants()` hook from `@livekit/components-react` — same data, same unwrapped-UI layer.
- Dropped the `TrackPublishOptions` type annotation from the two preset constants (`as const` literals); the LiveKit React hook accepts them structurally.

## Verification

- `npm run build` ✅
- `npm run lint` ✅ (no warnings)
- `grep -rn 'from "livekit-client"' src/ --include="*.ts" --include="*.tsx"` returns only `src/lib/transport/livekit-transport.ts`

## Files

- **Added**: `src/lib/transport/types.ts`, `src/lib/transport/livekit-transport.ts`, `src/lib/transport/index.ts`
- **Modified**: `src/app/studio/[id]/page.tsx` (removed imperative livekit-client import, switched to `useSpeakingParticipants`), `src/app/api/livekit-token/route.ts` (comment only)

## Test plan

- [ ] Join a studio session — LiveKit connects and audio publishes as before
- [ ] Remote participant audio-level meters light up when they speak
- [ ] Start/stop recording toggles between full-quality and bandwidth-saving presets
- [ ] No regressions in the prejoin / connected / recording flow

🤖 Generated with [Claude Code](https://claude.com/claude-code)