### PR TITLE
fix: durable upload safety and accurate progress (#49, #52)

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -69,6 +69,17 @@ button, a, [role="button"] {
   100% { transform: scale(1.55); opacity: 0;   }
 }
 
+/* Upload progress bar pulse (active upload) */
+.upload-bar-pulse {
+  animation: upload-pulse 1.6s ease-in-out infinite;
+}
+
+@keyframes upload-pulse {
+  0%   { opacity: 1;    }
+  50%  { opacity: 0.55; }
+  100% { opacity: 1;    }
+}
+
 /* Subtle film-grain overlay — pure CSS, no image assets */
 .grain::before {
   content: '';

--- a/src/app/studio/[id]/page.tsx
+++ b/src/app/studio/[id]/page.tsx
@@ -39,6 +39,8 @@ import {
   smoothLevel,
 } from "@/lib/audio-meter";
 import { FinishRecordingButton } from "@/components/FinishRecordingButton";
+import { useUploadProgress } from "@/hooks/useUploadProgress";
+import { UploadProgressBar } from "@/components/UploadProgressBar";
 
 import { Topbar } from "@/components/ui/Topbar";
 import { VUMeter, DbScale } from "@/components/ui/VUMeter";
@@ -486,7 +488,7 @@ function RoomContent({
   // so a transient peak still flashes instead of vanishing in one rAF.
   const localClipFramesRef = useRef(0);
   const localClipHoldRef = useRef(0);
-  const chunkUploadPromisesRef = useRef(new Set<Promise<void>>());
+  const uploadTracker = useUploadProgress();
 
   const [audioQualityMode, setAudioQualityMode] = useState<AudioQualityMode>("full");
   const [notification, setNotification] = useState<string | null>(null);
@@ -527,18 +529,6 @@ function RoomContent({
     [localParticipant],
   );
 
-  const trackChunkUpload = useCallback((uploadPromise: Promise<void>) => {
-    chunkUploadPromisesRef.current.add(uploadPromise);
-    uploadPromise.finally(() => {
-      chunkUploadPromisesRef.current.delete(uploadPromise);
-    });
-  }, []);
-
-  const waitForChunkUploads = useCallback(async () => {
-    while (chunkUploadPromisesRef.current.size > 0) {
-      await Promise.allSettled(Array.from(chunkUploadPromisesRef.current));
-    }
-  }, []);
 
   useEffect(() => {
     let cancelled = false;
@@ -736,19 +726,20 @@ function RoomContent({
         return;
       }
 
+      uploadTracker.reset();
+
       const recorder = new CozyRecorder(streamRef.current);
 
       recorder.onChunk((chunk, index) => {
+        const byteLength = chunk.size;
+        uploadTracker.onChunkRecorded(byteLength);
+
         const uploadPromise = (async () => {
-          try {
-            const url = await getPresignedUploadUrl(sessionId, trackId, index);
-            await uploadChunk(url, chunk);
-          } catch (err) {
-            console.error("Failed to upload chunk:", err);
-          }
+          const url = await getPresignedUploadUrl(sessionId, trackId, index);
+          await uploadChunk(url, chunk);
         })();
 
-        trackChunkUpload(uploadPromise);
+        void uploadTracker.trackUpload(byteLength, uploadPromise);
       });
 
       recorderRef.current = recorder;
@@ -781,7 +772,7 @@ function RoomContent({
       setStudioStateSync,
       showNotification,
       switchAudioQuality,
-      trackChunkUpload,
+      uploadTracker,
     ],
   );
 
@@ -805,9 +796,19 @@ function RoomContent({
       const blob = await recorder.stop();
       const durationMs = Date.now() - startedAt;
 
-      const url = await getPresignedUploadUrl(sessionId, trackId, 9999);
-      await uploadChunk(url, blob);
-      await waitForChunkUploads();
+      // Freeze denominator — recording is done, no more chunks will arrive.
+      uploadTracker.freezeRecorded();
+
+      // Track the final blob upload in the progress meter.
+      const finalBytes = blob.size;
+      uploadTracker.onChunkRecorded(finalBytes);
+      const finalUpload = (async () => {
+        const url = await getPresignedUploadUrl(sessionId, trackId, 9999);
+        await uploadChunk(url, blob);
+      })();
+      void uploadTracker.trackUpload(finalBytes, finalUpload);
+
+      await uploadTracker.waitForUploads();
       await completeUpload(sessionId, trackId, durationMs);
 
       setHasRecorded(true);
@@ -819,7 +820,7 @@ function RoomContent({
       // chunk-upload promise set is drained, regardless of error path. If the
       // happy path above already drained, this is effectively a no-op.
       try {
-        await waitForChunkUploads();
+        await uploadTracker.waitForUploads();
       } catch (drainErr) {
         console.error("Failed while draining chunk uploads:", drainErr);
       }
@@ -830,7 +831,7 @@ function RoomContent({
         console.error("Failed to restore audio quality:", err);
       });
     }
-  }, [sessionId, setStudioStateSync, switchAudioQuality, waitForChunkUploads]);
+  }, [sessionId, setStudioStateSync, switchAudioQuality, uploadTracker]);
 
   // Button handler: broadcast first so remote participants start close to our
   // own start time, then start locally. sessionStartedAt uses our local clock
@@ -883,6 +884,18 @@ function RoomContent({
     return unsub;
   }, [transport, startRecordingLocal, stopRecordingLocal, showNotification]);
 
+
+  // Warn before tab close when uploads are in flight or recording is active.
+  // This is the Layer A fix for #49 — prevents accidental data loss.
+  useEffect(() => {
+    if (!uploadTracker.hasInflight && studioState !== "recording") return;
+    const handler = (e: BeforeUnloadEvent) => {
+      e.preventDefault();
+      e.returnValue = "";
+    };
+    window.addEventListener("beforeunload", handler);
+    return () => window.removeEventListener("beforeunload", handler);
+  }, [uploadTracker.hasInflight, studioState]);
 
   useEffect(() => {
     return () => {
@@ -1028,7 +1041,7 @@ function RoomContent({
             <div className="flex justify-center mt-3">
               <FinishRecordingButton
                 sessionId={sessionId}
-                waitForUploads={waitForChunkUploads}
+                waitForUploads={uploadTracker.waitForUploads}
               />
             </div>
           )}
@@ -1115,23 +1128,10 @@ function RoomContent({
 
           <div className="w-10 h-px my-3" style={{ background: "var(--border)" }} />
 
-          {/* Upload indicator — real progress plumbing tracked in #27. */}
-          <div className="w-full px-3 flex flex-col gap-1.5 items-center mb-5">
-            <span className="font-mono text-[9px] text-text-3 tracking-[0.08em]">UPLOAD</span>
-            <div className="w-full h-0.5 rounded-[1px]" style={{ background: "var(--border)" }}>
-              <div
-                className="h-full rounded-[1px]"
-                style={{
-                  width: isUploading ? "30%" : "0%",
-                  background: "var(--amber)",
-                  transition: "width 600ms ease",
-                }}
-              />
-            </div>
-            <span className="font-mono text-[9px] text-text-3">
-              {isUploading ? "in flight" : "—"}
-            </span>
-          </div>
+          <UploadProgressBar
+            progress={uploadTracker.progress}
+            recordingStopped={studioState !== "recording"}
+          />
         </div>
       </div>
     </div>

--- a/src/app/studio/[id]/page.tsx
+++ b/src/app/studio/[id]/page.tsx
@@ -489,6 +489,17 @@ function RoomContent({
   const localClipFramesRef = useRef(0);
   const localClipHoldRef = useRef(0);
   const uploadTracker = useUploadProgress();
+  // Destructure stable callbacks so they can be listed individually in
+  // dependency arrays. `uploadTracker` itself is a fresh object each render,
+  // so depending on the whole tracker would recreate callbacks every render
+  // and force downstream effects to re-subscribe.
+  const {
+    onChunkRecorded: trackerOnChunkRecorded,
+    trackUpload: trackerTrackUpload,
+    freezeRecorded: trackerFreezeRecorded,
+    reset: trackerReset,
+    waitForUploads: trackerWaitForUploads,
+  } = uploadTracker;
 
   const [audioQualityMode, setAudioQualityMode] = useState<AudioQualityMode>("full");
   const [notification, setNotification] = useState<string | null>(null);
@@ -726,20 +737,20 @@ function RoomContent({
         return;
       }
 
-      uploadTracker.reset();
+      trackerReset();
 
       const recorder = new CozyRecorder(streamRef.current);
 
       recorder.onChunk((chunk, index) => {
         const byteLength = chunk.size;
-        uploadTracker.onChunkRecorded(byteLength);
+        trackerOnChunkRecorded(byteLength);
 
         const uploadPromise = (async () => {
           const url = await getPresignedUploadUrl(sessionId, trackId, index);
           await uploadChunk(url, chunk);
         })();
 
-        void uploadTracker.trackUpload(byteLength, uploadPromise);
+        void trackerTrackUpload(byteLength, uploadPromise);
       });
 
       recorderRef.current = recorder;
@@ -772,7 +783,9 @@ function RoomContent({
       setStudioStateSync,
       showNotification,
       switchAudioQuality,
-      uploadTracker,
+      trackerReset,
+      trackerOnChunkRecorded,
+      trackerTrackUpload,
     ],
   );
 
@@ -797,22 +810,29 @@ function RoomContent({
       const durationMs = Date.now() - startedAt;
 
       // Freeze denominator — recording is done, no more chunks will arrive.
-      uploadTracker.freezeRecorded();
+      trackerFreezeRecorded();
 
-      // Track the final blob upload in the progress meter.
+      // The final recording.webm upload is critical: if it fails, we must
+      // NOT call completeUpload (which marks the track complete and lets
+      // the server delete chunk files). Use rethrow so a failure surfaces
+      // here, lastError is set in the tracker (visible in the UI), and
+      // completeUpload is skipped.
       const finalBytes = blob.size;
-      uploadTracker.onChunkRecorded(finalBytes);
+      trackerOnChunkRecorded(finalBytes);
       const finalUpload = (async () => {
         const url = await getPresignedUploadUrl(sessionId, trackId, 9999);
         await uploadChunk(url, blob);
       })();
-      void uploadTracker.trackUpload(finalBytes, finalUpload);
+      await trackerTrackUpload(finalBytes, finalUpload, { rethrow: true });
 
-      await uploadTracker.waitForUploads();
+      // Wait for any background chunk uploads still settling.
+      await trackerWaitForUploads();
       await completeUpload(sessionId, trackId, durationMs);
 
       setHasRecorded(true);
     } catch (err) {
+      // Final upload (or stop()) failed. lastError is already populated by
+      // trackUpload's rethrow path; the recording stays incomplete.
       console.error("Failed to stop recording:", err);
     } finally {
       recorderRef.current = null;
@@ -820,7 +840,7 @@ function RoomContent({
       // chunk-upload promise set is drained, regardless of error path. If the
       // happy path above already drained, this is effectively a no-op.
       try {
-        await uploadTracker.waitForUploads();
+        await trackerWaitForUploads();
       } catch (drainErr) {
         console.error("Failed while draining chunk uploads:", drainErr);
       }
@@ -831,7 +851,15 @@ function RoomContent({
         console.error("Failed to restore audio quality:", err);
       });
     }
-  }, [sessionId, setStudioStateSync, switchAudioQuality, uploadTracker]);
+  }, [
+    sessionId,
+    setStudioStateSync,
+    switchAudioQuality,
+    trackerFreezeRecorded,
+    trackerOnChunkRecorded,
+    trackerTrackUpload,
+    trackerWaitForUploads,
+  ]);
 
   // Button handler: broadcast first so remote participants start close to our
   // own start time, then start locally. sessionStartedAt uses our local clock

--- a/src/components/UploadProgressBar.tsx
+++ b/src/components/UploadProgressBar.tsx
@@ -61,7 +61,9 @@ export function UploadProgressBar({
       >
         <div
           className={`h-full rounded-[2px] transition-[width] duration-500 ease-out${
-            phase === "uploading" ? " upload-bar-pulse" : ""
+            phase === "uploading" && progress.chunksInFlight > 0
+              ? " upload-bar-pulse"
+              : ""
           }`}
           style={{
             width: phase === "idle" ? "0%" : `${Math.max(pct, 2)}%`,

--- a/src/components/UploadProgressBar.tsx
+++ b/src/components/UploadProgressBar.tsx
@@ -1,0 +1,80 @@
+"use client";
+
+import type { UploadProgress } from "@/hooks/useUploadProgress";
+
+type UploadPhase = "idle" | "uploading" | "done" | "error";
+
+function getPhase(progress: UploadProgress, recordingStopped: boolean): UploadPhase {
+  if (progress.lastError) return "error";
+  if (progress.bytesRecorded === 0) return "idle";
+  if (recordingStopped && progress.fraction >= 1 && progress.chunksInFlight === 0)
+    return "done";
+  return "uploading";
+}
+
+export function UploadProgressBar({
+  progress,
+  recordingStopped,
+}: {
+  progress: UploadProgress;
+  recordingStopped: boolean;
+}) {
+  const phase = getPhase(progress, recordingStopped);
+  const pct = Math.round(progress.fraction * 100);
+
+  // Colors per phase.
+  const barColor: Record<UploadPhase, string> = {
+    idle: "var(--border)",
+    uploading: "var(--amber)",
+    done: "var(--ok)",
+    error: "var(--rec)",
+  };
+
+  const labelColor: Record<UploadPhase, string> = {
+    idle: "var(--text-3)",
+    uploading: "var(--amber)",
+    done: "var(--ok)",
+    error: "var(--rec)",
+  };
+
+  const label: Record<UploadPhase, string> = {
+    idle: "—",
+    uploading:
+      progress.chunksInFlight > 0
+        ? `${pct}% · ${progress.chunksInFlight} chunk${progress.chunksInFlight > 1 ? "s" : ""}`
+        : `${pct}%`,
+    done: "done",
+    error: progress.lastError ?? "error",
+  };
+
+  return (
+    <div className="w-full px-3 flex flex-col gap-1.5 items-center mb-5">
+      <span
+        className="font-mono text-[9px] tracking-[0.08em] font-medium"
+        style={{ color: labelColor[phase] }}
+      >
+        UPLOAD
+      </span>
+      <div
+        className="w-full h-1 rounded-[2px] overflow-hidden"
+        style={{ background: "var(--border)" }}
+      >
+        <div
+          className={`h-full rounded-[2px] transition-[width] duration-500 ease-out${
+            phase === "uploading" ? " upload-bar-pulse" : ""
+          }`}
+          style={{
+            width: phase === "idle" ? "0%" : `${Math.max(pct, 2)}%`,
+            background: barColor[phase],
+          }}
+        />
+      </div>
+      <span
+        className="font-mono text-[9px] truncate max-w-full"
+        style={{ color: labelColor[phase] }}
+      >
+        {label[phase]}
+      </span>
+    </div>
+  );
+}

--- a/src/hooks/useUploadProgress.ts
+++ b/src/hooks/useUploadProgress.ts
@@ -3,7 +3,7 @@
 import { useCallback, useRef, useState } from "react";
 
 export interface UploadProgress {
-  /** Total bytes from recorder chunks emitted so far. */
+  /** Total bytes enqueued for upload (recorder chunks + any final merged blobs). */
   bytesRecorded: number;
   /** Total bytes acknowledged by S3 (successful PUT responses). */
   bytesUploaded: number;
@@ -159,9 +159,10 @@ export function useUploadProgress(): UploadTracker {
   );
 
   const freezeRecorded = useCallback(() => {
-    // Denominator is already whatever recorded.current is — just flush to
-    // ensure state is in sync. After this, no more onChunkRecorded calls
-    // should arrive, so the denominator freezes naturally.
+    // Flushes current recorded-byte counters into React state so progress UI
+    // is accurate at the moment of call. Subsequent `onChunkRecorded` calls
+    // (e.g. for the final merged blob) are still permitted and will continue
+    // to grow the denominator.
     flush();
   }, [flush]);
 

--- a/src/hooks/useUploadProgress.ts
+++ b/src/hooks/useUploadProgress.ts
@@ -1,0 +1,155 @@
+"use client";
+
+import { useCallback, useRef, useState } from "react";
+
+export interface UploadProgress {
+  /** Total bytes from recorder chunks emitted so far. */
+  bytesRecorded: number;
+  /** Total bytes acknowledged by S3 (successful PUT responses). */
+  bytesUploaded: number;
+  /** Number of chunk uploads currently in flight. */
+  chunksInFlight: number;
+  /** Last upload error, if any. Cleared on next successful upload. */
+  lastError: string | null;
+  /** Whether the upload pipeline has any work remaining. */
+  hasInflight: boolean;
+  /** Fraction 0..1 of upload completion. 0 when nothing recorded. */
+  fraction: number;
+}
+
+export interface UploadTracker {
+  /** Current snapshot of upload progress. */
+  progress: UploadProgress;
+  /** Call when recorder emits a new chunk (before upload starts). */
+  onChunkRecorded: (byteLength: number) => void;
+  /** Wrap a chunk upload promise so it tracks bytes and in-flight count. */
+  trackUpload: (byteLength: number, uploadPromise: Promise<void>) => Promise<void>;
+  /** Freeze the denominator — call when recording stops. */
+  freezeRecorded: () => void;
+  /** Reset all counters for a new recording session. */
+  reset: () => void;
+  /** Wait until all in-flight uploads complete. */
+  waitForUploads: () => Promise<void>;
+  /** Whether uploads are pending (for beforeunload). */
+  hasInflight: boolean;
+}
+
+export function useUploadProgress(): UploadTracker {
+  const [progress, setProgress] = useState<UploadProgress>({
+    bytesRecorded: 0,
+    bytesUploaded: 0,
+    chunksInFlight: 0,
+    lastError: null,
+    hasInflight: false,
+    fraction: 0,
+  });
+
+  // Mutable counters for synchronous access (avoid stale closure issues).
+  const recorded = useRef(0);
+  const uploaded = useRef(0);
+  const inFlight = useRef(0);
+  const inflightPromises = useRef(new Set<Promise<void>>());
+
+  const flush = useCallback(() => {
+    const rec = recorded.current;
+    const up = uploaded.current;
+    const inf = inFlight.current;
+    const fraction = rec > 0 ? Math.min(1, up / rec) : 0;
+    setProgress((prev) => {
+      // Only update if something changed to avoid unnecessary re-renders.
+      if (
+        prev.bytesRecorded === rec &&
+        prev.bytesUploaded === up &&
+        prev.chunksInFlight === inf &&
+        prev.fraction === fraction &&
+        prev.hasInflight === (inf > 0)
+      ) {
+        return prev;
+      }
+      return {
+        bytesRecorded: rec,
+        bytesUploaded: up,
+        chunksInFlight: inf,
+        lastError: prev.lastError,
+        hasInflight: inf > 0,
+        fraction,
+      };
+    });
+  }, []);
+
+  const onChunkRecorded = useCallback(
+    (byteLength: number) => {
+      recorded.current += byteLength;
+      flush();
+    },
+    [flush],
+  );
+
+  const trackUpload = useCallback(
+    (byteLength: number, uploadPromise: Promise<void>): Promise<void> => {
+      inFlight.current += 1;
+      flush();
+
+      const tracked = uploadPromise
+        .then(() => {
+          uploaded.current += byteLength;
+          // Clear last error on success.
+          setProgress((prev) =>
+            prev.lastError !== null ? { ...prev, lastError: null } : prev,
+          );
+        })
+        .catch((err: unknown) => {
+          const message =
+            err instanceof Error ? err.message : "Upload failed";
+          setProgress((prev) => ({ ...prev, lastError: message }));
+        })
+        .finally(() => {
+          inFlight.current -= 1;
+          inflightPromises.current.delete(tracked);
+          flush();
+        });
+
+      inflightPromises.current.add(tracked);
+      return tracked;
+    },
+    [flush],
+  );
+
+  const freezeRecorded = useCallback(() => {
+    // Denominator is already whatever recorded.current is — just flush to
+    // ensure state is in sync. After this, no more onChunkRecorded calls
+    // should arrive, so the denominator freezes naturally.
+    flush();
+  }, [flush]);
+
+  const reset = useCallback(() => {
+    recorded.current = 0;
+    uploaded.current = 0;
+    inFlight.current = 0;
+    inflightPromises.current.clear();
+    setProgress({
+      bytesRecorded: 0,
+      bytesUploaded: 0,
+      chunksInFlight: 0,
+      lastError: null,
+      hasInflight: false,
+      fraction: 0,
+    });
+  }, []);
+
+  const waitForUploads = useCallback(async () => {
+    while (inflightPromises.current.size > 0) {
+      await Promise.allSettled(Array.from(inflightPromises.current));
+    }
+  }, []);
+
+  return {
+    progress,
+    onChunkRecorded,
+    trackUpload,
+    freezeRecorded,
+    reset,
+    waitForUploads,
+    hasInflight: progress.hasInflight,
+  };
+}

--- a/src/hooks/useUploadProgress.ts
+++ b/src/hooks/useUploadProgress.ts
@@ -17,13 +17,27 @@ export interface UploadProgress {
   fraction: number;
 }
 
+export interface TrackUploadOptions {
+  /**
+   * If true, rethrow the upload error after recording it in `lastError`.
+   * Use for critical uploads (e.g. final recording.webm) where the caller
+   * needs to abort follow-up actions on failure. Defaults to false so
+   * background chunk uploads don't produce unhandled rejections.
+   */
+  rethrow?: boolean;
+}
+
 export interface UploadTracker {
   /** Current snapshot of upload progress. */
   progress: UploadProgress;
   /** Call when recorder emits a new chunk (before upload starts). */
   onChunkRecorded: (byteLength: number) => void;
   /** Wrap a chunk upload promise so it tracks bytes and in-flight count. */
-  trackUpload: (byteLength: number, uploadPromise: Promise<void>) => Promise<void>;
+  trackUpload: (
+    byteLength: number,
+    uploadPromise: Promise<void>,
+    options?: TrackUploadOptions,
+  ) => Promise<void>;
   /** Freeze the denominator — call when recording stops. */
   freezeRecorded: () => void;
   /** Reset all counters for a new recording session. */
@@ -86,22 +100,36 @@ export function useUploadProgress(): UploadTracker {
   );
 
   const trackUpload = useCallback(
-    (byteLength: number, uploadPromise: Promise<void>): Promise<void> => {
+    (
+      byteLength: number,
+      uploadPromise: Promise<void>,
+      options?: TrackUploadOptions,
+    ): Promise<void> => {
+      const rethrow = options?.rethrow ?? false;
       inFlight.current += 1;
       flush();
 
-      const tracked = uploadPromise
-        .then(() => {
-          uploaded.current += byteLength;
-          // Clear last error on success.
-          setProgress((prev) =>
-            prev.lastError !== null ? { ...prev, lastError: null } : prev,
-          );
-        })
-        .catch((err: unknown) => {
-          const message =
-            err instanceof Error ? err.message : "Upload failed";
-          setProgress((prev) => ({ ...prev, lastError: message }));
+      // Build a tracker promise that always settles successfully so it can
+      // live in `inflightPromises` without producing unhandled rejections —
+      // independent of whether we rethrow to the caller.
+      const settled: Promise<{ ok: true } | { ok: false; err: unknown }> =
+        uploadPromise.then(
+          () => ({ ok: true as const }),
+          (err: unknown) => ({ ok: false as const, err }),
+        );
+
+      const tracked: Promise<void> = settled
+        .then((result) => {
+          if (result.ok) {
+            uploaded.current += byteLength;
+            setProgress((prev) =>
+              prev.lastError !== null ? { ...prev, lastError: null } : prev,
+            );
+          } else {
+            const message =
+              result.err instanceof Error ? result.err.message : "Upload failed";
+            setProgress((prev) => ({ ...prev, lastError: message }));
+          }
         })
         .finally(() => {
           inFlight.current -= 1;
@@ -110,6 +138,21 @@ export function useUploadProgress(): UploadTracker {
         });
 
       inflightPromises.current.add(tracked);
+
+      if (rethrow) {
+        // Caller wants to abort on failure. Wait for tracking bookkeeping to
+        // finish (so `lastError` is set and counters are decremented) before
+        // surfacing the original error.
+        return tracked.then(async () => {
+          const result = await settled;
+          if (!result.ok) {
+            throw result.err instanceof Error
+              ? result.err
+              : new Error("Upload failed");
+          }
+        });
+      }
+
       return tracked;
     },
     [flush],
@@ -123,6 +166,17 @@ export function useUploadProgress(): UploadTracker {
   }, [flush]);
 
   const reset = useCallback(() => {
+    // Defensive: clearing inflightPromises while uploads are still running
+    // would let those promises' .finally drive counters negative when they
+    // settle. Callers must waitForUploads() (or otherwise reach an idle
+    // state) before resetting. The finalizing-state invariant guarantees
+    // this in practice — this guard catches programming mistakes.
+    if (inFlight.current > 0) {
+      console.warn(
+        `useUploadProgress.reset() called with ${inFlight.current} uploads still in flight; ignoring.`,
+      );
+      return;
+    }
     recorded.current = 0;
     uploaded.current = 0;
     inFlight.current = 0;


### PR DESCRIPTION
## Summary

- **beforeunload warning** (#49 Layer A): Browser shows "changes may not be saved" dialog when the user tries to close the tab while uploads are in flight or recording is active. Prevents accidental data loss.
- **Real upload progress indicator** (#52): Replaced the placeholder 30%-stuck progress bar with a byte-level progress meter. Tracks `bytesUploaded / bytesRecorded` across all chunks with distinct visual states: idle, uploading (animated pulse), done (green), error (red).
- **Shared state surface**: New `useUploadProgress` hook provides a single source of truth (`bytesRecorded`, `bytesUploaded`, `chunksInFlight`, `lastError`, `fraction`) consumed by both the progress bar and the beforeunload guard.

### How the progress bar works

- During recording: denominator (`bytesRecorded`) grows as chunks are emitted every 5s; numerator (`bytesUploaded`) grows as S3 acknowledges each PUT. Bar fills smoothly.
- After stop: denominator freezes (includes final blob). Bar drains to 100% as remaining chunks finish uploading.
- Error state: if any chunk upload fails, the bar turns red and shows the error. Clears on next successful upload.

### Layer B (server-side recovery) — deferred

The upload architecture uses **separate S3 objects per chunk** (not multipart upload parts). A server-side stitching job is feasible but out of scope for this PR. Filed as #56 with design notes.

Closes #49
Closes #52

## Test plan

- [ ] Start recording with host + cohost, verify progress bar fills smoothly during recording
- [ ] Stop recording — progress bar should drain to 100% as final chunks upload, then show green "done"
- [ ] During upload, try to close tab — browser should show "changes may not be saved" warning
- [ ] After upload completes and "done" shows, tab should close without warning
- [ ] Throttle network in DevTools to Slow 3G — verify progress bar reflects slow upload accurately
- [ ] Kill network mid-upload — verify error state (red bar) appears
- [ ] Verify Vercel preview build is green

🤖 Generated with [Claude Code](https://claude.com/claude-code)