### PR TITLE
Hide remote audio meters from non-host participants

### DIFF
--- a/src/app/studio/[id]/page.tsx
+++ b/src/app/studio/[id]/page.tsx
@@ -860,21 +860,29 @@ function RoomContent({
             status={localStatus}
           />
 
-          {remoteParticipants.map((p) => (
-            <ParticipantStrip
-              key={p.identity}
-              name={p.identity}
-              role="guest"
-              micLabel={undefined /* Remote mic label — needs #28 (LiveKit metadata propagation). */}
-              isBuiltIn={false /* Remote built-in detection — needs #28. */}
-              level={audioLevels.get(p.identity) ?? 0}
-              // studioState is local-only, so showing localStatus on remote
-              // strips was misleading (guests appeared to be "Recording" whenever
-              // the host hit record). Remote per-participant status is tracked
-              // in #30; until then we show a stable "connected" for remotes.
-              status="connected"
-            />
-          ))}
+          {/* Remote participant strips are host-only for now (#44). The remote
+              audio level we surface comes from LiveKit's speaking-participants
+              hook, which is a coarse "is this person talking" signal — not a
+              true representation of the recorded remote track. Showing it to
+              guests is misleading ("is my cohost's audio being captured?"),
+              so guests only see their own meter. Host-side multi-participant
+              metering with accurate levels is tracked separately. */}
+          {isHost &&
+            remoteParticipants.map((p) => (
+              <ParticipantStrip
+                key={p.identity}
+                name={p.identity}
+                role="guest"
+                micLabel={undefined /* Remote mic label — needs #28 (LiveKit metadata propagation). */}
+                isBuiltIn={false /* Remote built-in detection — needs #28. */}
+                level={audioLevels.get(p.identity) ?? 0}
+                // studioState is local-only, so showing localStatus on remote
+                // strips was misleading (guests appeared to be "Recording" whenever
+                // the host hit record). Remote per-participant status is tracked
+                // in #30; until then we show a stable "connected" for remotes.
+                status="connected"
+              />
+            ))}
 
           {/* Invite tile — host-only. Guests don't see the affordance; the
               underlying API also rejects non-host callers. */}


### PR DESCRIPTION
Closes #44.

## Summary

- Gates the remote `ParticipantStrip` rendering in the studio on `isHost`, so guests only see their own meter.
- The remote level we surface today comes from `useSpeakingParticipants`, which is a coarse "is this person talking" signal — not a true representation of the recorded remote track. Showing it to a guest is misleading ("is my cohost's audio being captured?"). The short-term fix per the issue is to not show it to non-hosts at all.
- The host view is unchanged: hosts still see their own strip plus one strip per remote participant.

## Why this preserves future work

The change is purely a render-gate at the strip-rendering site. The underlying plumbing (`useRemoteParticipants`, `useSpeakingParticipants`, the `audioLevels` map, the `ParticipantStrip` component) is untouched, so future host-side multi-participant accurate metering can build on the same surface without reverting this PR.

## Files changed

- `src/app/studio/[id]/page.tsx` — wrap the `remoteParticipants.map(...)` block in `isHost && ...` and update the surrounding comment to point at #44.

## Testing

- `npm run lint` — no warnings or errors
- `npx tsc --noEmit` — clean
- `npm test` — 24/24 passing (4 files)
- `npm run build` — production build succeeds

## Acceptance criteria mapping

- [x] Guest in a recording session sees only their own audio meter.
- [x] When a remote participant speaks, the guest UI does not show a remote audio meter that could be mistaken for accurate remote-track metering.
- [x] Host view continues to render a strip per remote participant; no host plumbing was removed, so future host-side metering work is unblocked.