### PR TITLE
Document ready-for-review PR default

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -15,6 +15,7 @@
 - Assume the user reviews every implementation through commits.
 - After implementing an approved change, surface the commit hash in the response.
 - If there are uncommitted changes that belong to the just-finished implementation, commit them before concluding unless the user explicitly says not to.
+- When opening a pull request, create a regular ready-for-review PR unless the user explicitly asks for a draft.
 
 ## Safety
 


### PR DESCRIPTION
## Summary

Updates `AGENTS.md` so implementation work opens regular ready-for-review pull requests by default, unless the user explicitly asks for a draft.

I also checked for repo-level conflicting draft-PR instructions. The only `draft` hit is `.github/workflows/request-copilot-review.yml`, which intentionally skips Copilot review on draft PRs and is not an agent instruction, so I left it unchanged.

## Verification

- `git diff --check` passed

## Notes

This is a documentation-only workflow change.