### PR TITLE
Wire cohost invite tile in studio

### DIFF
--- a/src/app/api/auth/me/route.ts
+++ b/src/app/api/auth/me/route.ts
@@ -1,0 +1,22 @@
+import { NextRequest, NextResponse } from "next/server";
+import { resolvePrincipal } from "@/lib/auth";
+
+// Thin endpoint so client UI can branch on principal (host vs guest for a
+// given session) without duplicating the cookie-verification logic. Guests
+// are scoped to a single session, so the caller passes the sessionId as a
+// query param when it wants guest detection.
+export async function GET(req: NextRequest) {
+  const sessionId = req.nextUrl.searchParams.get("sessionId") ?? undefined;
+  const principal = await resolvePrincipal(req, sessionId);
+  if (!principal) {
+    return NextResponse.json({ role: null }, { status: 200 });
+  }
+  if (principal.kind === "host") {
+    return NextResponse.json({ role: "host" });
+  }
+  return NextResponse.json({
+    role: "guest",
+    sessionId: principal.sessionId,
+    name: principal.name,
+  });
+}

--- a/src/app/studio/[id]/page.tsx
+++ b/src/app/studio/[id]/page.tsx
@@ -244,14 +244,53 @@ function InviteLinkModal({
   const [copyState, setCopyState] = useState<"idle" | "copied">(
     initialCopyState,
   );
+  const dialogRef = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
     function handleKeyDown(e: KeyboardEvent) {
-      if (e.key === "Escape") onClose();
+      if (e.key === "Escape") {
+        onClose();
+        return;
+      }
+      if (e.key !== "Tab") return;
+      const container = dialogRef.current;
+      if (!container) return;
+
+      const focusable = Array.from(
+        container.querySelectorAll<HTMLElement>("button, input, a[href]"),
+      ).filter((el) => !el.hasAttribute("disabled"));
+      if (focusable.length === 0) return;
+
+      const first = focusable[0];
+      const last = focusable[focusable.length - 1];
+      const active = document.activeElement as HTMLElement | null;
+
+      if (e.shiftKey) {
+        if (active === first || !container.contains(active)) {
+          e.preventDefault();
+          last.focus();
+        }
+      } else {
+        if (active === last || !container.contains(active)) {
+          e.preventDefault();
+          first.focus();
+        }
+      }
     }
     document.addEventListener("keydown", handleKeyDown);
     return () => document.removeEventListener("keydown", handleKeyDown);
   }, [onClose]);
+
+  // Focus the first focusable element on open so keyboard users start inside
+  // the dialog rather than on whatever was focused on the page behind it.
+  useEffect(() => {
+    const container = dialogRef.current;
+    if (!container) return;
+    const first = container.querySelector<HTMLElement>(
+      "button, input, a[href]",
+    );
+    first?.focus();
+  }, []);
 
   async function copy() {
     try {
@@ -262,7 +301,9 @@ function InviteLinkModal({
     }
   }
 
-  const hours = Math.max(1, Math.round(expiresInSeconds / 3600));
+  // Use ceil so we never overstate validity. The token may expire sooner than
+  // the rounded hour figure would suggest, hence "up to".
+  const hours = Math.max(1, Math.ceil(expiresInSeconds / 3600));
 
   return (
     <div
@@ -270,6 +311,7 @@ function InviteLinkModal({
       onClick={onClose}
     >
       <div
+        ref={dialogRef}
         role="dialog"
         aria-modal="true"
         aria-labelledby="invite-link-title"
@@ -285,8 +327,8 @@ function InviteLinkModal({
             Invite a cohost
           </h2>
           <p className="text-sm text-text-2 mt-1.5">
-            Share this link. Anyone who opens it can join this session until it
-            expires in {hours}h.
+            Share this link. Anyone who opens it can join this session; it
+            expires in up to {hours}h.
           </p>
         </div>
         <div
@@ -311,7 +353,6 @@ function InviteLinkModal({
             <button
               type="button"
               onClick={copy}
-              autoFocus
               className="text-[12px] px-3 py-1.5 rounded-md font-medium"
               style={{ background: "var(--amber)", color: "var(--bg)" }}
             >

--- a/src/app/studio/[id]/page.tsx
+++ b/src/app/studio/[id]/page.tsx
@@ -144,6 +144,186 @@ function ParticipantStrip({
   );
 }
 
+// ---------- Invite Cohost Tile ----------
+
+// Host-only tile. Clicking mints a fresh invite URL via the session's invite
+// endpoint, copies it to the clipboard, and shows a modal so the host can
+// re-copy or see the expiry. Each click mints a new token — we don't persist
+// the last one; it's cheap and keeps the UI stateless across reloads.
+function InviteCohostTile({ sessionId }: { sessionId: string }) {
+  const [pending, setPending] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [invite, setInvite] = useState<{
+    url: string;
+    expiresInSeconds: number;
+  } | null>(null);
+  const [copyState, setCopyState] = useState<"idle" | "copied">("idle");
+
+  async function onClick() {
+    if (pending) return;
+    setPending(true);
+    setError(null);
+    try {
+      const res = await fetch(`/api/sessions/${sessionId}/invite`, {
+        method: "POST",
+      });
+      if (!res.ok) {
+        const body = await res.json().catch(() => ({}));
+        setError(body.error ?? "Failed to create invite");
+        return;
+      }
+      const body: { url: string; expiresInSeconds: number } = await res.json();
+      setInvite(body);
+      try {
+        await navigator.clipboard.writeText(body.url);
+        setCopyState("copied");
+      } catch {
+        setCopyState("idle");
+      }
+    } catch {
+      setError("Network error");
+    } finally {
+      setPending(false);
+    }
+  }
+
+  return (
+    <>
+      <button
+        type="button"
+        onClick={onClick}
+        disabled={pending}
+        className="rounded-lg px-4 py-3.5 flex items-center gap-3 border border-dashed hover:bg-card/40 focus:outline-none focus:ring-1 focus:ring-[var(--border-hi)] transition-colors disabled:opacity-60 disabled:cursor-wait text-left"
+        style={{ borderColor: "var(--border)" }}
+        title="Generate a shareable invite link for a cohost"
+      >
+        <div
+          className="w-8 h-8 rounded-full flex items-center justify-center border border-dashed"
+          style={{ borderColor: "var(--border-hi)" }}
+        >
+          <IcoPlus size={14} color="var(--text-3)" />
+        </div>
+        <span className="text-[13px] text-text-2">
+          {pending ? "Generating invite…" : "Invite a cohost…"}
+        </span>
+        <div className="ml-auto">
+          <IcoLink size={13} color="var(--text-3)" />
+        </div>
+      </button>
+      {error && (
+        <div className="text-[11px] text-red-400 px-1" role="alert">
+          {error}
+        </div>
+      )}
+      {invite && (
+        <InviteLinkModal
+          url={invite.url}
+          expiresInSeconds={invite.expiresInSeconds}
+          initialCopyState={copyState}
+          onClose={() => {
+            setInvite(null);
+            setCopyState("idle");
+          }}
+        />
+      )}
+    </>
+  );
+}
+
+function InviteLinkModal({
+  url,
+  expiresInSeconds,
+  initialCopyState,
+  onClose,
+}: {
+  url: string;
+  expiresInSeconds: number;
+  initialCopyState: "idle" | "copied";
+  onClose: () => void;
+}) {
+  const [copyState, setCopyState] = useState<"idle" | "copied">(
+    initialCopyState,
+  );
+
+  useEffect(() => {
+    function handleKeyDown(e: KeyboardEvent) {
+      if (e.key === "Escape") onClose();
+    }
+    document.addEventListener("keydown", handleKeyDown);
+    return () => document.removeEventListener("keydown", handleKeyDown);
+  }, [onClose]);
+
+  async function copy() {
+    try {
+      await navigator.clipboard.writeText(url);
+      setCopyState("copied");
+    } catch {
+      // Clipboard can fail on insecure origins; the URL is still visible.
+    }
+  }
+
+  const hours = Math.max(1, Math.round(expiresInSeconds / 3600));
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/60 backdrop-blur-sm px-4"
+      onClick={onClose}
+    >
+      <div
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="invite-link-title"
+        onClick={(e) => e.stopPropagation()}
+        className="max-w-md w-full rounded-xl border p-6 shadow-2xl space-y-5"
+        style={{ background: "var(--card)", borderColor: "var(--border-hi)" }}
+      >
+        <div>
+          <h2
+            id="invite-link-title"
+            className="text-lg font-semibold text-text"
+          >
+            Invite a cohost
+          </h2>
+          <p className="text-sm text-text-2 mt-1.5">
+            Share this link. Anyone who opens it can join this session until it
+            expires in {hours}h.
+          </p>
+        </div>
+        <div
+          className="rounded-md border px-3 py-2 text-[11px] font-mono text-text-2 break-all select-all"
+          style={{ background: "var(--bg)", borderColor: "var(--border)" }}
+        >
+          {url}
+        </div>
+        <div className="flex items-center justify-between gap-3">
+          <span className="text-[11px] text-text-3">
+            {copyState === "copied" ? "Copied to clipboard" : ""}
+          </span>
+          <div className="flex items-center gap-2">
+            <button
+              type="button"
+              onClick={onClose}
+              className="text-[12px] px-3 py-1.5 rounded-md border hover:bg-card/50"
+              style={{ borderColor: "var(--border)", color: "var(--text-2)" }}
+            >
+              Close
+            </button>
+            <button
+              type="button"
+              onClick={copy}
+              autoFocus
+              className="text-[12px] px-3 py-1.5 rounded-md font-medium"
+              style={{ background: "var(--amber)", color: "var(--bg)" }}
+            >
+              {copyState === "copied" ? "Copy again" : "Copy link"}
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}
+
 // ---------- Room Content (inside LiveKitRoom) ----------
 
 function RoomContent({
@@ -158,6 +338,7 @@ function RoomContent({
   monitorVolume,
   onMonitorEnabledChange,
   onMonitorVolumeChange,
+  isHost,
 }: {
   sessionId: string;
   participantName: string;
@@ -170,6 +351,7 @@ function RoomContent({
   monitorVolume: number;
   onMonitorEnabledChange: (enabled: boolean) => void;
   onMonitorVolumeChange: (volume: number) => void;
+  isHost: boolean;
 }) {
   const remoteParticipants = useRemoteParticipants();
   const speakingParticipants = useSpeakingParticipants();
@@ -593,23 +775,9 @@ function RoomContent({
             />
           ))}
 
-          {/* Invite tile — blocked on cozytrack#23 (invite tokens). */}
-          <div
-            className="rounded-lg px-4 py-3.5 flex items-center gap-3 opacity-50 cursor-not-allowed border border-dashed"
-            style={{ borderColor: "var(--border)" }}
-            title="Cohost invite links tracked in #23"
-          >
-            <div
-              className="w-8 h-8 rounded-full flex items-center justify-center border border-dashed"
-              style={{ borderColor: "var(--border-hi)" }}
-            >
-              <IcoPlus size={14} color="var(--text-3)" />
-            </div>
-            <span className="text-[13px] text-text-3">Invite a cohost…</span>
-            <div className="ml-auto">
-              <IcoLink size={13} color="var(--text-3)" />
-            </div>
-          </div>
+          {/* Invite tile — host-only. Guests don't see the affordance; the
+              underlying API also rejects non-host callers. */}
+          {isHost && <InviteCohostTile sessionId={sessionId} />}
 
           {/* Monitor toggle kept below the strips so it doesn't crowd the meters */}
           <div className="mt-2">
@@ -715,11 +883,40 @@ export default function StudioPage() {
   const [connecting, setConnecting] = useState(false);
   const [monitorEnabled, setMonitorEnabled] = useState(false);
   const [monitorVolume, setMonitorVolume] = useState(70);
+  // Role drives host-only affordances (e.g. the cohost invite tile). Guests
+  // arriving via /join have their display name recorded in the cookie; we
+  // use it to prefill the prejoin form.
+  const [isHost, setIsHost] = useState(false);
 
   useEffect(() => {
     setMonitorEnabled(getStoredMonitorEnabled());
     setMonitorVolume(getStoredMonitorVolume());
   }, []);
+
+  useEffect(() => {
+    let cancelled = false;
+    async function loadPrincipal() {
+      try {
+        const res = await fetch(
+          `/api/auth/me?sessionId=${encodeURIComponent(sessionId)}`,
+        );
+        if (!res.ok) return;
+        const body: { role?: string; name?: string } = await res.json();
+        if (cancelled) return;
+        if (body.role === "host") {
+          setIsHost(true);
+        } else if (body.role === "guest" && typeof body.name === "string") {
+          setParticipantName((prev) => (prev ? prev : body.name ?? ""));
+        }
+      } catch {
+        // Leave defaults — the studio still works, just without host UI.
+      }
+    }
+    void loadPrincipal();
+    return () => {
+      cancelled = true;
+    };
+  }, [sessionId]);
 
   const [showMicWarning, setShowMicWarning] = useState(false);
   const [acknowledgedDevices, setAcknowledgedDevices] = useState<Set<string>>(
@@ -969,6 +1166,7 @@ export default function StudioPage() {
           monitorVolume={monitorVolume}
           onMonitorEnabledChange={setMonitorEnabled}
           onMonitorVolumeChange={setMonitorVolume}
+          isHost={isHost}
         />
       </LiveKitRoom>
     </div>

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -20,6 +20,10 @@ const PUBLIC_PATHS = [
   "/api/auth/signin",
   "/api/auth/signout",
   "/api/auth/accept-invite",
+  // /api/auth/me does its own principal resolution and returns {role: null}
+  // for unauthenticated callers. It must be reachable for guests-in-session
+  // so the studio page can branch on host-vs-guest without 401-ing the call.
+  "/api/auth/me",
 ];
 
 const PUBLIC_PREFIXES = ["/join/", "/_next/", "/favicon.ico"];


### PR DESCRIPTION
## Summary

The redesigned studio page had a disabled \"Invite a cohost…\" tile as a placeholder. The invite minting API (`POST /api/sessions/[id]/invite`) and the `/join/<token>` landing flow already shipped as part of the auth lockdown (#38) — all that was missing was the studio-side affordance. This wires it up.

- New `GET /api/auth/me` — thin endpoint that returns the caller's role (`host`, `guest`, or `null`) so the studio client can branch on who's viewing without duplicating cookie-verification. Takes an optional `sessionId` query param for guest detection (guests are scoped to a single session).
- Studio page calls `/api/auth/me` on mount:
  - **Host**: renders the real invite tile.
  - **Guest**: prefills the prejoin form's \"Your Name\" field from the cookie so guests don't retype what they entered on `/join`. Matches the issue's \"participant name prefilled\" ask.
- Invite tile mints a token via the existing API, copies the URL to the clipboard, and opens a modal with the URL (select-all + mono font), a \"Copy link\" / \"Copy again\" button, a Close button, and an `expires in Nh` note. Dismisses on overlay click / Escape.

Non-hosts never see the tile, and the underlying API also enforces host-only, so there's no way for a guest to mint an invite even if they bypass the UI.

## Testing

- [x] `npm run lint` — clean
- [x] `npx tsc --noEmit` — clean
- [x] `npm run build` — succeeds; `/api/auth/me` registered as a dynamic route
- [ ] Manual smoke: sign in as host → open `/studio/<id>` → click \"Invite a cohost…\" → verify modal shows URL + \"Copied to clipboard\" → open URL in a second browser → enter a name → lands in `/studio/<id>` with the name prefilled on the prejoin form

Closes #23

🤖 Generated with [Claude Code](https://claude.com/claude-code)