### PR TITLE
fix: stop co-host elapsed-time ticker when host stops recording (#48)

### DIFF
--- a/src/app/studio/[id]/page.tsx
+++ b/src/app/studio/[id]/page.tsx
@@ -593,26 +593,23 @@ function RoomContent({
     });
   }, [speakingParticipants]);
 
-  // Tick the elapsed-time display while recording
+  // Tick the elapsed-time display while recording. The interval is bound to
+  // studioState — when stop is initiated (locally OR via a received
+  // recording_stop control message), studioState transitions to "connected"
+  // and this effect tears the interval down. The display is left frozen at
+  // the stop-moment value rather than reset to zero, and only reinitialized
+  // when a new recording begins.
   useEffect(() => {
-    if (studioState === "recording") {
-      setElapsedMs(0);
-      const started = Date.now();
-      elapsedTimerRef.current = setInterval(() => {
-        setElapsedMs(Date.now() - started);
-      }, 250);
-    } else {
-      setElapsedMs(0);
-      if (elapsedTimerRef.current) {
-        clearInterval(elapsedTimerRef.current);
-        elapsedTimerRef.current = null;
-      }
-    }
+    if (studioState !== "recording") return;
+    setElapsedMs(0);
+    const started = Date.now();
+    const id = setInterval(() => {
+      setElapsedMs(Date.now() - started);
+    }, 250);
+    elapsedTimerRef.current = id;
     return () => {
-      if (elapsedTimerRef.current) {
-        clearInterval(elapsedTimerRef.current);
-        elapsedTimerRef.current = null;
-      }
+      clearInterval(id);
+      elapsedTimerRef.current = null;
     };
   }, [studioState]);
 
@@ -691,11 +688,20 @@ function RoomContent({
   );
 
   // Core recording stop. Idempotent: no-op when we have no active recorder.
+  // Transitions studioState out of "recording" up front so UI elements bound
+  // to it (notably the elapsed-time ticker) tear down even if the async
+  // upload finalization below throws. Without this, a network blip on the
+  // co-host during finalize would leave the timer running forever (#48).
   const stopRecordingLocal = useCallback(async () => {
     if (!recorderRef.current) return;
 
+    const recorder = recorderRef.current;
+    recorderRef.current = null;
+    setStudioStateSync("connected");
+    setHasRecorded(true);
+
     try {
-      const blob = await recorderRef.current.stop();
+      const blob = await recorder.stop();
       const trackId = trackIdRef.current;
       const durationMs = Date.now() - recordingStartRef.current;
 
@@ -704,15 +710,10 @@ function RoomContent({
       await waitForChunkUploads();
       await completeUpload(sessionId, trackId, durationMs);
 
-      setStudioStateSync("connected");
-      setHasRecorded(true);
-
       await switchAudioQuality("full");
     } catch (err) {
       console.error("Failed to stop recording:", err);
     }
-
-    recorderRef.current = null;
   }, [sessionId, setStudioStateSync, switchAudioQuality, waitForChunkUploads]);
 
   // Button handler: broadcast first so remote participants start close to our


### PR DESCRIPTION
## Summary

Fixes #48. When the host stops a broadcast recording, the recording correctly stops on the co-host's machine but the elapsed-time UI ticker keeps incrementing forever.

**Root cause:** the elapsed-time `setInterval` in `src/app/studio/[id]/page.tsx` is bound to `studioState`, and `studioState` was only transitioned back to `"connected"` *after* `stopRecordingLocal`'s full async upload-finalize chain (`recorder.stop()` → presigned URL → final chunk upload → `completeUpload`). If any of those steps threw — easy to hit on the co-host with a network blip — the state never transitioned and the ticker kept running.

**Fix:** transition `studioState` out of `"recording"` up front in `stopRecordingLocal`, before the async finalize work, so the ticker tears down regardless of whether the upload pipeline succeeds. Also leave the elapsed display frozen at the stop-moment value rather than resetting to zero (per the issue's fix direction).

This works whether the stop was initiated locally (host clicking stop) or via a received `recording_stop` control message (co-host being notified) — both paths go through `stopRecordingLocal`.

Closes #48

## Testing

- `npm run lint` — clean
- `npx tsc --noEmit` — clean
- `npm test` — 24/24 passing
- `npm run build` — green

Manual repro path covered by the change:
- Host + co-host join, host starts recording — both timers tick.
- Host stops recording — co-host's `recording_stop` handler invokes `stopRecordingLocal`, which now transitions state synchronously and tears down the interval. Ticker stops; displayed elapsed is frozen at stop moment.
- Even if the co-host's upload finalize step throws, the timer still stops (the prior bug).

🤖 Generated with [Claude Code](https://claude.com/claude-code)