### PR TITLE
fix: force mono recording when mono is requested (#46)

### DIFF
--- a/src/app/studio/[id]/page.tsx
+++ b/src/app/studio/[id]/page.tsx
@@ -572,9 +572,19 @@ function RoomContent({
         }
 
         // Tear down any prior stream/downmix before installing the new one.
+        // Both raw and mono streams must be stopped: AudioContext.close() does
+        // not reliably end the destination track on every browser, so the
+        // previous mono MediaStreamTrack can otherwise outlive the switch.
+        // The guard prevents a double-stop in the fallback path where
+        // forceMonoStream failed and monoStream === rawStream.
+        const previousRawStream = rawStreamRef.current;
+        const previousStream = streamRef.current;
         downmixDisposeRef.current?.();
         downmixDisposeRef.current = null;
-        rawStreamRef.current?.getTracks().forEach((track) => track.stop());
+        previousRawStream?.getTracks().forEach((track) => track.stop());
+        if (previousStream && previousStream !== previousRawStream) {
+          previousStream.getTracks().forEach((track) => track.stop());
+        }
 
         // Force the recording stream to a single channel even when the
         // browser hands back a 2-channel track despite our `channelCount: 1`
@@ -615,9 +625,17 @@ function RoomContent({
 
     return () => {
       cancelled = true;
+      // Mirror the on-switch teardown: stop both raw and mono tracks. The
+      // guard avoids a double-stop in the fallback path where
+      // forceMonoStream failed and streamRef === rawStreamRef.
+      const previousRawStream = rawStreamRef.current;
+      const previousStream = streamRef.current;
       downmixDisposeRef.current?.();
       downmixDisposeRef.current = null;
-      rawStreamRef.current?.getTracks().forEach((track) => track.stop());
+      previousRawStream?.getTracks().forEach((track) => track.stop());
+      if (previousStream && previousStream !== previousRawStream) {
+        previousStream.getTracks().forEach((track) => track.stop());
+      }
       rawStreamRef.current = null;
       streamRef.current = null;
       setRecordingStream(null);
@@ -973,11 +991,15 @@ function RoomContent({
     return () => {
       downmixDisposeRef.current?.();
       downmixDisposeRef.current = null;
-      if (rawStreamRef.current) {
-        rawStreamRef.current.getTracks().forEach((t) => t.stop());
+      const rawStream = rawStreamRef.current;
+      const monoStream = streamRef.current;
+      if (rawStream) {
+        rawStream.getTracks().forEach((t) => t.stop());
       }
-      if (streamRef.current) {
-        streamRef.current.getTracks().forEach((t) => t.stop());
+      // Guard against double-stopping when the fallback path made
+      // monoStream === rawStream.
+      if (monoStream && monoStream !== rawStream) {
+        monoStream.getTracks().forEach((t) => t.stop());
       }
     };
   }, []);

--- a/src/app/studio/[id]/page.tsx
+++ b/src/app/studio/[id]/page.tsx
@@ -20,6 +20,7 @@ import {
 } from "@livekit/components-react";
 import { v4 as uuidv4 } from "uuid";
 import { CozyRecorder } from "@/lib/recorder";
+import { forceMonoStream, getTrackChannelCount } from "@/lib/audio-downmix";
 import { getPresignedUploadUrl, uploadChunk, completeUpload } from "@/lib/upload";
 import { getToken, LIVEKIT_URL } from "@/lib/livekit";
 import { useTransport } from "@/lib/transport";
@@ -452,7 +453,15 @@ function RoomContent({
   const transport = useTransport();
   const recorderRef = useRef<CozyRecorder | null>(null);
   const trackIdRef = useRef<string>("");
+  // Raw stream straight from getUserMedia — retained so we can stop the
+  // underlying device tracks on teardown.
+  const rawStreamRef = useRef<MediaStream | null>(null);
+  // Mono-forced stream (post-downmix) — what the recorder, level meter, and
+  // sidetone monitor actually consume. See `forceMonoStream` in
+  // `@/lib/audio-downmix` for why we always downmix instead of trusting
+  // `getUserMedia` constraints.
   const streamRef = useRef<MediaStream | null>(null);
+  const downmixDisposeRef = useRef<(() => void) | null>(null);
   const [recordingStream, setRecordingStream] = useState<MediaStream | null>(null);
   // Mirror of studioState so callbacks invoked from transport subscriptions
   // (which close over the value at subscription time) can check current state
@@ -546,7 +555,7 @@ function RoomContent({
 
     async function getRecordingStream() {
       try {
-        const stream = await navigator.mediaDevices.getUserMedia({
+        const rawStream = await navigator.mediaDevices.getUserMedia({
           audio: {
             deviceId: selectedMic ? { exact: selectedMic } : undefined,
             echoCancellation: false,
@@ -558,13 +567,45 @@ function RoomContent({
         });
 
         if (cancelled) {
-          stream.getTracks().forEach((track) => track.stop());
+          rawStream.getTracks().forEach((track) => track.stop());
           return;
         }
 
-        streamRef.current?.getTracks().forEach((track) => track.stop());
-        streamRef.current = stream;
-        setRecordingStream(stream);
+        // Tear down any prior stream/downmix before installing the new one.
+        downmixDisposeRef.current?.();
+        downmixDisposeRef.current = null;
+        rawStreamRef.current?.getTracks().forEach((track) => track.stop());
+
+        // Force the recording stream to a single channel even when the
+        // browser hands back a 2-channel track despite our `channelCount: 1`
+        // constraint (issue #46). Logs a warning when we observe the mismatch
+        // so we can spot affected devices in the field.
+        const [rawTrack] = rawStream.getAudioTracks();
+        const reportedChannels = rawTrack ? getTrackChannelCount(rawTrack) : undefined;
+        if (reportedChannels !== undefined && reportedChannels > 1) {
+          console.warn(
+            `Recording: device returned ${reportedChannels}-channel track despite mono request; downmixing to mono.`,
+          );
+        }
+
+        let monoStream: MediaStream;
+        let dispose: (() => void) | null = null;
+        try {
+          const result = forceMonoStream(rawStream);
+          monoStream = result.stream;
+          dispose = result.dispose;
+        } catch (err) {
+          // Web Audio unavailable — fall back to the raw stream. The
+          // recorder will still encode whatever the device returned, but at
+          // least the rest of the UI keeps working.
+          console.error("Recording: forceMonoStream failed; using raw stream.", err);
+          monoStream = rawStream;
+        }
+
+        rawStreamRef.current = rawStream;
+        streamRef.current = monoStream;
+        downmixDisposeRef.current = dispose;
+        setRecordingStream(monoStream);
       } catch (err) {
         console.error("Failed to get recording stream:", err);
       }
@@ -574,7 +615,10 @@ function RoomContent({
 
     return () => {
       cancelled = true;
-      streamRef.current?.getTracks().forEach((track) => track.stop());
+      downmixDisposeRef.current?.();
+      downmixDisposeRef.current = null;
+      rawStreamRef.current?.getTracks().forEach((track) => track.stop());
+      rawStreamRef.current = null;
       streamRef.current = null;
       setRecordingStream(null);
     };
@@ -927,6 +971,11 @@ function RoomContent({
 
   useEffect(() => {
     return () => {
+      downmixDisposeRef.current?.();
+      downmixDisposeRef.current = null;
+      if (rawStreamRef.current) {
+        rawStreamRef.current.getTracks().forEach((t) => t.stop());
+      }
       if (streamRef.current) {
         streamRef.current.getTracks().forEach((t) => t.stop());
       }

--- a/src/lib/audio-downmix.ts
+++ b/src/lib/audio-downmix.ts
@@ -75,7 +75,23 @@ export function forceMonoStream(
       } catch {
         // Already disconnected — ignore.
       }
-      void ctx.close();
+      // Stop the synthetic destination track so callers that drop their
+      // reference don't leak a live MediaStreamTrack waiting for `ended`.
+      // AudioContext.close() alone does not reliably end the track on every
+      // browser.
+      for (const track of destination.stream.getTracks()) {
+        try {
+          track.stop();
+        } catch {
+          // Already stopped or unavailable — ignore.
+        }
+      }
+      // close() can reject on already-closed/suspended contexts or browser
+      // quirks. Swallow so dispose stays best-effort and silent — an
+      // unhandled rejection here would surface in app-level error logging.
+      void ctx.close().catch(() => {
+        // Ignore close failures.
+      });
     },
   };
 }

--- a/src/lib/audio-downmix.ts
+++ b/src/lib/audio-downmix.ts
@@ -1,0 +1,92 @@
+"use client";
+
+// Force the encoder to see a true single-channel input regardless of what
+// the device actually delivered.
+//
+// `getUserMedia({ audio: { channelCount: 1 } })` is advisory under the W3C
+// spec: many devices (built-in mic on some macOS Chromes, AirPods, certain
+// USB mics) hand back a 2-channel track even when mono was requested. The
+// browser then pads the second channel with silence, the recorder dutifully
+// encodes both channels, and the resulting WebM is stereo with a silent
+// right channel. See issue #46.
+//
+// We can't trust `track.getSettings().channelCount` either — Chrome has
+// shipped versions that report 1 while the actual track produced 2 channels.
+// The robust fix is to downmix in JS via Web Audio: a GainNode with
+// channelCount=1, channelCountMode='explicit', channelInterpretation='speakers'
+// performs the standard L/R-average downmix; the destination node is then
+// configured to expose a single channel on its output stream.
+//
+// The returned stream's audio track replaces the original for recording. The
+// caller is responsible for keeping the original live (Web Audio holds a
+// reference) and calling `dispose()` once recording stops.
+
+export type AudioContextCtor = new (options?: AudioContextOptions) => AudioContext;
+
+export type ForceMonoResult = {
+  stream: MediaStream;
+  dispose: () => void;
+};
+
+export function forceMonoStream(
+  source: MediaStream,
+  AudioCtxCtor?: AudioContextCtor,
+): ForceMonoResult {
+  const Ctor =
+    AudioCtxCtor ??
+    (typeof window !== "undefined"
+      ? (window.AudioContext ??
+        (window as unknown as { webkitAudioContext?: AudioContextCtor })
+          .webkitAudioContext)
+      : undefined);
+
+  if (!Ctor) {
+    throw new Error("forceMonoStream: no AudioContext available");
+  }
+
+  const ctx = new Ctor();
+  const sourceNode = ctx.createMediaStreamSource(source);
+  // GainNode acts as the explicit downmix: channelCount=1 +
+  // channelCountMode='explicit' forces the standard L/R average mix.
+  const downmix = ctx.createGain();
+  downmix.channelCount = 1;
+  downmix.channelCountMode = "explicit";
+  downmix.channelInterpretation = "speakers";
+  // Destination must also be 1-channel so the resulting MediaStreamTrack is
+  // emitted as a mono track (not a stereo track with a duplicated channel).
+  const destination = new MediaStreamAudioDestinationNode(ctx, { channelCount: 1 });
+
+  sourceNode.connect(downmix);
+  downmix.connect(destination);
+
+  let disposed = false;
+  return {
+    stream: destination.stream,
+    dispose: () => {
+      if (disposed) return;
+      disposed = true;
+      try {
+        sourceNode.disconnect();
+      } catch {
+        // Already disconnected — ignore.
+      }
+      try {
+        downmix.disconnect();
+      } catch {
+        // Already disconnected — ignore.
+      }
+      void ctx.close();
+    },
+  };
+}
+
+// Lightweight, side-effect-free helper used by callers that want to log or
+// telemetry-trace whether a track came back stereo despite mono being
+// requested. Browser implementations are inconsistent — treat the return
+// value as advisory; the actual recording path should always go through
+// `forceMonoStream` regardless.
+export function getTrackChannelCount(track: MediaStreamTrack): number | undefined {
+  if (typeof track.getSettings !== "function") return undefined;
+  const settings = track.getSettings() as MediaTrackSettings & { channelCount?: number };
+  return settings.channelCount;
+}

--- a/tests/audio-downmix.test.ts
+++ b/tests/audio-downmix.test.ts
@@ -1,0 +1,182 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { forceMonoStream, getTrackChannelCount } from "@/lib/audio-downmix";
+
+// Minimal Web Audio mocks: we only need to verify that forceMonoStream
+// configures the graph for an explicit 1-channel downmix and exposes the
+// destination's stream. A real AudioContext can't run in the node test
+// environment.
+
+type MockNode = {
+  connect: ReturnType<typeof vi.fn>;
+  disconnect: ReturnType<typeof vi.fn>;
+  channelCount: number;
+  channelCountMode: ChannelCountMode;
+  channelInterpretation: ChannelInterpretation;
+};
+
+function makeNode(): MockNode {
+  return {
+    connect: vi.fn(),
+    disconnect: vi.fn(),
+    channelCount: 2,
+    channelCountMode: "max",
+    channelInterpretation: "speakers",
+  };
+}
+
+class MockMediaStream {
+  // Just a tag so identity comparisons work.
+  readonly _kind = "stream" as const;
+}
+
+class MockDestinationNode {
+  channelCount: number;
+  stream = new MockMediaStream() as unknown as MediaStream;
+  connect = vi.fn();
+  disconnect = vi.fn();
+  channelCountMode: ChannelCountMode = "explicit";
+  channelInterpretation: ChannelInterpretation = "speakers";
+
+  constructor(_ctx: unknown, opts?: { channelCount?: number }) {
+    this.channelCount = opts?.channelCount ?? 2;
+  }
+}
+
+function makeMockAudioContextCtor() {
+  const sourceNode = makeNode();
+  const gainNode = makeNode();
+  const destinationCalls: Array<{ args: unknown[]; instance: MockDestinationNode }> = [];
+
+  // Real class so `new ...()` works; spy via a wrapper that records the call.
+  function DestinationCtorImpl(this: MockDestinationNode, ctx: unknown, opts?: { channelCount?: number }) {
+    const inst = new MockDestinationNode(ctx, opts);
+    destinationCalls.push({ args: [ctx, opts], instance: inst });
+    return inst;
+  }
+  // Make it usable as a constructor with `new`.
+  const DestinationCtor = DestinationCtorImpl as unknown as new (
+    ctx: unknown,
+    opts?: { channelCount?: number },
+  ) => MockDestinationNode;
+
+  class MockAudioContext {
+    closed = false;
+    createMediaStreamSource = vi.fn().mockReturnValue(sourceNode);
+    createGain = vi.fn().mockReturnValue(gainNode);
+    close = vi.fn().mockImplementation(() => {
+      this.closed = true;
+      return Promise.resolve();
+    });
+  }
+
+  return {
+    Ctor: MockAudioContext as unknown as typeof AudioContext,
+    sourceNode,
+    gainNode,
+    DestinationCtor,
+    destinationCalls,
+  };
+}
+
+describe("forceMonoStream", () => {
+  let originalDestinationCtor: unknown;
+  let captured: ReturnType<typeof makeMockAudioContextCtor>;
+
+  beforeEach(() => {
+    captured = makeMockAudioContextCtor();
+    // forceMonoStream uses `new MediaStreamAudioDestinationNode(ctx, ...)`
+    // — patch the global so the mock constructor receives the call.
+    originalDestinationCtor = (
+      globalThis as { MediaStreamAudioDestinationNode?: unknown }
+    ).MediaStreamAudioDestinationNode;
+    (
+      globalThis as { MediaStreamAudioDestinationNode: unknown }
+    ).MediaStreamAudioDestinationNode = captured.DestinationCtor;
+  });
+
+  afterEach(() => {
+    (
+      globalThis as { MediaStreamAudioDestinationNode?: unknown }
+    ).MediaStreamAudioDestinationNode = originalDestinationCtor;
+  });
+
+  it("forces the gain node into single-channel explicit downmix mode", () => {
+    const fakeStream = {} as MediaStream;
+    forceMonoStream(fakeStream, captured.Ctor);
+
+    expect(captured.gainNode.channelCount).toBe(1);
+    expect(captured.gainNode.channelCountMode).toBe("explicit");
+    expect(captured.gainNode.channelInterpretation).toBe("speakers");
+  });
+
+  it("creates a 1-channel destination so the output track is mono", () => {
+    const fakeStream = {} as MediaStream;
+    forceMonoStream(fakeStream, captured.Ctor);
+
+    expect(captured.destinationCalls).toHaveLength(1);
+    expect(captured.destinationCalls[0].args[1]).toEqual({ channelCount: 1 });
+    expect(captured.destinationCalls[0].instance.channelCount).toBe(1);
+  });
+
+  it("connects source -> gain -> destination", () => {
+    const fakeStream = {} as MediaStream;
+    forceMonoStream(fakeStream, captured.Ctor);
+
+    expect(captured.sourceNode.connect).toHaveBeenCalledTimes(1);
+    expect(captured.sourceNode.connect.mock.calls[0][0]).toBe(captured.gainNode);
+    expect(captured.gainNode.connect).toHaveBeenCalledTimes(1);
+    // destination instance is the single argument captured by gainNode.connect.
+    const destArg = captured.gainNode.connect.mock.calls[0][0];
+    expect(destArg).toBeDefined();
+  });
+
+  it("returned stream comes from the destination node", () => {
+    const fakeStream = {} as MediaStream;
+    const { stream } = forceMonoStream(fakeStream, captured.Ctor);
+    // The mock destination assigned a sentinel MockMediaStream — the same
+    // instance must be what forceMonoStream surfaced to the caller.
+    expect((stream as unknown as { _kind?: string })._kind).toBe("stream");
+  });
+
+  it("dispose() disconnects nodes and closes the context exactly once", () => {
+    const fakeStream = {} as MediaStream;
+    const { dispose } = forceMonoStream(fakeStream, captured.Ctor);
+
+    dispose();
+    expect(captured.sourceNode.disconnect).toHaveBeenCalledTimes(1);
+    expect(captured.gainNode.disconnect).toHaveBeenCalledTimes(1);
+
+    // Idempotent — a second call must not double-close.
+    dispose();
+    expect(captured.sourceNode.disconnect).toHaveBeenCalledTimes(1);
+    expect(captured.gainNode.disconnect).toHaveBeenCalledTimes(1);
+  });
+
+  it("throws when no AudioContext is available", () => {
+    const fakeStream = {} as MediaStream;
+    expect(() => forceMonoStream(fakeStream, undefined)).toThrowError(
+      /no AudioContext/,
+    );
+  });
+});
+
+describe("getTrackChannelCount", () => {
+  it("returns the reported channelCount when getSettings exposes one", () => {
+    const track = {
+      getSettings: () => ({ channelCount: 2 }),
+    } as unknown as MediaStreamTrack;
+    expect(getTrackChannelCount(track)).toBe(2);
+  });
+
+  it("returns undefined when getSettings is missing", () => {
+    const track = {} as MediaStreamTrack;
+    expect(getTrackChannelCount(track)).toBeUndefined();
+  });
+
+  it("returns undefined when channelCount is not in settings", () => {
+    const track = {
+      getSettings: () => ({}),
+    } as unknown as MediaStreamTrack;
+    expect(getTrackChannelCount(track)).toBeUndefined();
+  });
+});

--- a/tests/audio-downmix.test.ts
+++ b/tests/audio-downmix.test.ts
@@ -27,6 +27,11 @@ function makeNode(): MockNode {
 class MockMediaStream {
   // Just a tag so identity comparisons work.
   readonly _kind = "stream" as const;
+  // Default implementation — individual tests may overwrite this to inject
+  // spy tracks.
+  getTracks(): MediaStreamTrack[] {
+    return [];
+  }
 }
 
 class MockDestinationNode {
@@ -42,10 +47,18 @@ class MockDestinationNode {
   }
 }
 
+type MockAudioCtxInstance = {
+  closed: boolean;
+  createMediaStreamSource: ReturnType<typeof vi.fn>;
+  createGain: ReturnType<typeof vi.fn>;
+  close: ReturnType<typeof vi.fn>;
+};
+
 function makeMockAudioContextCtor() {
   const sourceNode = makeNode();
   const gainNode = makeNode();
   const destinationCalls: Array<{ args: unknown[]; instance: MockDestinationNode }> = [];
+  const audioContextInstances: MockAudioCtxInstance[] = [];
 
   // Real class so `new ...()` works; spy via a wrapper that records the call.
   function DestinationCtorImpl(this: MockDestinationNode, ctx: unknown, opts?: { channelCount?: number }) {
@@ -67,6 +80,9 @@ function makeMockAudioContextCtor() {
       this.closed = true;
       return Promise.resolve();
     });
+    constructor() {
+      audioContextInstances.push(this as MockAudioCtxInstance);
+    }
   }
 
   return {
@@ -75,6 +91,7 @@ function makeMockAudioContextCtor() {
     gainNode,
     DestinationCtor,
     destinationCalls,
+    audioContextInstances,
   };
 }
 
@@ -125,9 +142,12 @@ describe("forceMonoStream", () => {
     expect(captured.sourceNode.connect).toHaveBeenCalledTimes(1);
     expect(captured.sourceNode.connect.mock.calls[0][0]).toBe(captured.gainNode);
     expect(captured.gainNode.connect).toHaveBeenCalledTimes(1);
-    // destination instance is the single argument captured by gainNode.connect.
-    const destArg = captured.gainNode.connect.mock.calls[0][0];
-    expect(destArg).toBeDefined();
+    // gain must connect to the actual destination instance — asserting the
+    // arg is merely defined would let mis-wirings (e.g. gain -> source -> dest)
+    // slip through.
+    expect(captured.gainNode.connect.mock.calls[0][0]).toBe(
+      captured.destinationCalls[0].instance,
+    );
   });
 
   it("returned stream comes from the destination node", () => {
@@ -141,15 +161,60 @@ describe("forceMonoStream", () => {
   it("dispose() disconnects nodes and closes the context exactly once", () => {
     const fakeStream = {} as MediaStream;
     const { dispose } = forceMonoStream(fakeStream, captured.Ctor);
+    const audioCtx = captured.audioContextInstances[0];
 
     dispose();
     expect(captured.sourceNode.disconnect).toHaveBeenCalledTimes(1);
     expect(captured.gainNode.disconnect).toHaveBeenCalledTimes(1);
+    expect(audioCtx.close).toHaveBeenCalledTimes(1);
 
     // Idempotent — a second call must not double-close.
     dispose();
     expect(captured.sourceNode.disconnect).toHaveBeenCalledTimes(1);
     expect(captured.gainNode.disconnect).toHaveBeenCalledTimes(1);
+    expect(audioCtx.close).toHaveBeenCalledTimes(1);
+  });
+
+  it("dispose() stops the synthetic destination stream tracks", () => {
+    const fakeStream = {} as MediaStream;
+    const stopSpy = vi.fn();
+    const fakeTrack = { stop: stopSpy } as unknown as MediaStreamTrack;
+
+    const { dispose } = forceMonoStream(fakeStream, captured.Ctor);
+    // Surface a stoppable track on the destination's MediaStream. dispose()
+    // hasn't been called yet, so patching now is safe — the closure reads
+    // destination.stream.getTracks() lazily inside dispose.
+    const destInstance = captured.destinationCalls[0].instance;
+    (destInstance.stream as unknown as { getTracks: () => MediaStreamTrack[] })
+      .getTracks = () => [fakeTrack];
+
+    dispose();
+    expect(stopSpy).toHaveBeenCalledTimes(1);
+
+    // Idempotent — calling dispose again must not re-stop.
+    dispose();
+    expect(stopSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it("dispose() swallows rejections from ctx.close()", async () => {
+    const fakeStream = {} as MediaStream;
+    // Override Ctor so close() rejects.
+    class RejectingCtx {
+      closed = false;
+      createMediaStreamSource = vi.fn().mockReturnValue(captured.sourceNode);
+      createGain = vi.fn().mockReturnValue(captured.gainNode);
+      close = vi.fn().mockRejectedValue(new Error("already closed"));
+    }
+    const { dispose } = forceMonoStream(
+      fakeStream,
+      RejectingCtx as unknown as typeof AudioContext,
+    );
+
+    // If dispose did not catch, this would log an unhandled rejection.
+    expect(() => dispose()).not.toThrow();
+    // Flush microtasks so the rejected promise settles before the test ends.
+    await Promise.resolve();
+    await Promise.resolve();
   });
 
   it("throws when no AudioContext is available", () => {


### PR DESCRIPTION
## Summary

Closes #46.

`getUserMedia({ audio: { channelCount: 1 } })` is advisory in the W3C spec — many browser/device combos (Chrome on macOS built-in mic, AirPods, some USB mics) hand back a 2-channel track with the right channel padded to silence anyway. `MediaRecorder` then dutifully encodes both channels, yielding stereo WebM files with a silent right channel: ~2× file size and a misleading signal for any downstream tooling that treats a silent channel as broken.

`track.getSettings().channelCount` is also unreliable across browser versions, so this PR doesn't try to detect-and-skip — it always downmixes via Web Audio:

```
MediaStreamAudioSourceNode
  → GainNode (channelCount=1, channelCountMode='explicit', channelInterpretation='speakers')
  → MediaStreamAudioDestinationNode (channelCount=1)
```

The destination node's `MediaStream` (with one mono track) is what feeds `CozyRecorder`, the local meter, and the sidetone monitor. The raw `getUserMedia` stream is held separately and torn down on cleanup.

The fix is scoped to the recording path only — LiveKit publish/preview is untouched, and the prejoin meter still runs against the raw stream (it isn't recorded).

A `console.warn` fires when `track.getSettings().channelCount` reports >1 despite mono being requested, so the affected device population is visible in production telemetry.

## What changed

- `src/lib/audio-downmix.ts` (new) — `forceMonoStream(stream, AudioContextCtor?)` and `getTrackChannelCount(track)`. Exposes a `dispose()` callback to release the audio graph and close the `AudioContext`.
- `src/app/studio/[id]/page.tsx` — recording-stream effect now wraps the raw stream with `forceMonoStream` before exposing it as `recordingStream`. Adds `rawStreamRef` + `downmixDisposeRef` so device tracks are stopped and the audio graph is closed on every teardown path (selectedMic change, component unmount).
- `tests/audio-downmix.test.ts` (new) — 9 unit tests covering channel-count config, graph wiring, `dispose()` idempotency, missing-AudioContext error path, and `getTrackChannelCount` fallbacks.

## Why no test for "real mono input through MediaRecorder"

`vitest` runs in `node` here — there's no `AudioContext`, `MediaRecorder`, or `getUserMedia`. The deterministic invariant we *can* test is the audio graph configuration, which is the actual fix. Behavior in real browsers will need a manual verification (see Test plan).

## Test plan

- [x] `npm test` — 6 files, 45 tests pass (9 new in `tests/audio-downmix.test.ts`)
- [x] `npm run lint` — clean
- [x] `npx tsc --noEmit` — clean
- [ ] Manual: record on macOS Chrome with built-in mic, run `ffprobe` on resulting `.webm` — confirm `channels=1`
- [ ] Manual: record on macOS Chrome with a real stereo USB interface configured for stereo — confirm output is also mono (intentional, since the constraint requested mono); separate ticket if we want a stereo opt-in.

## Notes for reviewers

- I considered branching on `getTrackChannelCount` (only downmix when reported > 1), but Chrome has shipped versions where `getSettings().channelCount === 1` while the actual track still produced 2 channels. Always-downmix is the only robust answer; the cost is a single GainNode in the graph.
- Issue comments and Copilot-style review comments on this issue: none observed at the time of writing (`gh api repos/pashafateev/cozytrack/issues/46/comments` returned empty).