### PR TITLE
Lock down all routes with host password + signed guest invite links

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -15,3 +15,11 @@ S3_BUCKET_NAME=cozytrack-dev-pasha
 
 # App
 NEXT_PUBLIC_LIVEKIT_URL=ws://localhost:7880
+
+# Auth (required)
+# 32+ char random string used to sign host + guest session JWTs.
+# Generate: `openssl rand -hex 32`
+AUTH_SECRET=
+# Plaintext password for host sign-in. This is the single operator credential.
+# Guests join via signed invite URLs minted by the host after sign-in.
+HOST_PASSWORD=

--- a/.env.example
+++ b/.env.example
@@ -20,6 +20,7 @@ NEXT_PUBLIC_LIVEKIT_URL=ws://localhost:7880
 # 32+ char random string used to sign host + guest session JWTs.
 # Generate: `openssl rand -hex 32`
 AUTH_SECRET=
-# Plaintext password for host sign-in. This is the single operator credential.
-# Guests join via signed invite URLs minted by the host after sign-in.
+# Plaintext password for host sign-in. Minimum 12 characters. This is the
+# single operator credential; guests join via signed invite URLs minted by
+# the host after sign-in. Generate a strong one with: openssl rand -hex 24
 HOST_PASSWORD=

--- a/README.md
+++ b/README.md
@@ -171,7 +171,7 @@ livekit.yaml                   # LiveKit server config
 | `AWS_REGION` | AWS region | `us-west-2` |
 | `S3_BUCKET_NAME` | S3 bucket for recordings | `cozytrack-dev-pasha` |
 | `AUTH_SECRET` | 32+ char secret for signing host + guest session JWTs. Generate with `openssl rand -hex 32`. | — (required) |
-| `HOST_PASSWORD` | Plaintext password for host sign-in. Single operator credential. | — (required) |
+| `HOST_PASSWORD` | Plaintext password for host sign-in. **Minimum 12 characters.** Hashed with scrypt at startup. | — (required) |
 
 ## Auth Model (interim)
 

--- a/README.md
+++ b/README.md
@@ -170,3 +170,16 @@ livekit.yaml                   # LiveKit server config
 | `AWS_SECRET_ACCESS_KEY` | Optional AWS secret key for local env-based auth | — |
 | `AWS_REGION` | AWS region | `us-west-2` |
 | `S3_BUCKET_NAME` | S3 bucket for recordings | `cozytrack-dev-pasha` |
+| `AUTH_SECRET` | 32+ char secret for signing host + guest session JWTs. Generate with `openssl rand -hex 32`. | — (required) |
+| `HOST_PASSWORD` | Plaintext password for host sign-in. Single operator credential. | — (required) |
+
+## Auth Model (interim)
+
+Strict lockdown: everything requires a valid session. Two principals:
+
+- **Host** — signs in at `/signin` with `HOST_PASSWORD`. Can access any session, create sessions, download tracks, mint invite links. Session cookie lasts 7 days.
+- **Guest** — receives an invite link (`/join/<token>`) minted by the host. The cookie is scoped to a single session; the same guest can't access any other session. Invite tokens expire after 48h; guest sessions after 12h.
+
+Both cookies are signed HS256 JWTs (`jose`). Middleware (`src/middleware.ts`) gates every non-public route. Per-route authorization in the API handlers enforces that guests can only touch their own session — this is where the S3 blast radius is capped.
+
+Long-term plan: this scheme gets replaced by podflow-as-IdP (see `pashafateev/podflow#11`, `pashafateev/cozytrack#36`, `pashafateev/cozytrack#37`). The JWT primitive stays; only the token issuer changes.

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "@aws-sdk/s3-request-presigner": "^3.600.0",
         "@livekit/components-react": "^2.6.0",
         "@prisma/client": "^6.0.0",
+        "jose": "^6.2.2",
         "livekit-client": "^2.6.0",
         "livekit-server-sdk": "^2.9.0",
         "next": "^15.0.0",

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "@aws-sdk/s3-request-presigner": "^3.600.0",
     "@livekit/components-react": "^2.6.0",
     "@prisma/client": "^6.0.0",
+    "jose": "^6.2.2",
     "livekit-client": "^2.6.0",
     "livekit-server-sdk": "^2.9.0",
     "next": "^15.0.0",

--- a/src/app/api/auth/accept-invite/route.ts
+++ b/src/app/api/auth/accept-invite/route.ts
@@ -1,0 +1,35 @@
+import { NextRequest, NextResponse } from "next/server";
+import { issueGuestSessionCookie, verifyInviteToken } from "@/lib/auth";
+
+export async function POST(req: NextRequest) {
+  let body: { token?: unknown; name?: unknown };
+  try {
+    body = await req.json();
+  } catch {
+    return NextResponse.json({ error: "Invalid body" }, { status: 400 });
+  }
+
+  const token = typeof body.token === "string" ? body.token : "";
+  const rawName = typeof body.name === "string" ? body.name.trim() : "";
+  if (!token || !rawName) {
+    return NextResponse.json({ error: "token and name are required" }, { status: 400 });
+  }
+  const name = rawName.slice(0, 80);
+
+  const payload = await verifyInviteToken(token);
+  if (!payload) {
+    return NextResponse.json({ error: "Invite invalid or expired" }, { status: 401 });
+  }
+
+  const { cookieName, value, ttl } = await issueGuestSessionCookie(payload.sessionId, name);
+
+  const res = NextResponse.json({ ok: true, sessionId: payload.sessionId });
+  res.cookies.set(cookieName, value, {
+    httpOnly: true,
+    secure: process.env.NODE_ENV === "production",
+    sameSite: "lax",
+    path: "/",
+    maxAge: ttl,
+  });
+  return res;
+}

--- a/src/app/api/auth/signin/route.ts
+++ b/src/app/api/auth/signin/route.ts
@@ -1,0 +1,59 @@
+import { NextRequest, NextResponse } from "next/server";
+import { AUTH_COOKIES, AUTH_TTLS, issueHostSessionCookie } from "@/lib/auth";
+import { verifyHostPassword } from "@/lib/auth-password";
+
+// Naive in-memory rate limit per IP. Good enough for a single-host deployment;
+// swap for a shared store if we ever run multi-instance.
+const attempts = new Map<string, { count: number; resetAt: number }>();
+const WINDOW_MS = 10 * 60 * 1000; // 10 min
+const MAX_ATTEMPTS = 10;
+
+function rateLimit(ip: string): boolean {
+  const now = Date.now();
+  const rec = attempts.get(ip);
+  if (!rec || rec.resetAt < now) {
+    attempts.set(ip, { count: 1, resetAt: now + WINDOW_MS });
+    return true;
+  }
+  rec.count += 1;
+  return rec.count <= MAX_ATTEMPTS;
+}
+
+export async function POST(req: NextRequest) {
+  const ip =
+    req.headers.get("x-forwarded-for")?.split(",")[0]?.trim() ??
+    req.headers.get("x-real-ip") ??
+    "unknown";
+
+  if (!rateLimit(ip)) {
+    return NextResponse.json(
+      { error: "Too many attempts. Try again in a few minutes." },
+      { status: 429 },
+    );
+  }
+
+  let body: { password?: unknown };
+  try {
+    body = await req.json();
+  } catch {
+    return NextResponse.json({ error: "Invalid body" }, { status: 400 });
+  }
+
+  const password = typeof body.password === "string" ? body.password : "";
+  if (!verifyHostPassword(password)) {
+    // Uniform 401 + delay to reduce signal from timing
+    await new Promise((r) => setTimeout(r, 250));
+    return NextResponse.json({ error: "Invalid password" }, { status: 401 });
+  }
+
+  const token = await issueHostSessionCookie();
+  const res = NextResponse.json({ ok: true });
+  res.cookies.set(AUTH_COOKIES.host, token, {
+    httpOnly: true,
+    secure: process.env.NODE_ENV === "production",
+    sameSite: "lax",
+    path: "/",
+    maxAge: AUTH_TTLS.hostSession,
+  });
+  return res;
+}

--- a/src/app/api/auth/signin/route.ts
+++ b/src/app/api/auth/signin/route.ts
@@ -2,14 +2,37 @@ import { NextRequest, NextResponse } from "next/server";
 import { AUTH_COOKIES, AUTH_TTLS, issueHostSessionCookie } from "@/lib/auth";
 import { verifyHostPassword } from "@/lib/auth-password";
 
-// Naive in-memory rate limit per IP. Good enough for a single-host deployment;
-// swap for a shared store if we ever run multi-instance.
+// Best-effort in-memory rate limit per IP. On Vercel this is per-instance and
+// resets on cold start, so it will NOT stop a determined online brute-forcer
+// across instances. It's defense-in-depth on top of the slow KDF in
+// auth-password.ts (scrypt) and the configured HOST_PASSWORD entropy.
+//
+// For a hard guarantee, put this app behind a WAF or rate-limit at the edge
+// (Vercel Firewall / Cloudflare) and/or swap this map for a shared store
+// (Vercel KV, Upstash Redis).
 const attempts = new Map<string, { count: number; resetAt: number }>();
 const WINDOW_MS = 10 * 60 * 1000; // 10 min
 const MAX_ATTEMPTS = 10;
+const MAX_TRACKED_IPS = 10_000; // cap to prevent unbounded memory growth
+
+function evictExpired(now: number) {
+  // Cheap sweep: only run when we'd otherwise blow the cap.
+  if (attempts.size < MAX_TRACKED_IPS) return;
+  for (const [ip, rec] of attempts) {
+    if (rec.resetAt < now) attempts.delete(ip);
+    if (attempts.size < MAX_TRACKED_IPS) break;
+  }
+  // If still over cap (all entries live), drop oldest insertions.
+  while (attempts.size >= MAX_TRACKED_IPS) {
+    const first = attempts.keys().next().value;
+    if (first === undefined) break;
+    attempts.delete(first);
+  }
+}
 
 function rateLimit(ip: string): boolean {
   const now = Date.now();
+  evictExpired(now);
   const rec = attempts.get(ip);
   if (!rec || rec.resetAt < now) {
     attempts.set(ip, { count: 1, resetAt: now + WINDOW_MS });
@@ -40,7 +63,15 @@ export async function POST(req: NextRequest) {
   }
 
   const password = typeof body.password === "string" ? body.password : "";
-  if (!verifyHostPassword(password)) {
+  let ok: boolean;
+  try {
+    ok = verifyHostPassword(password);
+  } catch (err) {
+    // HOST_PASSWORD misconfigured (e.g. too short). Surface to logs, 500 to client.
+    console.error("[auth] verifyHostPassword threw:", err);
+    return NextResponse.json({ error: "Auth misconfigured" }, { status: 500 });
+  }
+  if (!ok) {
     // Uniform 401 + delay to reduce signal from timing
     await new Promise((r) => setTimeout(r, 250));
     return NextResponse.json({ error: "Invalid password" }, { status: 401 });

--- a/src/app/api/auth/signout/route.ts
+++ b/src/app/api/auth/signout/route.ts
@@ -1,26 +1,25 @@
 import { NextRequest, NextResponse } from "next/server";
-import { AUTH_COOKIES } from "@/lib/auth";
+import { AUTH_COOKIES, isGuestCookieName } from "@/lib/auth";
+
+// Sign-out is a state-changing action, so it's POST-only. GET would be
+// triggerable by link prefetchers, crawlers, or cross-site navigations
+// (SameSite=Lax still allows top-level GETs), causing surprise logouts.
+// The UI uses a <form method="post"> in the Topbar.
 
 export async function POST(req: NextRequest) {
-  const res = NextResponse.json({ ok: true });
+  const res = NextResponse.redirect(new URL("/signin", req.url), { status: 303 });
   res.cookies.delete(AUTH_COOKIES.host);
-  // Also clear any guest cookies on this client.
   for (const c of req.cookies.getAll()) {
-    if (c.name.startsWith("cozytrack_guest_")) {
-      res.cookies.delete(c.name);
-    }
+    if (isGuestCookieName(c.name)) res.cookies.delete(c.name);
   }
   return res;
 }
 
-// Allow GET for a simple sign-out link that redirects back to /signin.
-export async function GET(req: NextRequest) {
-  const res = NextResponse.redirect(new URL("/signin", req.url));
-  res.cookies.delete(AUTH_COOKIES.host);
-  for (const c of req.cookies.getAll()) {
-    if (c.name.startsWith("cozytrack_guest_")) {
-      res.cookies.delete(c.name);
-    }
-  }
-  return res;
+export function GET() {
+  // Refuse state-changing GETs explicitly so accidental visits (browser
+  // history, prefetch, curl) don't silently log the user out.
+  return new NextResponse("Method Not Allowed. Use POST.", {
+    status: 405,
+    headers: { Allow: "POST" },
+  });
 }

--- a/src/app/api/auth/signout/route.ts
+++ b/src/app/api/auth/signout/route.ts
@@ -1,0 +1,26 @@
+import { NextRequest, NextResponse } from "next/server";
+import { AUTH_COOKIES } from "@/lib/auth";
+
+export async function POST(req: NextRequest) {
+  const res = NextResponse.json({ ok: true });
+  res.cookies.delete(AUTH_COOKIES.host);
+  // Also clear any guest cookies on this client.
+  for (const c of req.cookies.getAll()) {
+    if (c.name.startsWith("cozytrack_guest_")) {
+      res.cookies.delete(c.name);
+    }
+  }
+  return res;
+}
+
+// Allow GET for a simple sign-out link that redirects back to /signin.
+export async function GET(req: NextRequest) {
+  const res = NextResponse.redirect(new URL("/signin", req.url));
+  res.cookies.delete(AUTH_COOKIES.host);
+  for (const c of req.cookies.getAll()) {
+    if (c.name.startsWith("cozytrack_guest_")) {
+      res.cookies.delete(c.name);
+    }
+  }
+  return res;
+}

--- a/src/app/api/livekit-token/route.ts
+++ b/src/app/api/livekit-token/route.ts
@@ -4,6 +4,7 @@
 
 import { NextRequest, NextResponse } from "next/server";
 import { AccessToken } from "livekit-server-sdk";
+import { resolvePrincipal } from "@/lib/auth";
 
 export async function POST(req: NextRequest) {
   try {
@@ -15,6 +16,15 @@ export async function POST(req: NextRequest) {
         { error: "roomName and participantName are required" },
         { status: 400 }
       );
+    }
+
+    // LiveKit rooms are 1:1 with cozytrack sessions, so roomName == sessionId.
+    const principal = await resolvePrincipal(req, roomName);
+    if (!principal) {
+      return NextResponse.json({ error: "unauthorized" }, { status: 401 });
+    }
+    if (principal.kind === "guest" && principal.sessionId !== roomName) {
+      return NextResponse.json({ error: "forbidden" }, { status: 403 });
     }
 
     const apiKey = process.env.LIVEKIT_API_KEY;

--- a/src/app/api/sessions/[id]/invite/route.ts
+++ b/src/app/api/sessions/[id]/invite/route.ts
@@ -1,0 +1,33 @@
+import { NextRequest, NextResponse } from "next/server";
+import { db } from "@/lib/db";
+import { AUTH_TTLS, mintInviteToken, verifyHostCookie, AUTH_COOKIES } from "@/lib/auth";
+
+/**
+ * Host-only. Mints a signed invite token for a specific session and returns
+ * a shareable URL. The token is not persisted — invites are stateless and
+ * expire in AUTH_TTLS.invite seconds.
+ */
+export async function POST(
+  req: NextRequest,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  const host = await verifyHostCookie(req.cookies.get(AUTH_COOKIES.host)?.value);
+  if (!host) {
+    return NextResponse.json({ error: "unauthorized" }, { status: 401 });
+  }
+
+  const { id } = await params;
+  const session = await db.session.findUnique({ where: { id }, select: { id: true } });
+  if (!session) {
+    return NextResponse.json({ error: "session not found" }, { status: 404 });
+  }
+
+  const token = await mintInviteToken(id);
+  const origin = req.nextUrl.origin;
+  const url = `${origin}/join/${token}`;
+
+  return NextResponse.json({
+    url,
+    expiresInSeconds: AUTH_TTLS.invite,
+  });
+}

--- a/src/app/api/sessions/[id]/route.ts
+++ b/src/app/api/sessions/[id]/route.ts
@@ -1,12 +1,23 @@
 import { NextRequest, NextResponse } from "next/server";
 import { db } from "@/lib/db";
+import { resolvePrincipal } from "@/lib/auth";
 
 export async function GET(
-  _req: NextRequest,
+  req: NextRequest,
   { params }: { params: Promise<{ id: string }> }
 ) {
   try {
     const { id } = await params;
+
+    // Host can read any session; guest can read only the session their
+    // invite is scoped to (so the studio page loads for them).
+    const principal = await resolvePrincipal(req, id);
+    if (!principal) {
+      return NextResponse.json({ error: "unauthorized" }, { status: 401 });
+    }
+    if (principal.kind === "guest" && principal.sessionId !== id) {
+      return NextResponse.json({ error: "forbidden" }, { status: 403 });
+    }
 
     const session = await db.session.findUnique({
       where: { id },

--- a/src/app/api/sessions/route.ts
+++ b/src/app/api/sessions/route.ts
@@ -1,7 +1,16 @@
 import { NextRequest, NextResponse } from "next/server";
 import { db } from "@/lib/db";
+import { AUTH_COOKIES, verifyHostCookie } from "@/lib/auth";
+
+async function requireHost(req: NextRequest): Promise<boolean> {
+  const host = await verifyHostCookie(req.cookies.get(AUTH_COOKIES.host)?.value);
+  return Boolean(host);
+}
 
 export async function POST(req: NextRequest) {
+  if (!(await requireHost(req))) {
+    return NextResponse.json({ error: "unauthorized" }, { status: 401 });
+  }
   try {
     const body = await req.json();
     const { name } = body;
@@ -27,7 +36,10 @@ export async function POST(req: NextRequest) {
   }
 }
 
-export async function GET() {
+export async function GET(req: NextRequest) {
+  if (!(await requireHost(req))) {
+    return NextResponse.json({ error: "unauthorized" }, { status: 401 });
+  }
   try {
     const sessions = await db.session.findMany({
       include: {

--- a/src/app/api/tracks/[id]/download/route.ts
+++ b/src/app/api/tracks/[id]/download/route.ts
@@ -1,11 +1,18 @@
 import { NextRequest, NextResponse } from "next/server";
 import { db } from "@/lib/db";
 import { getPresignedGetUrl } from "@/lib/s3";
+import { AUTH_COOKIES, verifyHostCookie } from "@/lib/auth";
 
 export async function GET(
-  _req: NextRequest,
+  req: NextRequest,
   { params }: { params: Promise<{ id: string }> }
 ) {
+  // Downloads are host-only. Guests record; they don't retrieve mastered tracks.
+  const host = await verifyHostCookie(req.cookies.get(AUTH_COOKIES.host)?.value);
+  if (!host) {
+    return NextResponse.json({ error: "unauthorized" }, { status: 401 });
+  }
+
   try {
     const { id } = await params;
 

--- a/src/app/api/upload/complete/route.ts
+++ b/src/app/api/upload/complete/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from "next/server";
 import { db } from "@/lib/db";
 import { deleteTrackChunks, trackRecordingKey } from "@/lib/s3";
+import { resolvePrincipal } from "@/lib/auth";
 
 export async function POST(req: NextRequest) {
   try {
@@ -12,6 +13,14 @@ export async function POST(req: NextRequest) {
         { error: "sessionId and trackId are required" },
         { status: 400 }
       );
+    }
+
+    const principal = await resolvePrincipal(req, sessionId);
+    if (!principal) {
+      return NextResponse.json({ error: "unauthorized" }, { status: 401 });
+    }
+    if (principal.kind === "guest" && principal.sessionId !== sessionId) {
+      return NextResponse.json({ error: "forbidden" }, { status: 403 });
     }
 
     const s3Key = trackRecordingKey(sessionId, trackId);

--- a/src/app/api/upload/presign/route.ts
+++ b/src/app/api/upload/presign/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from "next/server";
 import { db } from "@/lib/db";
 import { trackPartKey, trackRecordingKey, getPresignedPutUrl } from "@/lib/s3";
+import { resolvePrincipal } from "@/lib/auth";
 
 function getUploadErrorMessage(error: unknown): string {
   if (!(error instanceof Error)) {
@@ -27,6 +28,16 @@ export async function POST(req: NextRequest) {
         { error: "sessionId, trackId, and partNumber are required" },
         { status: 400 }
       );
+    }
+
+    // AuthZ: host can presign for any session; guest only for the session
+    // their cookie is scoped to. This is where we enforce the S3 blast radius.
+    const principal = await resolvePrincipal(req, sessionId);
+    if (!principal) {
+      return NextResponse.json({ error: "unauthorized" }, { status: 401 });
+    }
+    if (principal.kind === "guest" && principal.sessionId !== sessionId) {
+      return NextResponse.json({ error: "forbidden" }, { status: 403 });
     }
 
     if (partNumber === 0) {

--- a/src/app/join/[token]/JoinForm.tsx
+++ b/src/app/join/[token]/JoinForm.tsx
@@ -1,0 +1,83 @@
+"use client";
+
+import { useState } from "react";
+import { useRouter } from "next/navigation";
+
+export default function JoinForm({
+  token,
+  sessionName,
+  sessionId,
+}: {
+  token: string;
+  sessionName: string;
+  sessionId: string;
+}) {
+  const router = useRouter();
+  const [name, setName] = useState("");
+  const [error, setError] = useState<string | null>(null);
+  const [pending, setPending] = useState(false);
+
+  async function onSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    setPending(true);
+    setError(null);
+    try {
+      const res = await fetch("/api/auth/accept-invite", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ token, name: name.trim() }),
+      });
+      if (!res.ok) {
+        const body = await res.json().catch(() => ({}));
+        setError(body.error ?? "Could not join session");
+        setPending(false);
+        return;
+      }
+      router.push(`/studio/${sessionId}`);
+      router.refresh();
+    } catch {
+      setError("Network error");
+      setPending(false);
+    }
+  }
+
+  return (
+    <div className="min-h-screen flex items-center justify-center bg-neutral-950 text-neutral-100 px-4">
+      <form onSubmit={onSubmit} className="w-full max-w-sm space-y-4">
+        <div className="space-y-1">
+          <p className="text-sm text-neutral-400">You&apos;re invited to record</p>
+          <h1 className="text-2xl font-semibold">{sessionName}</h1>
+        </div>
+        <div className="space-y-2">
+          <label htmlFor="name" className="block text-sm text-neutral-300">
+            Your name
+          </label>
+          <input
+            id="name"
+            name="name"
+            type="text"
+            autoFocus
+            required
+            minLength={1}
+            maxLength={80}
+            value={name}
+            onChange={(e) => setName(e.target.value)}
+            className="w-full rounded-md border border-neutral-800 bg-neutral-900 px-3 py-2 text-sm outline-none focus:border-neutral-600"
+          />
+        </div>
+        {error && (
+          <p className="text-sm text-red-400" role="alert">
+            {error}
+          </p>
+        )}
+        <button
+          type="submit"
+          disabled={pending || name.trim().length === 0}
+          className="w-full rounded-md bg-neutral-100 px-3 py-2 text-sm font-medium text-neutral-900 hover:bg-white disabled:opacity-50 disabled:cursor-not-allowed"
+        >
+          {pending ? "Joining…" : "Join session"}
+        </button>
+      </form>
+    </div>
+  );
+}

--- a/src/app/join/[token]/page.tsx
+++ b/src/app/join/[token]/page.tsx
@@ -1,0 +1,38 @@
+import { notFound } from "next/navigation";
+import { db } from "@/lib/db";
+import { verifyInviteToken } from "@/lib/auth";
+import JoinForm from "./JoinForm";
+
+// Guest invite landing page. Validates the token server-side, shows a minimal
+// "enter your name" form, and POSTs to /api/auth/accept-invite which sets a
+// session-scoped guest cookie.
+export default async function JoinPage({
+  params,
+}: {
+  params: Promise<{ token: string }>;
+}) {
+  const { token } = await params;
+  const payload = await verifyInviteToken(token);
+  if (!payload) {
+    return (
+      <div className="min-h-screen flex items-center justify-center bg-neutral-950 text-neutral-100 px-4">
+        <div className="max-w-sm space-y-2 text-center">
+          <h1 className="text-xl font-semibold">Invite link invalid or expired</h1>
+          <p className="text-sm text-neutral-400">
+            Ask your host to send a fresh link.
+          </p>
+        </div>
+      </div>
+    );
+  }
+
+  const session = await db.session.findUnique({
+    where: { id: payload.sessionId },
+    select: { id: true, name: true },
+  });
+  if (!session) notFound();
+
+  return <JoinForm token={token} sessionName={session.name} sessionId={session.id} />;
+}
+
+export const dynamic = "force-dynamic";

--- a/src/app/session/[id]/page.tsx
+++ b/src/app/session/[id]/page.tsx
@@ -169,6 +169,7 @@ export default function SessionDetailPage() {
           <ButtonLink href={`/studio/${session.id}`} variant="ghost" size="md">
             Open Studio
           </ButtonLink>
+          <InviteButton sessionId={session.id} />
         </div>
 
         {/* Notes (local-only for now) */}
@@ -317,3 +318,64 @@ export default function SessionDetailPage() {
     </div>
   );
 }
+
+/**
+ * Host-only button that mints an invite link and copies it to the clipboard.
+ * Rendered on the session detail page; the middleware already ensures only
+ * a signed-in host can reach this page.
+ */
+function InviteButton({ sessionId }: { sessionId: string }) {
+  const [state, setState] = useState<
+    | { kind: "idle" }
+    | { kind: "pending" }
+    | { kind: "ready"; url: string; expiresInSeconds: number }
+    | { kind: "error"; message: string }
+  >({ kind: "idle" });
+
+  async function onClick() {
+    setState({ kind: "pending" });
+    try {
+      const res = await fetch(`/api/sessions/${sessionId}/invite`, { method: "POST" });
+      if (!res.ok) {
+        const body = await res.json().catch(() => ({}));
+        setState({ kind: "error", message: body.error ?? "Failed to create invite" });
+        return;
+      }
+      const { url, expiresInSeconds } = await res.json();
+      try {
+        await navigator.clipboard.writeText(url);
+      } catch {
+        // Clipboard may fail in insecure contexts — the URL is still shown.
+      }
+      setState({ kind: "ready", url, expiresInSeconds });
+    } catch {
+      setState({ kind: "error", message: "Network error" });
+    }
+  }
+
+  return (
+    <div className="flex flex-col gap-2">
+      <Button
+        variant="ghost"
+        size="md"
+        onClick={onClick}
+        disabled={state.kind === "pending"}
+        title="Generate a single-use invite link for a cohost"
+      >
+        {state.kind === "pending" ? "Generating…" : "Invite cohost"}
+      </Button>
+      {state.kind === "ready" && (
+        <div className="text-[11px] font-mono text-text-3 break-all max-w-[520px]">
+          <div className="text-text-2 mb-1">
+            Copied to clipboard — expires in {Math.round(state.expiresInSeconds / 3600)}h
+          </div>
+          {state.url}
+        </div>
+      )}
+      {state.kind === "error" && (
+        <div className="text-[11px] text-red-400">{state.message}</div>
+      )}
+    </div>
+  );
+}
+

--- a/src/app/session/[id]/page.tsx
+++ b/src/app/session/[id]/page.tsx
@@ -321,8 +321,9 @@ export default function SessionDetailPage() {
 
 /**
  * Host-only button that mints an invite link and copies it to the clipboard.
- * Rendered on the session detail page; the middleware already ensures only
- * a signed-in host can reach this page.
+ * Rendered on the session detail page. Middleware gates /session/<id> to
+ * host auth only (guests never reach this page), so the button can assume
+ * the caller is a host. The underlying API endpoint also enforces this.
  */
 function InviteButton({ sessionId }: { sessionId: string }) {
   const [state, setState] = useState<
@@ -360,14 +361,14 @@ function InviteButton({ sessionId }: { sessionId: string }) {
         size="md"
         onClick={onClick}
         disabled={state.kind === "pending"}
-        title="Generate a single-use invite link for a cohost"
+        title="Generate an invite link for a cohost. The link works until it expires; anyone with it can join until then."
       >
         {state.kind === "pending" ? "Generating…" : "Invite cohost"}
       </Button>
       {state.kind === "ready" && (
         <div className="text-[11px] font-mono text-text-3 break-all max-w-[520px]">
           <div className="text-text-2 mb-1">
-            Copied to clipboard — expires in {Math.round(state.expiresInSeconds / 3600)}h
+            Copied to clipboard — this invite link expires in {Math.round(state.expiresInSeconds / 3600)}h
           </div>
           {state.url}
         </div>

--- a/src/app/signin/page.tsx
+++ b/src/app/signin/page.tsx
@@ -1,0 +1,92 @@
+"use client";
+
+import { useState, Suspense } from "react";
+import { useRouter, useSearchParams } from "next/navigation";
+
+function SignInForm() {
+  const router = useRouter();
+  const params = useSearchParams();
+  const returnTo = params.get("return_to") ?? "/dashboard";
+
+  const [password, setPassword] = useState("");
+  const [error, setError] = useState<string | null>(null);
+  const [pending, setPending] = useState(false);
+
+  async function onSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    setPending(true);
+    setError(null);
+    try {
+      const res = await fetch("/api/auth/signin", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ password }),
+      });
+      if (!res.ok) {
+        const body = await res.json().catch(() => ({}));
+        setError(body.error ?? "Sign-in failed");
+        setPending(false);
+        return;
+      }
+      // Avoid open-redirect: only allow same-origin return_to
+      const safeReturnTo = returnTo.startsWith("/") && !returnTo.startsWith("//")
+        ? returnTo
+        : "/dashboard";
+      router.push(safeReturnTo);
+      router.refresh();
+    } catch {
+      setError("Network error");
+      setPending(false);
+    }
+  }
+
+  return (
+    <div className="min-h-screen flex items-center justify-center bg-neutral-950 text-neutral-100 px-4">
+      <form onSubmit={onSubmit} className="w-full max-w-sm space-y-4">
+        <div className="space-y-1">
+          <h1 className="text-2xl font-semibold">Cozytrack</h1>
+          <p className="text-sm text-neutral-400">Host sign-in</p>
+        </div>
+        <div className="space-y-2">
+          <label htmlFor="password" className="block text-sm text-neutral-300">
+            Password
+          </label>
+          <input
+            id="password"
+            name="password"
+            type="password"
+            autoComplete="current-password"
+            autoFocus
+            required
+            value={password}
+            onChange={(e) => setPassword(e.target.value)}
+            className="w-full rounded-md border border-neutral-800 bg-neutral-900 px-3 py-2 text-sm outline-none focus:border-neutral-600"
+          />
+        </div>
+        {error && (
+          <p className="text-sm text-red-400" role="alert">
+            {error}
+          </p>
+        )}
+        <button
+          type="submit"
+          disabled={pending || password.length === 0}
+          className="w-full rounded-md bg-neutral-100 px-3 py-2 text-sm font-medium text-neutral-900 hover:bg-white disabled:opacity-50 disabled:cursor-not-allowed"
+        >
+          {pending ? "Signing in…" : "Sign in"}
+        </button>
+        <p className="text-xs text-neutral-500">
+          Guests: use the invite link you were sent. This page is for the host.
+        </p>
+      </form>
+    </div>
+  );
+}
+
+export default function SignInPage() {
+  return (
+    <Suspense fallback={null}>
+      <SignInForm />
+    </Suspense>
+  );
+}

--- a/src/components/ui/Topbar.tsx
+++ b/src/components/ui/Topbar.tsx
@@ -55,13 +55,16 @@ export function Topbar({ session }: TopbarProps) {
         {/* Studio is contextual — only meaningful when you're inside a specific session. */}
         {isStudio && chip("studio", true, pathname)}
         {chip("dashboard", isDashboard, "/dashboard")}
-        <a
-          href="/api/auth/signout"
-          className="text-xs font-medium text-text-3 hover:text-text-2 ml-2"
-          title="Sign out"
-        >
-          sign out
-        </a>
+        {/* Sign-out is POST to avoid accidental logouts from prefetchers */}
+        <form action="/api/auth/signout" method="post" className="ml-2">
+          <button
+            type="submit"
+            className="text-xs font-medium text-text-3 hover:text-text-2 bg-transparent border-0 cursor-pointer p-0"
+            title="Sign out"
+          >
+            sign out
+          </button>
+        </form>
       </div>
     </div>
   );

--- a/src/components/ui/Topbar.tsx
+++ b/src/components/ui/Topbar.tsx
@@ -51,10 +51,17 @@ export function Topbar({ session }: TopbarProps) {
       {session && (
         <span className="text-[13px] font-medium text-text-2 truncate">{session}</span>
       )}
-      <div className="ml-auto flex gap-2">
+      <div className="ml-auto flex gap-2 items-center">
         {/* Studio is contextual — only meaningful when you're inside a specific session. */}
         {isStudio && chip("studio", true, pathname)}
         {chip("dashboard", isDashboard, "/dashboard")}
+        <a
+          href="/api/auth/signout"
+          className="text-xs font-medium text-text-3 hover:text-text-2 ml-2"
+          title="Sign out"
+        >
+          sign out
+        </a>
       </div>
     </div>
   );

--- a/src/lib/auth-password.ts
+++ b/src/lib/auth-password.ts
@@ -1,0 +1,19 @@
+// Password verification helpers. Isolated from src/lib/auth because this file
+// imports node:crypto, which is not available in the Edge runtime (where
+// middleware runs). The signin route pulls this in; middleware does not.
+
+import { createHash, timingSafeEqual } from "node:crypto";
+
+function getHostPasswordHash(): Buffer | null {
+  const pw = process.env.HOST_PASSWORD;
+  if (!pw) return null;
+  return createHash("sha256").update(pw).digest();
+}
+
+export function verifyHostPassword(candidate: string): boolean {
+  const expected = getHostPasswordHash();
+  if (!expected) return false;
+  const got = createHash("sha256").update(candidate).digest();
+  if (got.length !== expected.length) return false;
+  return timingSafeEqual(got, expected);
+}

--- a/src/lib/auth-password.ts
+++ b/src/lib/auth-password.ts
@@ -1,19 +1,52 @@
 // Password verification helpers. Isolated from src/lib/auth because this file
 // imports node:crypto, which is not available in the Edge runtime (where
 // middleware runs). The signin route pulls this in; middleware does not.
+//
+// We use scrypt (slow KDF) rather than a raw SHA-256 so that if the
+// per-instance rate limit in /api/auth/signin is bypassed (multi-instance
+// cold starts, distributed attack), brute-forcing stays expensive.
 
-import { createHash, timingSafeEqual } from "node:crypto";
+import { scryptSync, timingSafeEqual } from "node:crypto";
+
+// A fixed salt is fine here: there's a single secret we're hashing (not a
+// user database), and the salt only exists to stop rainbow tables. If we
+// ever grow to per-user passwords, switch to a per-row random salt stored
+// alongside the hash.
+const SCRYPT_SALT = "cozytrack.host-password.v1";
+const SCRYPT_KEYLEN = 32;
+// N=16384 is scrypt's interactive-login default (~30ms on a modern CPU).
+const SCRYPT_OPTS = { N: 16384, r: 8, p: 1 } as const;
+
+const MIN_PASSWORD_LENGTH = 12;
+
+let cachedHash: Buffer | null | undefined;
 
 function getHostPasswordHash(): Buffer | null {
+  if (cachedHash !== undefined) return cachedHash;
   const pw = process.env.HOST_PASSWORD;
-  if (!pw) return null;
-  return createHash("sha256").update(pw).digest();
+  if (!pw) {
+    cachedHash = null;
+    return cachedHash;
+  }
+  if (pw.length < MIN_PASSWORD_LENGTH) {
+    // Fail loudly at first use so a weak password is caught in deploy, not
+    // discovered by an attacker. The signin route surfaces this as a 500.
+    throw new Error(
+      `HOST_PASSWORD must be at least ${MIN_PASSWORD_LENGTH} characters. Generate one with: openssl rand -hex 24`,
+    );
+  }
+  cachedHash = scryptSync(pw, SCRYPT_SALT, SCRYPT_KEYLEN, SCRYPT_OPTS) as Buffer;
+  return cachedHash;
 }
 
 export function verifyHostPassword(candidate: string): boolean {
   const expected = getHostPasswordHash();
   if (!expected) return false;
-  const got = createHash("sha256").update(candidate).digest();
+  // Short-circuit on wildly wrong lengths without running scrypt, since the
+  // KDF is intentionally expensive. This does leak "password length looks
+  // plausible" via timing, but callers already see "401 invalid" either way.
+  if (candidate.length === 0 || candidate.length > 256) return false;
+  const got = scryptSync(candidate, SCRYPT_SALT, SCRYPT_KEYLEN, SCRYPT_OPTS) as Buffer;
   if (got.length !== expected.length) return false;
   return timingSafeEqual(got, expected);
 }

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -1,0 +1,173 @@
+// Interim auth for cozytrack. Two principals:
+//   - host: a single password-authenticated operator (you). Signed session cookie.
+//   - guest: per-session invite token. Signed JWT in URL, exchanged for a scoped cookie.
+//
+// Both use the same primitive: HS256 JWT via `jose`. When podflow ships as IdP
+// (see issue #36), verifyHostSession() gets replaced by verifyPodflowToken()
+// and the rest of this file can stay.
+
+import { SignJWT, jwtVerify } from "jose";
+import { NextRequest } from "next/server";
+import { cookies } from "next/headers";
+
+const HOST_COOKIE = "cozytrack_host";
+const GUEST_COOKIE_PREFIX = "cozytrack_guest_"; // + sessionId
+
+const HOST_SESSION_TTL_SECONDS = 60 * 60 * 24 * 7; // 7 days
+const GUEST_SESSION_TTL_SECONDS = 60 * 60 * 12; // 12 hours
+const INVITE_TOKEN_TTL_SECONDS = 60 * 60 * 48; // 48 hours
+
+export type HostPrincipal = { kind: "host" };
+export type GuestPrincipal = { kind: "guest"; sessionId: string; name: string };
+export type Principal = HostPrincipal | GuestPrincipal;
+
+function getSecret(): Uint8Array {
+  const secret = process.env.AUTH_SECRET;
+  if (!secret || secret.length < 32) {
+    throw new Error(
+      "AUTH_SECRET env var must be set to a 32+ character random string. Generate with: openssl rand -hex 32",
+    );
+  }
+  return new TextEncoder().encode(secret);
+}
+
+// ---------- Host sessions ----------
+
+export async function issueHostSessionCookie(): Promise<string> {
+  return await new SignJWT({})
+    .setProtectedHeader({ alg: "HS256" })
+    .setIssuer("cozytrack")
+    .setAudience("cozytrack:host")
+    .setSubject("host")
+    .setIssuedAt()
+    .setExpirationTime(`${HOST_SESSION_TTL_SECONDS}s`)
+    .sign(getSecret());
+}
+
+export async function verifyHostCookie(token: string | undefined): Promise<HostPrincipal | null> {
+  if (!token) return null;
+  try {
+    await jwtVerify(token, getSecret(), {
+      issuer: "cozytrack",
+      audience: "cozytrack:host",
+    });
+    return { kind: "host" };
+  } catch {
+    return null;
+  }
+}
+
+// ---------- Guest invite tokens ----------
+
+export async function mintInviteToken(sessionId: string): Promise<string> {
+  return await new SignJWT({ sessionId })
+    .setProtectedHeader({ alg: "HS256" })
+    .setIssuer("cozytrack")
+    .setAudience("cozytrack:invite")
+    .setIssuedAt()
+    .setExpirationTime(`${INVITE_TOKEN_TTL_SECONDS}s`)
+    .sign(getSecret());
+}
+
+export async function verifyInviteToken(token: string): Promise<{ sessionId: string } | null> {
+  try {
+    const { payload } = await jwtVerify(token, getSecret(), {
+      issuer: "cozytrack",
+      audience: "cozytrack:invite",
+    });
+    if (typeof payload.sessionId !== "string") return null;
+    return { sessionId: payload.sessionId };
+  } catch {
+    return null;
+  }
+}
+
+// ---------- Guest sessions (post-invite-acceptance) ----------
+
+export async function issueGuestSessionCookie(
+  sessionId: string,
+  name: string,
+): Promise<{ cookieName: string; value: string; ttl: number }> {
+  const value = await new SignJWT({ sessionId, name })
+    .setProtectedHeader({ alg: "HS256" })
+    .setIssuer("cozytrack")
+    .setAudience("cozytrack:guest")
+    .setSubject(`guest:${sessionId}`)
+    .setIssuedAt()
+    .setExpirationTime(`${GUEST_SESSION_TTL_SECONDS}s`)
+    .sign(getSecret());
+  return { cookieName: guestCookieName(sessionId), value, ttl: GUEST_SESSION_TTL_SECONDS };
+}
+
+export async function verifyGuestCookie(
+  token: string | undefined,
+  sessionId: string,
+): Promise<GuestPrincipal | null> {
+  if (!token) return null;
+  try {
+    const { payload } = await jwtVerify(token, getSecret(), {
+      issuer: "cozytrack",
+      audience: "cozytrack:guest",
+    });
+    if (payload.sessionId !== sessionId) return null;
+    const name = typeof payload.name === "string" ? payload.name : "Guest";
+    return { kind: "guest", sessionId, name };
+  } catch {
+    return null;
+  }
+}
+
+function guestCookieName(sessionId: string): string {
+  // Cookie names are per-session so a guest invited to one session doesn't
+  // accidentally carry credentials into another.
+  return `${GUEST_COOKIE_PREFIX}${sessionId}`;
+}
+
+// ---------- Request-level helpers ----------
+
+/**
+ * Resolves the caller for a given request + session scope.
+ *
+ * - Host cookie always wins (hosts can access any session).
+ * - Guest cookie is accepted only if it matches the requested sessionId.
+ * - Returns null if neither applies.
+ */
+export async function resolvePrincipal(
+  req: NextRequest,
+  sessionId?: string,
+): Promise<Principal | null> {
+  const host = await verifyHostCookie(req.cookies.get(HOST_COOKIE)?.value);
+  if (host) return host;
+
+  if (sessionId) {
+    const guestCookie = req.cookies.get(guestCookieName(sessionId))?.value;
+    const guest = await verifyGuestCookie(guestCookie, sessionId);
+    if (guest) return guest;
+  }
+
+  return null;
+}
+
+/** Server-component / route-handler variant using next/headers cookies() */
+export async function resolvePrincipalFromCookies(sessionId?: string): Promise<Principal | null> {
+  const jar = await cookies();
+  const host = await verifyHostCookie(jar.get(HOST_COOKIE)?.value);
+  if (host) return host;
+
+  if (sessionId) {
+    const guest = await verifyGuestCookie(jar.get(guestCookieName(sessionId))?.value, sessionId);
+    if (guest) return guest;
+  }
+  return null;
+}
+
+export const AUTH_COOKIES = {
+  host: HOST_COOKIE,
+  guest: guestCookieName,
+} as const;
+
+export const AUTH_TTLS = {
+  hostSession: HOST_SESSION_TTL_SECONDS,
+  guestSession: GUEST_SESSION_TTL_SECONDS,
+  invite: INVITE_TOKEN_TTL_SECONDS,
+} as const;

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -123,6 +123,11 @@ function guestCookieName(sessionId: string): string {
   return `${GUEST_COOKIE_PREFIX}${sessionId}`;
 }
 
+/** True if the cookie name belongs to a guest session. Safe for middleware/Edge. */
+export function isGuestCookieName(name: string): boolean {
+  return name.startsWith(GUEST_COOKIE_PREFIX);
+}
+
 // ---------- Request-level helpers ----------
 
 /**
@@ -163,6 +168,7 @@ export async function resolvePrincipalFromCookies(sessionId?: string): Promise<P
 
 export const AUTH_COOKIES = {
   host: HOST_COOKIE,
+  guestPrefix: GUEST_COOKIE_PREFIX,
   guest: guestCookieName,
 } as const;
 

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,0 +1,106 @@
+// Strict lockdown middleware.
+//
+// Policy:
+//   - Public: /signin (host login), /join/[token] (guest invite landing),
+//             /api/auth/* (login/logout/accept), plus Next internals.
+//   - Everything else requires EITHER a valid host cookie OR, when the URL
+//     names a specific session, a matching guest cookie.
+//
+// Session-scoped paths ({/studio,/session,/api/sessions,/api/tracks}/:id/...):
+//   host cookie always grants access; guest cookie grants only if its
+//   sessionId matches the URL path segment.
+//
+// Every other API/page route requires host auth.
+
+import { NextRequest, NextResponse } from "next/server";
+import { verifyHostCookie, verifyGuestCookie, AUTH_COOKIES } from "@/lib/auth";
+
+const PUBLIC_PATHS = [
+  "/signin",
+  "/api/auth/signin",
+  "/api/auth/signout",
+  "/api/auth/accept-invite",
+];
+
+const PUBLIC_PREFIXES = ["/join/", "/_next/", "/favicon.ico"];
+
+function isPublic(pathname: string): boolean {
+  if (PUBLIC_PATHS.includes(pathname)) return true;
+  return PUBLIC_PREFIXES.some((p) => pathname.startsWith(p));
+}
+
+/**
+ * Extract the session id from a URL if it's a session-scoped route.
+ * Returns null for routes that are not session-scoped.
+ */
+function extractSessionId(pathname: string): string | null {
+  // /studio/<id>, /session/<id>, /api/sessions/<id>/..., /api/tracks/<trackId>/...
+  // Tracks are not session-scoped in the URL — they only accept host auth.
+  const sessionMatch =
+    pathname.match(/^\/studio\/([^/]+)/) ??
+    pathname.match(/^\/session\/([^/]+)/) ??
+    pathname.match(/^\/api\/sessions\/([^/]+)/);
+  return sessionMatch?.[1] ?? null;
+}
+
+/**
+ * Is this a session-scoped write endpoint where a guest (in that session)
+ * should be allowed through? Upload presign/complete accept guest auth;
+ * the caller proves scope by including the sessionId in the body — but
+ * middleware can only check cookie-vs-URL, so we accept any guest cookie
+ * here and let the route handler enforce sessionId matching.
+ */
+function isGuestAllowedForSessionEndpoint(pathname: string): boolean {
+  return (
+    pathname === "/api/upload/presign" ||
+    pathname === "/api/upload/complete" ||
+    pathname === "/api/livekit-token"
+  );
+}
+
+export async function middleware(req: NextRequest) {
+  const { pathname } = req.nextUrl;
+
+  if (isPublic(pathname)) return NextResponse.next();
+
+  const hostCookie = req.cookies.get(AUTH_COOKIES.host)?.value;
+  const host = await verifyHostCookie(hostCookie);
+  if (host) return NextResponse.next();
+
+  // Session-scoped route: accept a matching guest cookie.
+  const sessionId = extractSessionId(pathname);
+  if (sessionId) {
+    const guestCookie = req.cookies.get(AUTH_COOKIES.guest(sessionId))?.value;
+    const guest = await verifyGuestCookie(guestCookie, sessionId);
+    if (guest) return NextResponse.next();
+  }
+
+  // Guest-allowed upload endpoints: the route handler inspects the request
+  // body and matches it to the guest cookie. Middleware can't read the body
+  // (streams aren't cloneable here), so we let any request with *some* guest
+  // cookie continue to the handler, which does the real check.
+  if (isGuestAllowedForSessionEndpoint(pathname)) {
+    const guestCookies = req.cookies
+      .getAll()
+      .filter((c) => c.name.startsWith("cozytrack_guest_"));
+    if (guestCookies.length > 0) {
+      return NextResponse.next();
+    }
+  }
+
+  // API routes return JSON 401; pages redirect to sign-in.
+  if (pathname.startsWith("/api/")) {
+    return NextResponse.json({ error: "unauthorized" }, { status: 401 });
+  }
+
+  const signinUrl = new URL("/signin", req.url);
+  signinUrl.searchParams.set("return_to", pathname + req.nextUrl.search);
+  return NextResponse.redirect(signinUrl);
+}
+
+export const config = {
+  matcher: [
+    // Match everything except static assets and image optimizer
+    "/((?!_next/static|_next/image|favicon.ico).*)",
+  ],
+};

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -13,7 +13,7 @@
 // Every other API/page route requires host auth.
 
 import { NextRequest, NextResponse } from "next/server";
-import { verifyHostCookie, verifyGuestCookie, AUTH_COOKIES } from "@/lib/auth";
+import { verifyHostCookie, verifyGuestCookie, AUTH_COOKIES, isGuestCookieName } from "@/lib/auth";
 
 const PUBLIC_PATHS = [
   "/signin",
@@ -30,15 +30,17 @@ function isPublic(pathname: string): boolean {
 }
 
 /**
- * Extract the session id from a URL if it's a session-scoped route.
- * Returns null for routes that are not session-scoped.
+ * Extract the session id from a URL if it's a guest-accessible session-scoped
+ * route. Returns null for routes that require host auth.
+ *
+ * Guests are deliberately limited to recording in the studio. The session
+ * detail page (/session/<id>) is host-only because it exposes admin UI
+ * (invite minting, download links). /api/sessions/<id> GET is allowed for
+ * guests so the studio page can load the session metadata it needs.
  */
 function extractSessionId(pathname: string): string | null {
-  // /studio/<id>, /session/<id>, /api/sessions/<id>/..., /api/tracks/<trackId>/...
-  // Tracks are not session-scoped in the URL — they only accept host auth.
   const sessionMatch =
     pathname.match(/^\/studio\/([^/]+)/) ??
-    pathname.match(/^\/session\/([^/]+)/) ??
     pathname.match(/^\/api\/sessions\/([^/]+)/);
   return sessionMatch?.[1] ?? null;
 }
@@ -80,9 +82,7 @@ export async function middleware(req: NextRequest) {
   // (streams aren't cloneable here), so we let any request with *some* guest
   // cookie continue to the handler, which does the real check.
   if (isGuestAllowedForSessionEndpoint(pathname)) {
-    const guestCookies = req.cookies
-      .getAll()
-      .filter((c) => c.name.startsWith("cozytrack_guest_"));
+    const guestCookies = req.cookies.getAll().filter((c) => isGuestCookieName(c.name));
     if (guestCookies.length > 0) {
       return NextResponse.next();
     }


### PR DESCRIPTION
Closes nothing on its own — this is the **interim** lockdown that unblocks public deployment and sets up the migration to podflow-as-IdP tracked in the companion issues below.

## What this does

Before: every route under `src/app/api/*` accepted anonymous callers. Anyone with the URL could `POST /api/upload/presign` and mint S3 `PUT` URLs against the configured bucket, or `POST /api/livekit-token` and burn LiveKit minutes. After: strict lockdown.

Two principals, one primitive (HS256 JWT via `jose`):

| | Host | Guest |
|---|---|---|
| Sign-in | Password at `/signin` | Invite link `/join/<token>` minted by host |
| Cookie TTL | 7 days | 12 hours |
| Scope | Any session | Exactly one `sessionId` |
| Can do | Everything | Record their own track in their invited session only |

The three tokens use distinct JWT audiences (`cozytrack:host`, `cozytrack:guest`, `cozytrack:invite`) so they can't be cross-misused.

## Enforcement layers

- **`src/middleware.ts`** — Gates everything except `/signin`, `/join/<token>`, and the three `/api/auth/*` endpoints. Unauthed browsers get redirected to `/signin?return_to=...`; unauthed API calls get 401 JSON.
- **Per-route authorization in handlers** — This is the real protection. Middleware only sees cookies vs URL; the handlers cross-check cookie `sessionId` against request-body `sessionId`:
  - `/api/upload/presign`, `/api/upload/complete`, `/api/livekit-token`, `GET /api/sessions/[id]`: accept host OR guest-in-session; reject guest-cross-session
  - `POST/GET /api/sessions`, `GET /api/tracks/[id]/download`, `POST /api/sessions/[id]/invite`: host-only
- **Rate limiting + timing mitigation** — 10 attempts / 10 min / IP on `/api/auth/signin`, plus 250ms delay on failed attempts

## Edge compatibility

Middleware runs on Edge, which doesn't support `node:crypto`. Password hashing is isolated in `src/lib/auth-password.ts` and only imported by the signin route. `src/lib/auth.ts` stays jose-only.

## UX

- `/signin` — minimal password form
- `/join/<token>` — validates token server-side, shows session name, asks for display name
- Session detail page — "Invite cohost" button mints a link and copies it to clipboard, shows expiry
- Topbar — "sign out" link clears host + guest cookies

## Env vars added (required before deploy)

```
AUTH_SECRET=<openssl rand -hex 32>
HOST_PASSWORD=<your chosen password>
```

`.env.example` and README updated.

## Tested

Smoke test covered (and then removed):
- Password accept / reject / empty
- Host + guest + invite cookie roundtrips
- **Guest cookie for session A rejected against session B** (critical: this is the S3 blast-radius containment)
- Host token rejected as guest token and vice versa

Full `npx tsc --noEmit`, `npx next lint`, and `npx next build` all green.

## Migration path (long-term, tracked separately)

This interim scheme gets replaced by podflow-as-IdP. The JWT primitive stays; only `verifyHostCookie` gets swapped for `verifyPodflowToken`. The guest path stays as-is.

- pashafateev/podflow#11 — Adopt Auth.js v5 as the platform identity provider
- #36 — Replace interim auth with podflow JWT verification + JIT user provisioning
- #37 — Service token flow for podline → cozytrack calls

## Deploy checklist

- [ ] Generate `AUTH_SECRET` with `openssl rand -hex 32`
- [ ] Set `AUTH_SECRET` and `HOST_PASSWORD` in Vercel (Production + Preview) and `.env.local`
- [ ] Deploy and verify `/signin` gates everything
- [ ] Verify invite link flow end-to-end with a second browser / private window
