### PR TITLE
feat: remote audio level meters via getStats (#47)

### DIFF
--- a/src/app/studio/[id]/page.tsx
+++ b/src/app/studio/[id]/page.tsx
@@ -32,6 +32,12 @@ import {
 } from "@/components/MicMonitorToggle";
 import { useMicMonitor } from "@/hooks/useMicMonitor";
 import { useRemoteAudioLevels } from "@/hooks/useRemoteAudioLevels";
+import {
+  CLIP_MIN_FRAMES,
+  CLIP_THRESHOLD,
+  SHAPING_EXPONENT,
+  smoothLevel,
+} from "@/lib/audio-meter";
 import { FinishRecordingButton } from "@/components/FinishRecordingButton";
 
 import { Topbar } from "@/components/ui/Topbar";
@@ -582,26 +588,27 @@ function RoomContent({
 
       const rms = Math.sqrt(sumSquares / dataArray.length);
       const normalized = Math.min(1, Math.max(0, (rms - 0.01) / 0.12));
-      const targetLevel = Math.round(Math.pow(normalized, 0.6) * 255);
+      const targetLevel = Math.round(Math.pow(normalized, SHAPING_EXPONENT) * 255);
       const smoothedLevel = Math.round(
-        localLevelRef.current * 0.7 + targetLevel * 0.3
+        smoothLevel(localLevelRef.current, targetLevel)
       );
       localLevelRef.current = smoothedLevel;
 
-      // Clipping flag: peak >= -1 dBFS for 2+ consecutive frames, then hold
-      // the visible flag briefly so a single transient peak still registers.
-      // 0.891 ≈ 10^(-1/20).
-      if (peak >= 0.891) {
+      // Clipping flag: peak >= -1 dBFS for CLIP_MIN_FRAMES consecutive frames,
+      // then hold the visible flag briefly so a single transient peak still
+      // registers. The hold count here is in RAF frames (~60Hz), giving ~500ms.
+      if (peak >= CLIP_THRESHOLD) {
         localClipFramesRef.current += 1;
-        if (localClipFramesRef.current >= 2) {
+        if (localClipFramesRef.current >= CLIP_MIN_FRAMES) {
           localClipHoldRef.current = 30;
         }
       } else {
         localClipFramesRef.current = 0;
       }
-      const wasClipping = localClipHoldRef.current > 0;
-      if (wasClipping) localClipHoldRef.current -= 1;
+      // Compute visibility from the CURRENT hold first, then decrement, so a
+      // hold of N yields N visible frames (not N-1).
       const isClipping = localClipHoldRef.current > 0;
+      if (isClipping) localClipHoldRef.current -= 1;
       // Avoid setState every frame when nothing changed.
       setLocalClipping((prev) => (prev === isClipping ? prev : isClipping));
 

--- a/src/app/studio/[id]/page.tsx
+++ b/src/app/studio/[id]/page.tsx
@@ -17,7 +17,6 @@ import {
   RoomAudioRenderer,
   useRemoteParticipants,
   useLocalParticipant,
-  useSpeakingParticipants,
 } from "@livekit/components-react";
 import { v4 as uuidv4 } from "uuid";
 import { CozyRecorder } from "@/lib/recorder";
@@ -32,6 +31,7 @@ import {
   getStoredMonitorVolume,
 } from "@/components/MicMonitorToggle";
 import { useMicMonitor } from "@/hooks/useMicMonitor";
+import { useRemoteAudioLevels } from "@/hooks/useRemoteAudioLevels";
 import { FinishRecordingButton } from "@/components/FinishRecordingButton";
 
 import { Topbar } from "@/components/ui/Topbar";
@@ -80,6 +80,7 @@ interface ParticipantStripProps {
   isBuiltIn: boolean;
   level: number; // 0..255
   status: Status;
+  clipping?: boolean;
 }
 
 function ParticipantStrip({
@@ -89,6 +90,7 @@ function ParticipantStrip({
   isBuiltIn,
   level,
   status,
+  clipping = false,
 }: ParticipantStripProps) {
   const normalized = Math.max(0, Math.min(1, level / 255));
   return (
@@ -96,7 +98,9 @@ function ParticipantStrip({
       className="rounded-lg px-4 py-3.5 border flex flex-col gap-2.5"
       style={{
         background: "var(--card)",
-        borderColor: "var(--border)",
+        borderColor: clipping ? "var(--rec)" : "var(--border)",
+        boxShadow: clipping ? "0 0 0 1px var(--rec), 0 0 12px rgba(232,80,80,0.45)" : undefined,
+        transition: "border-color 80ms ease, box-shadow 80ms ease",
       }}
     >
       <div className="flex items-center gap-2.5">
@@ -134,6 +138,21 @@ function ParticipantStrip({
                 className="inline-flex"
               >
                 <IcoAlert size={11} color="var(--warn)" />
+              </span>
+            )}
+            {clipping && (
+              <span
+                title="Audio is clipping — ask the talker to back off the mic or lower input gain"
+                aria-label="Audio is clipping"
+                className="inline-flex items-center font-mono text-[10px] font-semibold px-1.5 py-0.5 rounded-[4px]"
+                style={{
+                  background: "rgba(232,80,80,0.16)",
+                  color: "var(--rec)",
+                  border: "1px solid rgba(232,80,80,0.3)",
+                  letterSpacing: "0.04em",
+                }}
+              >
+                CLIP
               </span>
             )}
           </div>
@@ -401,7 +420,6 @@ function RoomContent({
   isHost: boolean;
 }) {
   const remoteParticipants = useRemoteParticipants();
-  const speakingParticipants = useSpeakingParticipants();
   const { localParticipant } = useLocalParticipant();
   const transport = useTransport();
   const recorderRef = useRef<CozyRecorder | null>(null);
@@ -433,10 +451,15 @@ function RoomContent({
   useMicMonitor({ stream: recordingStream, enabled: monitorEnabled, volume: monitorVolume });
 
   const [audioLevels, setAudioLevels] = useState<Map<string, number>>(new Map());
+  const [localClipping, setLocalClipping] = useState(false);
   const analyserRef = useRef<AnalyserNode | null>(null);
   const animFrameRef = useRef<number>(0);
   const recordingStartRef = useRef<number>(0);
   const localLevelRef = useRef(0);
+  // Tracks consecutive clip frames + remaining hold ticks for the local meter,
+  // so a transient peak still flashes instead of vanishing in one rAF.
+  const localClipFramesRef = useRef(0);
+  const localClipHoldRef = useRef(0);
   const chunkUploadPromisesRef = useRef(new Set<Promise<void>>());
 
   const [audioQualityMode, setAudioQualityMode] = useState<AudioQualityMode>("full");
@@ -549,9 +572,12 @@ function RoomContent({
       analyserRef.current.getByteTimeDomainData(dataArray);
 
       let sumSquares = 0;
+      let peak = 0;
       for (const value of dataArray) {
         const centeredSample = (value - 128) / 128;
         sumSquares += centeredSample * centeredSample;
+        const abs = Math.abs(centeredSample);
+        if (abs > peak) peak = abs;
       }
 
       const rms = Math.sqrt(sumSquares / dataArray.length);
@@ -561,6 +587,23 @@ function RoomContent({
         localLevelRef.current * 0.7 + targetLevel * 0.3
       );
       localLevelRef.current = smoothedLevel;
+
+      // Clipping flag: peak >= -1 dBFS for 2+ consecutive frames, then hold
+      // the visible flag briefly so a single transient peak still registers.
+      // 0.891 ≈ 10^(-1/20).
+      if (peak >= 0.891) {
+        localClipFramesRef.current += 1;
+        if (localClipFramesRef.current >= 2) {
+          localClipHoldRef.current = 30;
+        }
+      } else {
+        localClipFramesRef.current = 0;
+      }
+      const wasClipping = localClipHoldRef.current > 0;
+      if (wasClipping) localClipHoldRef.current -= 1;
+      const isClipping = localClipHoldRef.current > 0;
+      // Avoid setState every frame when nothing changed.
+      setLocalClipping((prev) => (prev === isClipping ? prev : isClipping));
 
       setAudioLevels((prev) => {
         const next = new Map(prev);
@@ -579,19 +622,28 @@ function RoomContent({
     };
   }, [participantName, recordingStream]);
 
-  // Track remote audio levels via the speaking-participants hook
+  // Track remote audio levels via getStats() polling on each remote audio
+  // track's RTCRtpReceiver. Replaces the prior `useSpeakingParticipants`
+  // approach, which only emitted while the LiveKit voice-activity heuristic
+  // flagged a participant as "speaking" — fine for grid highlights but useless
+  // for level monitoring (silent talkers + no clipping signal). See #47.
+  const remoteAudio = useRemoteAudioLevels(remoteParticipants);
+  // Merge remote levels into the same audioLevels map the local meter feeds.
   useEffect(() => {
     setAudioLevels((prev) => {
       const next = new Map(prev);
-      for (const s of speakingParticipants) {
-        next.set(
-          s.identity ?? "unknown",
-          Math.round((s.audioLevel ?? 0) * 255),
-        );
+      // Wipe any identities that vanished so stale bars don't linger.
+      for (const id of next.keys()) {
+        if (id !== participantName && !remoteAudio.levels.has(id)) {
+          next.delete(id);
+        }
+      }
+      for (const [id, lvl] of remoteAudio.levels) {
+        next.set(id, lvl);
       }
       return next;
     });
-  }, [speakingParticipants]);
+  }, [remoteAudio.levels, participantName]);
 
   // Tick the elapsed-time display while recording
   useEffect(() => {
@@ -858,6 +910,7 @@ function RoomContent({
             isBuiltIn={selectedMicIsBuiltIn}
             level={audioLevels.get(participantName) ?? 0}
             status={localStatus}
+            clipping={localClipping}
           />
 
           {remoteParticipants.map((p) => (
@@ -873,6 +926,7 @@ function RoomContent({
               // the host hit record). Remote per-participant status is tracked
               // in #30; until then we show a stable "connected" for remotes.
               status="connected"
+              clipping={remoteAudio.clipping.has(p.identity)}
             />
           ))}
 

--- a/src/hooks/useRemoteAudioLevels.ts
+++ b/src/hooks/useRemoteAudioLevels.ts
@@ -11,13 +11,15 @@
 
 import { useEffect, useRef, useState } from "react";
 import type { RemoteParticipant } from "livekit-client";
+import {
+  CLIP_MIN_FRAMES,
+  CLIP_THRESHOLD,
+  shapeLevel,
+  smoothLevel,
+} from "@/lib/audio-meter";
 
 const POLL_INTERVAL_MS = 100; // ~10 Hz, per the issue.
 
-// "Clipping" here means the receiver-side audioLevel is essentially full-scale.
-// `audioLevel` from inbound-rtp is normalized 0..1; -1 dBFS ≈ 0.891.
-const CLIP_THRESHOLD = 0.891;
-const CLIP_MIN_FRAMES = 2;
 // How many polls we hold the clip indicator after it stops triggering, so a
 // single transient peak still flashes visibly (~400ms at 10Hz).
 const CLIP_HOLD_FRAMES = 4;
@@ -90,6 +92,11 @@ export function useRemoteAudioLevels(
             if (typeof audioLevel === "number") break;
           }
 
+          // Bail out before any ref mutation if the effect was cleaned up
+          // mid-poll (e.g. participants prop changed). Otherwise this stale
+          // poll would race with the new effect's loop on the same refs.
+          if (cancelled) return;
+
           if (typeof audioLevel !== "number") {
             // No fresh stat — fade existing smoothed value toward zero so the
             // meter doesn't appear stuck if a participant goes silent.
@@ -97,11 +104,18 @@ export function useRemoteAudioLevels(
             const decayed = Math.max(0, prev * 0.85);
             smoothedRef.current.set(identity, decayed);
             nextLevels.set(identity, Math.round(decayed));
-            // Drain any clip-hold counter without retriggering.
-            const hold = (clipHoldFramesRef.current.get(identity) ?? 0) - 1;
+            // Drain any clip-hold counter without retriggering. Mirror the
+            // main path: check > 0 first, THEN decrement, so the final held
+            // frame still flashes even when stats happen to be missing.
+            const hold = clipHoldFramesRef.current.get(identity) ?? 0;
             if (hold > 0) {
-              clipHoldFramesRef.current.set(identity, hold);
               nextClipping.add(identity);
+              const remaining = hold - 1;
+              if (remaining > 0) {
+                clipHoldFramesRef.current.set(identity, remaining);
+              } else {
+                clipHoldFramesRef.current.delete(identity);
+              }
             } else {
               clipHoldFramesRef.current.delete(identity);
             }
@@ -109,12 +123,10 @@ export function useRemoteAudioLevels(
             return;
           }
 
-          // Match the local meter's perceptual curve so both look identical:
-          // raise to ~0.6 (compander) then scale to 0..255 like the host side.
-          const shaped = Math.pow(Math.max(0, Math.min(1, audioLevel)), 0.6);
-          const target = shaped * 255;
+          // Match the local meter's perceptual curve so both look identical.
+          const target = shapeLevel(audioLevel);
           const prev = smoothedRef.current.get(identity) ?? 0;
-          const smoothed = prev * 0.7 + target * 0.3;
+          const smoothed = smoothLevel(prev, target);
           smoothedRef.current.set(identity, smoothed);
           nextLevels.set(identity, Math.round(smoothed));
 

--- a/src/hooks/useRemoteAudioLevels.ts
+++ b/src/hooks/useRemoteAudioLevels.ts
@@ -1,0 +1,200 @@
+"use client";
+
+// Polls each remote participant's subscribed audio track for inbound-rtp
+// level stats and exposes a per-identity level (0..255) plus a clipping flag.
+//
+// This is the Option A fix from issue #47: audio levels here are POST-network
+// (decoded receiver side, after the jitter buffer and any browser gain), not
+// the co-host's true pre-network signal. It's the pragmatic version that
+// works on existing clients without any data-channel coordination. Option B
+// (each client publishes its own pre-network level) is tracked separately.
+
+import { useEffect, useRef, useState } from "react";
+import type { RemoteParticipant } from "livekit-client";
+
+const POLL_INTERVAL_MS = 100; // ~10 Hz, per the issue.
+
+// "Clipping" here means the receiver-side audioLevel is essentially full-scale.
+// `audioLevel` from inbound-rtp is normalized 0..1; -1 dBFS ≈ 0.891.
+const CLIP_THRESHOLD = 0.891;
+const CLIP_MIN_FRAMES = 2;
+// How many polls we hold the clip indicator after it stops triggering, so a
+// single transient peak still flashes visibly (~400ms at 10Hz).
+const CLIP_HOLD_FRAMES = 4;
+
+interface RemoteLevels {
+  /** Level in [0, 255], matched to the local meter's scale. */
+  levels: Map<string, number>;
+  /** Identities currently flagged as clipping. */
+  clipping: Set<string>;
+}
+
+/**
+ * Returns the live audio level (0..255) and clipping flag for each remote
+ * participant. Reads from `RTCRtpReceiver.getStats()` via the LiveKit
+ * RemoteTrack's `getRTCStatsReport()` ~10 times per second.
+ */
+export function useRemoteAudioLevels(
+  participants: ReadonlyArray<RemoteParticipant>,
+): RemoteLevels {
+  const [state, setState] = useState<RemoteLevels>(() => ({
+    levels: new Map(),
+    clipping: new Set(),
+  }));
+
+  // Per-identity rolling state used between polls. Lives in a ref so the
+  // poll loop doesn't churn React state on every tick.
+  const consecutiveClipFramesRef = useRef<Map<string, number>>(new Map());
+  const clipHoldFramesRef = useRef<Map<string, number>>(new Map());
+  const smoothedRef = useRef<Map<string, number>>(new Map());
+
+  useEffect(() => {
+    let cancelled = false;
+    let timer: ReturnType<typeof setTimeout> | null = null;
+
+    async function pollOnce() {
+      const nextLevels = new Map<string, number>();
+      const nextClipping = new Set<string>();
+
+      // Snapshot the participants so a disconnect mid-poll doesn't blow up.
+      const snapshot = participants.slice();
+
+      await Promise.all(
+        snapshot.map(async (participant) => {
+          const identity = participant.identity;
+          if (!identity) return;
+
+          // Use the first subscribed audio publication. CozyTrack publishes
+          // a single mic track per participant, so this is unambiguous.
+          let audioLevel: number | undefined;
+          for (const pub of participant.audioTrackPublications.values()) {
+            const track = pub.track;
+            if (!track) continue;
+            try {
+              const report = await track.getRTCStatsReport();
+              if (!report) continue;
+              report.forEach((entry) => {
+                if (
+                  entry.type === "inbound-rtp" &&
+                  (entry as { kind?: string }).kind === "audio"
+                ) {
+                  const lvl = (entry as { audioLevel?: number }).audioLevel;
+                  if (typeof lvl === "number" && Number.isFinite(lvl)) {
+                    audioLevel = lvl;
+                  }
+                }
+              });
+            } catch {
+              // getStats can throw if the receiver is mid-teardown; ignore.
+            }
+            if (typeof audioLevel === "number") break;
+          }
+
+          if (typeof audioLevel !== "number") {
+            // No fresh stat — fade existing smoothed value toward zero so the
+            // meter doesn't appear stuck if a participant goes silent.
+            const prev = smoothedRef.current.get(identity) ?? 0;
+            const decayed = Math.max(0, prev * 0.85);
+            smoothedRef.current.set(identity, decayed);
+            nextLevels.set(identity, Math.round(decayed));
+            // Drain any clip-hold counter without retriggering.
+            const hold = (clipHoldFramesRef.current.get(identity) ?? 0) - 1;
+            if (hold > 0) {
+              clipHoldFramesRef.current.set(identity, hold);
+              nextClipping.add(identity);
+            } else {
+              clipHoldFramesRef.current.delete(identity);
+            }
+            consecutiveClipFramesRef.current.delete(identity);
+            return;
+          }
+
+          // Match the local meter's perceptual curve so both look identical:
+          // raise to ~0.6 (compander) then scale to 0..255 like the host side.
+          const shaped = Math.pow(Math.max(0, Math.min(1, audioLevel)), 0.6);
+          const target = shaped * 255;
+          const prev = smoothedRef.current.get(identity) ?? 0;
+          const smoothed = prev * 0.7 + target * 0.3;
+          smoothedRef.current.set(identity, smoothed);
+          nextLevels.set(identity, Math.round(smoothed));
+
+          // Clipping: count consecutive frames at/over threshold; latch the
+          // visible flag for a few extra frames so single peaks register.
+          if (audioLevel >= CLIP_THRESHOLD) {
+            const n =
+              (consecutiveClipFramesRef.current.get(identity) ?? 0) + 1;
+            consecutiveClipFramesRef.current.set(identity, n);
+            if (n >= CLIP_MIN_FRAMES) {
+              clipHoldFramesRef.current.set(identity, CLIP_HOLD_FRAMES);
+            }
+          } else {
+            consecutiveClipFramesRef.current.set(identity, 0);
+          }
+
+          const hold = clipHoldFramesRef.current.get(identity) ?? 0;
+          if (hold > 0) {
+            nextClipping.add(identity);
+            clipHoldFramesRef.current.set(identity, hold - 1);
+          }
+        }),
+      );
+
+      if (cancelled) return;
+
+      // Drop entries for participants that have left.
+      const liveIdentities = new Set(snapshot.map((p) => p.identity));
+      for (const id of smoothedRef.current.keys()) {
+        if (!liveIdentities.has(id)) {
+          smoothedRef.current.delete(id);
+          consecutiveClipFramesRef.current.delete(id);
+          clipHoldFramesRef.current.delete(id);
+        }
+      }
+
+      setState((prev) => {
+        // Skip the React update if nothing changed — the poll fires 10x/sec
+        // and most ticks for a quiet talker produce identical integer values.
+        if (
+          mapsEqual(prev.levels, nextLevels) &&
+          setsEqual(prev.clipping, nextClipping)
+        ) {
+          return prev;
+        }
+        return { levels: nextLevels, clipping: nextClipping };
+      });
+    }
+
+    function loop() {
+      if (cancelled) return;
+      void pollOnce().finally(() => {
+        if (cancelled) return;
+        timer = setTimeout(loop, POLL_INTERVAL_MS);
+      });
+    }
+
+    loop();
+
+    return () => {
+      cancelled = true;
+      if (timer) clearTimeout(timer);
+    };
+  }, [participants]);
+
+  return state;
+}
+
+function mapsEqual(a: Map<string, number>, b: Map<string, number>): boolean {
+  if (a.size !== b.size) return false;
+  for (const [k, v] of a) {
+    if (b.get(k) !== v) return false;
+  }
+  return true;
+}
+
+function setsEqual(a: Set<string>, b: Set<string>): boolean {
+  if (a.size !== b.size) return false;
+  for (const k of a) {
+    if (!b.has(k)) return false;
+  }
+  return true;
+}

--- a/src/lib/audio-meter.ts
+++ b/src/lib/audio-meter.ts
@@ -1,0 +1,35 @@
+// Shared constants and helpers for the audio level meters.
+//
+// The local meter (Web Audio analyser, ~60Hz RAF) and the remote meter
+// (RTCPeerConnection getStats(), ~10Hz polling) need to look identical to
+// the eye, so they share the perceptual shaping curve, smoothing weights,
+// and clip-detection thresholds defined here. Polling-rate-dependent values
+// (e.g. how many frames to hold the clip indicator) stay at the call site.
+
+/** Receiver-side audioLevel threshold for "clipping". -1 dBFS ≈ 10^(-1/20). */
+export const CLIP_THRESHOLD = 0.891;
+
+/** Consecutive frames at/over the threshold required to latch the clip flag. */
+export const CLIP_MIN_FRAMES = 2;
+
+/** Compander exponent applied before scaling to 0..255. */
+export const SHAPING_EXPONENT = 0.6;
+
+/** Exponential smoothing weights: smoothed = prev * PREV + target * TARGET. */
+export const SMOOTHING_PREV_WEIGHT = 0.7;
+export const SMOOTHING_TARGET_WEIGHT = 0.3;
+
+/**
+ * Map a raw 0..1 level to the shared 0..255 meter scale (compander curve).
+ */
+export function shapeLevel(audioLevel: number): number {
+  const clamped = Math.max(0, Math.min(1, audioLevel));
+  return Math.pow(clamped, SHAPING_EXPONENT) * 255;
+}
+
+/**
+ * Apply the shared exponential smoothing step.
+ */
+export function smoothLevel(prev: number, target: number): number {
+  return prev * SMOOTHING_PREV_WEIGHT + target * SMOOTHING_TARGET_WEIGHT;
+}


### PR DESCRIPTION
## Summary

Adds per-remote-participant level monitoring so the host can see what every participant in the room is doing in real time — and, critically, see when a co-host's mic is **clipping**. Refs #47.

This is **Option A** from the issue: poll `RTCRtpReceiver.getStats()` for the `inbound-rtp` audio entry on each remote track and read `audioLevel`. Receiver-side, post-network — but it works on existing clients today and surfaces the clipping cue that's been missing.

`#47` stays open: a follow-up issue will be filed for **Option B** (each client publishes its own *pre-network* level over the LiveKit data channel) which is the long-term correctness fix.

### Changes

- New hook `src/hooks/useRemoteAudioLevels.ts` — polls each remote audio track's `getRTCStatsReport()` at 10Hz, smooths to match the local meter's perceptual curve (`pow(x, 0.6)` on a 0..255 scale), and tracks per-identity clipping with a small hold so transient peaks still flash.
- `ParticipantStrip` gains a `clipping?: boolean` prop. Active state shows a red border + glow on the strip and a `CLIP` pill next to the participant's name.
- The local meter now also sets `clipping` from the time-domain peak (`peak ≥ -1 dBFS` ≈ `0.891` linear, 2+ consecutive frames). Both meters look identical and have parity on the clip indicator.
- Replaces `useSpeakingParticipants` for level monitoring — that hook only emits during voice-activity windows and was useless for hot-but-not-yet-shouting talkers + had no clipping signal.

### What didn't change

- Capture settings stay as-is: `echoCancellation: false, noiseSuppression: false, autoGainControl: false`.
- Local meter (Web Audio AnalyserNode) is preserved exactly. The meter is still pre-network for the host.
- No changes to recording, upload, transport, or signaling.

### Why Option A and not B in this PR

Option A is a single-client change that ships immediately and works for any peer (even one running an older client). Option B requires every participant to publish their own level over the data channel, which is a larger coordinated change and deserves its own PR. The follow-up issue will document the plug-points (transport `sendControlMessage` for the publish side; new subscription topic on the receive side) so it's a clean handoff.

## Testing

- [x] Typecheck passes for the touched files (other repo-wide TS errors are pre-existing and unrelated to this change).
- [x] ESLint clean on `src/hooks/useRemoteAudioLevels.ts` and `src/app/studio/[id]/page.tsx`.
- [ ] Manual: open studio with two participants; remote meter responds proportionally to remote talker's level; CLIP flashes red when remote intentionally clips.
- [ ] Manual: local meter still flashes CLIP when host clips locally (parity).
- [ ] Manual: participant disconnect tears down polling cleanly (no console spam).
- [ ] Vercel preview build green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)