### PR TITLE
Warn mobile studio users

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -17,6 +17,7 @@
   --rec:      #e85050;
   --border:    rgba(255,240,210,0.07);
   --border-hi: rgba(255,240,210,0.13);
+  --topbar-height: 52px;
 }
 
 html, body {

--- a/src/app/studio/[id]/page.tsx
+++ b/src/app/studio/[id]/page.tsx
@@ -41,6 +41,7 @@ import {
   IcoLink,
   IcoMic,
   IcoPlus,
+  IcoX,
 } from "@/components/ui/Icon";
 
 // ---------- Types ----------
@@ -68,6 +69,48 @@ function formatElapsed(totalMs: number): string {
   const m = Math.floor((totalSec % 3600) / 60).toString().padStart(2, "0");
   const s = (totalSec % 60).toString().padStart(2, "0");
   return `${h}:${m}:${s}`;
+}
+
+function isMobileBrowser(navigatorInfo: Navigator): boolean {
+  const ua = navigatorInfo.userAgent;
+  const looksLikeModernIpad =
+    navigatorInfo.platform === "MacIntel" && navigatorInfo.maxTouchPoints > 1;
+
+  return /iPhone|iPad|iPod|Android/i.test(ua) || looksLikeModernIpad;
+}
+
+function MobileBrowserWarningBanner({
+  onDismiss,
+}: {
+  onDismiss: () => void;
+}) {
+  return (
+    <div
+      className="sticky top-[52px] z-40 flex items-start gap-3 px-5 py-3 border-b"
+      style={{
+        background: "rgba(232,168,48,0.09)",
+        borderBottomColor: "rgba(232,168,48,0.22)",
+      }}
+    >
+      <span className="mt-0.5 flex-shrink-0">
+        <IcoAlert size={15} color="var(--warn)" />
+      </span>
+      <p className="flex-1 text-[12px] leading-5 text-warn">
+        <span className="font-semibold">Mobile browser detected.</span>{" "}
+        Audio quality may be reduced and recording may fail if you switch apps
+        or your screen locks. For best results, join from a laptop or desktop
+        browser.
+      </p>
+      <button
+        type="button"
+        onClick={onDismiss}
+        aria-label="Dismiss mobile browser warning"
+        className="mt-0.5 flex h-6 w-6 flex-shrink-0 items-center justify-center rounded-[4px] text-warn/70 hover:bg-warn/10 hover:text-warn"
+      >
+        <IcoX size={14} color="currentColor" />
+      </button>
+    </div>
+  );
 }
 
 // ---------- Participant Strip ----------
@@ -772,10 +815,16 @@ export default function StudioPage() {
   const [connecting, setConnecting] = useState(false);
   const [monitorEnabled, setMonitorEnabled] = useState(false);
   const [monitorVolume, setMonitorVolume] = useState(70);
+  const [isMobile, setIsMobile] = useState(false);
+  const [mobileWarningDismissed, setMobileWarningDismissed] = useState(false);
 
   useEffect(() => {
     setMonitorEnabled(getStoredMonitorEnabled());
     setMonitorVolume(getStoredMonitorVolume());
+  }, []);
+
+  useEffect(() => {
+    setIsMobile(isMobileBrowser(navigator));
   }, []);
 
   const [showMicWarning, setShowMicWarning] = useState(false);
@@ -897,6 +946,11 @@ export default function StudioPage() {
     return (
       <div className="animate-page-enter min-h-screen bg-bg flex flex-col">
         <Topbar />
+        {isMobile && !mobileWarningDismissed && (
+          <MobileBrowserWarningBanner
+            onDismiss={() => setMobileWarningDismissed(true)}
+          />
+        )}
         {showMicWarning && (
           <BuiltInMicWarningModal
             onAcknowledge={() => {
@@ -993,6 +1047,11 @@ export default function StudioPage() {
   return (
     <div className="animate-page-enter min-h-screen bg-bg flex flex-col">
       <Topbar session={`Session ${sessionId.slice(0, 8)}…`} />
+      {isMobile && !mobileWarningDismissed && (
+        <MobileBrowserWarningBanner
+          onDismiss={() => setMobileWarningDismissed(true)}
+        />
+      )}
       <LiveKitRoom
         serverUrl={LIVEKIT_URL}
         token={token}

--- a/src/app/studio/[id]/page.tsx
+++ b/src/app/studio/[id]/page.tsx
@@ -10,7 +10,14 @@
 // LiveKit operations (data channel sends, DataReceived subscriptions, etc.)
 // go through the Transport abstraction via useTransport().
 
-import { useEffect, useState, useRef, useCallback, useMemo } from "react";
+import {
+  type ReactNode,
+  useEffect,
+  useState,
+  useRef,
+  useCallback,
+  useMemo,
+} from "react";
 import { useParams } from "next/navigation";
 import {
   LiveKitRoom,
@@ -96,7 +103,9 @@ function MobileBrowserWarningBanner({
 }) {
   return (
     <div
-      className="sticky top-[52px] z-40 flex items-start gap-3 px-5 py-3 border-b"
+      role="status"
+      aria-live="polite"
+      className="sticky top-[var(--topbar-height)] z-40 flex items-start gap-3 px-5 py-3 border-b"
       style={{
         background: "rgba(232,168,48,0.09)",
         borderBottomColor: "rgba(232,168,48,0.22)",
@@ -119,6 +128,28 @@ function MobileBrowserWarningBanner({
       >
         <IcoX size={14} color="currentColor" />
       </button>
+    </div>
+  );
+}
+
+function StudioFrame({
+  children,
+  session,
+  showMobileWarning,
+  onDismissMobileWarning,
+}: {
+  children: ReactNode;
+  session?: string;
+  showMobileWarning: boolean;
+  onDismissMobileWarning: () => void;
+}) {
+  return (
+    <div className="animate-page-enter min-h-screen bg-bg flex flex-col">
+      <Topbar session={session} />
+      {showMobileWarning && (
+        <MobileBrowserWarningBanner onDismiss={onDismissMobileWarning} />
+      )}
+      {children}
     </div>
   );
 }
@@ -1452,13 +1483,10 @@ export default function StudioPage() {
 
   if (studioState === "prejoin") {
     return (
-      <div className="animate-page-enter min-h-screen bg-bg flex flex-col">
-        <Topbar />
-        {isMobile && !mobileWarningDismissed && (
-          <MobileBrowserWarningBanner
-            onDismiss={() => setMobileWarningDismissed(true)}
-          />
-        )}
+      <StudioFrame
+        showMobileWarning={isMobile && !mobileWarningDismissed}
+        onDismissMobileWarning={() => setMobileWarningDismissed(true)}
+      >
         {showMicWarning && (
           <BuiltInMicWarningModal
             onAcknowledge={() => {
@@ -1546,20 +1574,18 @@ export default function StudioPage() {
             </div>
           </div>
         </div>
-      </div>
+      </StudioFrame>
     );
   }
 
   // ---------- Connected / Recording ----------
 
   return (
-    <div className="animate-page-enter min-h-screen bg-bg flex flex-col">
-      <Topbar session={`Session ${sessionId.slice(0, 8)}…`} />
-      {isMobile && !mobileWarningDismissed && (
-        <MobileBrowserWarningBanner
-          onDismiss={() => setMobileWarningDismissed(true)}
-        />
-      )}
+    <StudioFrame
+      session={`Session ${sessionId.slice(0, 8)}…`}
+      showMobileWarning={isMobile && !mobileWarningDismissed}
+      onDismissMobileWarning={() => setMobileWarningDismissed(true)}
+    >
       <LiveKitRoom
         serverUrl={LIVEKIT_URL}
         token={token}
@@ -1596,6 +1622,6 @@ export default function StudioPage() {
           isHost={isHost}
         />
       </LiveKitRoom>
-    </div>
+    </StudioFrame>
   );
 }

--- a/src/components/ui/Icon.tsx
+++ b/src/components/ui/Icon.tsx
@@ -73,6 +73,7 @@ export const IcoPlay = (p: IconProps) => <Paths {...p} fill={p.fill ?? "currentC
 export const IcoPause = (p: IconProps) => <Paths {...p} d={["M6 4h4v16H6z", "M14 4h4v16h-4z"]} />;
 export const IcoChevron = (p: IconProps) => <Paths {...p} d="M15 18l-6-6 6-6" />;
 export const IcoPlus = (p: IconProps) => <Paths {...p} d={["M12 5v14", "M5 12h14"]} />;
+export const IcoX = (p: IconProps) => <Paths {...p} d={["M18 6L6 18", "M6 6l12 12"]} />;
 
 export const IcoAlert = (p: IconProps) => (
   <Paths

--- a/src/components/ui/Topbar.tsx
+++ b/src/components/ui/Topbar.tsx
@@ -35,7 +35,7 @@ export function Topbar({ session }: TopbarProps) {
 
   return (
     <div
-      className="h-[52px] sticky top-0 z-50 flex items-center gap-4 px-5 border-b"
+      className="h-[var(--topbar-height)] sticky top-0 z-50 flex items-center gap-4 px-5 border-b"
       style={{
         background: "var(--surface)",
         borderBottomColor: "var(--border)",


### PR DESCRIPTION
## Summary

Closes #21.

Adds a sticky, dismissible warning banner on the studio page when the browser identifies as mobile. The warning appears before joining and remains available in the connected studio view unless dismissed for the current page lifetime.

Also adds a shared `IcoX` icon for compact dismiss controls.

## Verification

- `git diff --check` passed
- `npm run build` passed, generated 17/17 static pages
- `npm test` passed, 47 tests passed

## Notes

This does not persist dismissal state, so the warning reappears after reload as requested.

Updated onto current `main` before marking ready for review.