### PR TITLE
fix: resolve OS-default device before showing mic warning (#50)

### DIFF
--- a/src/app/studio/[id]/page.tsx
+++ b/src/app/studio/[id]/page.tsx
@@ -24,7 +24,7 @@ import { CozyRecorder } from "@/lib/recorder";
 import { getPresignedUploadUrl, uploadChunk, completeUpload } from "@/lib/upload";
 import { getToken, LIVEKIT_URL } from "@/lib/livekit";
 import { useTransport } from "@/lib/transport";
-import { isBuiltInMic } from "@/lib/devices";
+import { isSelectedMicBuiltIn } from "@/lib/devices";
 import { BuiltInMicWarningModal } from "@/components/BuiltInMicWarningModal";
 import {
   MicMonitorToggle,
@@ -1134,7 +1134,7 @@ export default function StudioPage() {
 
     if (
       selectedMicDevice &&
-      isBuiltInMic(selectedMicDevice.label) &&
+      isSelectedMicBuiltIn(mics, selectedMic) &&
       !acknowledgedDevices.has(selectedMic)
     ) {
       setShowMicWarning(true);
@@ -1272,7 +1272,7 @@ export default function StudioPage() {
           participantName={participantName}
           selectedMic={selectedMic}
           selectedMicLabel={selectedMicDevice?.label || undefined}
-          selectedMicIsBuiltIn={selectedMicDevice ? isBuiltInMic(selectedMicDevice.label) : false}
+          selectedMicIsBuiltIn={selectedMicDevice ? isSelectedMicBuiltIn(mics, selectedMic) : false}
           studioState={studioState}
           setStudioState={setStudioState}
           monitorEnabled={monitorEnabled}

--- a/src/lib/devices.ts
+++ b/src/lib/devices.ts
@@ -2,9 +2,62 @@
  * Heuristic to detect built-in/internal microphones from their label.
  * Case-insensitive keyword match — easy to extend.
  */
-const BUILTIN_KEYWORDS = ["built-in", "internal", "macbook", "default"];
+const BUILTIN_KEYWORDS = ["built-in", "internal", "macbook"];
 
 export function isBuiltInMic(label: string): boolean {
   const lower = label.toLowerCase();
   return BUILTIN_KEYWORDS.some((kw) => lower.includes(kw));
+}
+
+/**
+ * Browsers expose a virtual "default" entry (deviceId === "default") whose
+ * label looks like "Default - <real device name>". The real device is also
+ * enumerated separately with its own deviceId (and matching groupId).
+ *
+ * Given a list of devices and the currently-selected deviceId, return the
+ * underlying real device. Falls back to the original device if no resolution
+ * is possible.
+ */
+export function resolveDefaultDevice(
+  devices: MediaDeviceInfo[],
+  deviceId: string,
+): MediaDeviceInfo | undefined {
+  const selected = devices.find((d) => d.deviceId === deviceId);
+  if (!selected) return undefined;
+  if (selected.deviceId !== "default") return selected;
+
+  // Try matching by groupId — the most reliable signal.
+  const byGroup = devices.find(
+    (d) => d.deviceId !== "default" && d.groupId && d.groupId === selected.groupId,
+  );
+  if (byGroup) return byGroup;
+
+  // Fallback: parse "Default - <name>" and match a device whose label ends
+  // with that name (Chrome wraps with "Default - ", Safari/Firefox vary).
+  const match = selected.label.match(/^Default\s*[-–—]\s*(.+)$/i);
+  if (match) {
+    const underlyingName = match[1].trim().toLowerCase();
+    const byLabel = devices.find(
+      (d) =>
+        d.deviceId !== "default" &&
+        d.label.toLowerCase().includes(underlyingName),
+    );
+    if (byLabel) return byLabel;
+  }
+
+  return selected;
+}
+
+/**
+ * Decide whether the currently-selected mic should trigger the built-in
+ * warning. Resolves OS-default to its underlying real device first so that
+ * "Default - <my Focusrite>" doesn't trip the heuristic.
+ */
+export function isSelectedMicBuiltIn(
+  devices: MediaDeviceInfo[],
+  deviceId: string,
+): boolean {
+  const resolved = resolveDefaultDevice(devices, deviceId);
+  if (!resolved) return false;
+  return isBuiltInMic(resolved.label);
 }

--- a/src/lib/devices.ts
+++ b/src/lib/devices.ts
@@ -37,12 +37,14 @@ export function resolveDefaultDevice(
   const match = selected.label.match(/^Default\s*[-–—]\s*(.+)$/i);
   if (match) {
     const underlyingName = match[1].trim().toLowerCase();
-    const byLabel = devices.find(
-      (d) =>
-        d.deviceId !== "default" &&
-        d.label.toLowerCase().includes(underlyingName),
-    );
-    if (byLabel) return byLabel;
+    if (underlyingName) {
+      const byLabel = devices.find(
+        (d) =>
+          d.deviceId !== "default" &&
+          d.label.toLowerCase().endsWith(underlyingName),
+      );
+      if (byLabel) return byLabel;
+    }
   }
 
   return selected;

--- a/tests/devices.test.ts
+++ b/tests/devices.test.ts
@@ -73,6 +73,16 @@ describe("resolveDefaultDevice", () => {
     const resolved = resolveDefaultDevice(devices, "default");
     expect(resolved?.deviceId).toBe("default");
   });
+
+  it("does not match an unrelated device when the parsed fallback label is empty", () => {
+    const devices = [
+      dev("default", "Default - ", ""),
+      dev("abc123", "Focusrite Scarlett 2i2", ""),
+      dev("xyz789", "MacBook Pro Microphone", ""),
+    ];
+    const resolved = resolveDefaultDevice(devices, "default");
+    expect(resolved?.deviceId).toBe("default");
+  });
 });
 
 describe("isSelectedMicBuiltIn", () => {

--- a/tests/devices.test.ts
+++ b/tests/devices.test.ts
@@ -1,0 +1,109 @@
+import { describe, expect, it } from "vitest";
+import {
+  isBuiltInMic,
+  isSelectedMicBuiltIn,
+  resolveDefaultDevice,
+} from "@/lib/devices";
+
+function dev(
+  deviceId: string,
+  label: string,
+  groupId = "",
+): MediaDeviceInfo {
+  return {
+    deviceId,
+    label,
+    groupId,
+    kind: "audioinput",
+    toJSON() {
+      return this;
+    },
+  } as MediaDeviceInfo;
+}
+
+describe("isBuiltInMic", () => {
+  it("matches built-in keywords", () => {
+    expect(isBuiltInMic("MacBook Pro Microphone")).toBe(true);
+    expect(isBuiltInMic("Built-in Audio")).toBe(true);
+    expect(isBuiltInMic("Internal Microphone")).toBe(true);
+  });
+
+  it("does not match the literal 'default' label any more", () => {
+    expect(isBuiltInMic("Default - Focusrite Scarlett 2i2")).toBe(false);
+    expect(isBuiltInMic("Default")).toBe(false);
+  });
+
+  it("does not match real interface labels", () => {
+    expect(isBuiltInMic("Focusrite Scarlett 2i2")).toBe(false);
+    expect(isBuiltInMic("Shure MV7")).toBe(false);
+  });
+});
+
+describe("resolveDefaultDevice", () => {
+  it("resolves 'default' to its underlying device by groupId", () => {
+    const devices = [
+      dev("default", "Default - Focusrite Scarlett 2i2", "g1"),
+      dev("abc123", "Focusrite Scarlett 2i2", "g1"),
+      dev("xyz789", "MacBook Pro Microphone", "g2"),
+    ];
+    const resolved = resolveDefaultDevice(devices, "default");
+    expect(resolved?.deviceId).toBe("abc123");
+  });
+
+  it("falls back to label parsing when groupIds don't match", () => {
+    const devices = [
+      dev("default", "Default - Focusrite Scarlett 2i2", ""),
+      dev("abc123", "Focusrite Scarlett 2i2", ""),
+    ];
+    const resolved = resolveDefaultDevice(devices, "default");
+    expect(resolved?.deviceId).toBe("abc123");
+  });
+
+  it("returns the device itself for non-default selections", () => {
+    const devices = [
+      dev("default", "Default - Focusrite Scarlett 2i2", "g1"),
+      dev("abc123", "Focusrite Scarlett 2i2", "g1"),
+    ];
+    const resolved = resolveDefaultDevice(devices, "abc123");
+    expect(resolved?.deviceId).toBe("abc123");
+  });
+
+  it("returns the default entry itself when nothing else matches", () => {
+    const devices = [dev("default", "Default", "")];
+    const resolved = resolveDefaultDevice(devices, "default");
+    expect(resolved?.deviceId).toBe("default");
+  });
+});
+
+describe("isSelectedMicBuiltIn", () => {
+  it("does NOT warn when default resolves to a real interface", () => {
+    const devices = [
+      dev("default", "Default - Focusrite Scarlett 2i2", "g1"),
+      dev("abc123", "Focusrite Scarlett 2i2", "g1"),
+      dev("xyz789", "MacBook Pro Microphone", "g2"),
+    ];
+    expect(isSelectedMicBuiltIn(devices, "default")).toBe(false);
+  });
+
+  it("warns when default resolves to the MacBook built-in mic", () => {
+    const devices = [
+      dev("default", "Default - MacBook Pro Microphone", "g2"),
+      dev("xyz789", "MacBook Pro Microphone", "g2"),
+    ];
+    expect(isSelectedMicBuiltIn(devices, "default")).toBe(true);
+  });
+
+  it("warns when the user explicitly picks the built-in mic", () => {
+    const devices = [
+      dev("default", "Default - Focusrite Scarlett 2i2", "g1"),
+      dev("abc123", "Focusrite Scarlett 2i2", "g1"),
+      dev("xyz789", "MacBook Pro Microphone", "g2"),
+    ];
+    expect(isSelectedMicBuiltIn(devices, "xyz789")).toBe(true);
+  });
+
+  it("does not warn for an unknown deviceId", () => {
+    const devices = [dev("abc123", "Focusrite Scarlett 2i2", "g1")];
+    expect(isSelectedMicBuiltIn(devices, "missing")).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

The built-in mic warning fires whenever the selected input is the browser's virtual `default` device — even when that default points at a real audio interface (Focusrite, Shure, etc.). Root cause: `isBuiltInMic` substring-matched the literal string `"default"` in device labels, so `"Default - Focusrite Scarlett 2i2"` was treated identically to `"MacBook Pro Microphone"`.

## Fix

- Add `resolveDefaultDevice(devices, deviceId)` in `src/lib/devices.ts`. When the selection is the `deviceId === "default"` entry, look up the underlying real device by `groupId`, falling back to parsing `"Default - <name>"` from the label.
- Add `isSelectedMicBuiltIn(devices, deviceId)` that resolves first, then applies the built-in keyword check.
- Drop `"default"` from `BUILTIN_KEYWORDS` so the literal "Default" label can no longer trigger the warning on its own.
- Update `src/app/studio/[id]/page.tsx` to call `isSelectedMicBuiltIn(mics, selectedMic)` at both the join-time check and the `selectedMicIsBuiltIn` prop.

The longer-term signal-quality mic check described in the issue is intentionally out of scope here — this PR just kills the false positive.

## Testing

- New `tests/devices.test.ts` (11 cases) covering:
  - `default → real interface` resolves correctly via `groupId` and via label parsing
  - selecting the OS default with a Focusrite as underlying device does **not** warn
  - selecting the OS default with the MacBook mic as underlying device **does** warn
  - explicitly selecting the built-in mic still warns
  - non-default selections, missing devices, edge cases
- `npm test -- tests/devices.test.ts` → 11/11 pass
- `npm run lint` → clean
- `npx tsc --noEmit` → clean

Manual macOS repro is recommended before merging: connect external interface, set as system default, join a session, confirm no warning. The logic is covered by the unit tests but the OS/browser interaction is what the original bug is about.

Closes #50