### PR TITLE
Add Layer 2 invariant tests

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -23,6 +23,7 @@
         "uuid": "^10.0.0"
       },
       "devDependencies": {
+        "@testing-library/react": "^16.3.2",
         "@types/node": "22.19.17",
         "@types/react": "^19.0.0",
         "@types/react-dom": "^19.0.0",
@@ -31,6 +32,7 @@
         "@vitest/coverage-v8": "^4.1.5",
         "eslint": "^9.0.0",
         "eslint-config-next": "^15.0.0",
+        "happy-dom": "^20.9.0",
         "postcss": "^8.4.0",
         "prisma": "^6.0.0",
         "tailwindcss": "^3.4.0",
@@ -38,7 +40,7 @@
         "vitest": "^4.1.5"
       },
       "engines": {
-        "node": ">=20"
+        "node": "^20.19.0 || >=22.12.0"
       }
     },
     "node_modules/@alloc/quick-lru": {
@@ -939,11 +941,27 @@
         "node": ">=18.0.0"
       }
     },
+    "node_modules/@babel/code-frame": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.0.tgz",
+      "integrity": "sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@babel/helper-validator-identifier": "^7.28.5",
+        "js-tokens": "^4.0.0",
+        "picocolors": "^1.1.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
     "node_modules/@babel/helper-string-parser": {
       "version": "7.27.1",
       "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz",
       "integrity": "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
@@ -953,7 +971,7 @@
       "version": "7.28.5",
       "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.28.5.tgz",
       "integrity": "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
@@ -963,7 +981,7 @@
       "version": "7.29.2",
       "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.2.tgz",
       "integrity": "sha512-4GgRzy/+fsBa72/RZVJmGKPmZu9Byn8o4MoLpmNe1m8ZfYnz5emHLQz3U4gLud6Zwl0RZIcgiLD7Uq7ySFuDLA==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@babel/types": "^7.29.0"
@@ -975,11 +993,21 @@
         "node": ">=6.0.0"
       }
     },
+    "node_modules/@babel/runtime": {
+      "version": "7.29.2",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.2.tgz",
+      "integrity": "sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
     "node_modules/@babel/types": {
       "version": "7.29.0",
       "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.0.tgz",
       "integrity": "sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-string-parser": "^7.27.1",
@@ -3157,6 +3185,66 @@
         "tslib": "^2.8.0"
       }
     },
+    "node_modules/@testing-library/dom": {
+      "version": "10.4.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-10.4.1.tgz",
+      "integrity": "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@babel/code-frame": "^7.10.4",
+        "@babel/runtime": "^7.12.5",
+        "@types/aria-query": "^5.0.1",
+        "aria-query": "5.3.0",
+        "dom-accessibility-api": "^0.5.9",
+        "lz-string": "^1.5.0",
+        "picocolors": "1.1.1",
+        "pretty-format": "^27.0.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@testing-library/dom/node_modules/aria-query": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.0.tgz",
+      "integrity": "sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "dequal": "^2.0.3"
+      }
+    },
+    "node_modules/@testing-library/react": {
+      "version": "16.3.2",
+      "resolved": "https://registry.npmjs.org/@testing-library/react/-/react-16.3.2.tgz",
+      "integrity": "sha512-XU5/SytQM+ykqMnAnvB2umaJNIOsLF3PVv//1Ew4CTcpz0/BRyy/af40qqrt7SjKpDdT1saBMc42CUok5gaw+g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.12.5"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@testing-library/dom": "^10.0.0",
+        "@types/react": "^18.0.0 || ^19.0.0",
+        "@types/react-dom": "^18.0.0 || ^19.0.0",
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@tybys/wasm-util": {
       "version": "0.10.1",
       "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.1.tgz",
@@ -3167,6 +3255,14 @@
       "dependencies": {
         "tslib": "^2.4.0"
       }
+    },
+    "node_modules/@types/aria-query": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
+      "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@types/chai": {
       "version": "5.2.3",
@@ -3257,6 +3353,23 @@
       "integrity": "sha512-7gqG38EyHgyP1S+7+xomFtL+ZNHcKv6DwNaCZmJmo1vgMugyF3TCnXVg4t1uk89mLNwnLtnY3TpOpCOyp1/xHQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@types/whatwg-mimetype": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/whatwg-mimetype/-/whatwg-mimetype-3.0.2.tgz",
+      "integrity": "sha512-c2AKvDT8ToxLIOUlN51gTiHXflsfIFisS4pO7pDPoKouJCESkhZnEy623gwP9laCy5lnLDAw1vAzu2vM2YLOrA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/ws": {
+      "version": "8.18.1",
+      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.18.1.tgz",
+      "integrity": "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
       "version": "8.58.1",
@@ -4003,6 +4116,17 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/ansi-styles": {
@@ -4810,6 +4934,17 @@
       "devOptional": true,
       "license": "MIT"
     },
+    "node_modules/dequal": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
+      "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/destr": {
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/destr/-/destr-2.0.5.tgz",
@@ -4853,6 +4988,14 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/dom-accessibility-api": {
+      "version": "0.5.16",
+      "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
+      "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/dotenv": {
       "version": "16.6.1",
@@ -4908,6 +5051,19 @@
       "license": "MIT",
       "engines": {
         "node": ">=14"
+      }
+    },
+    "node_modules/entities": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-7.0.1.tgz",
+      "integrity": "sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
       }
     },
     "node_modules/es-abstract": {
@@ -5958,6 +6114,24 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/happy-dom": {
+      "version": "20.9.0",
+      "resolved": "https://registry.npmjs.org/happy-dom/-/happy-dom-20.9.0.tgz",
+      "integrity": "sha512-GZZ9mKe8r646NUAf/zemnGbjYh4Bt8/MqASJY+pSm5ZDtc3YQox+4gsLI7yi1hba6o+eCsGxpHn5+iEVn31/FQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": ">=20.0.0",
+        "@types/whatwg-mimetype": "^3.0.2",
+        "@types/ws": "^8.18.1",
+        "entities": "^7.0.1",
+        "whatwg-mimetype": "^3.0.0",
+        "ws": "^8.18.3"
+      },
+      "engines": {
+        "node": ">=20.0.0"
       }
     },
     "node_modules/has-bigints": {
@@ -7125,6 +7299,17 @@
         "loose-envify": "cli.js"
       }
     },
+    "node_modules/lz-string": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/lz-string/-/lz-string-1.5.0.tgz",
+      "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "bin": {
+        "lz-string": "bin/bin.js"
+      }
+    },
     "node_modules/magic-string": {
       "version": "0.30.21",
       "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
@@ -7133,20 +7318,6 @@
       "license": "MIT",
       "dependencies": {
         "@jridgewell/sourcemap-codec": "^1.5.5"
-      }
-    },
-    "node_modules/magicast": {
-      "version": "0.3.5",
-      "resolved": "https://registry.npmjs.org/magicast/-/magicast-0.3.5.tgz",
-      "integrity": "sha512-L0WhttDl+2BOsybvEOLK7fW3UA0OQ0IQ2d6Zl2x/a6vVRs3bAY0ECOSHHeL5jD+SbOpOCUEi0y1DgHEn9Qn1AQ==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "@babel/parser": "^7.25.4",
-        "@babel/types": "^7.25.4",
-        "source-map-js": "^1.2.0"
       }
     },
     "node_modules/make-dir": {
@@ -7987,6 +8158,44 @@
       "engines": {
         "node": ">= 0.8.0"
       }
+    },
+    "node_modules/pretty-format": {
+      "version": "27.5.1",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.5.1.tgz",
+      "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "ansi-regex": "^5.0.1",
+        "ansi-styles": "^5.0.0",
+        "react-is": "^17.0.1"
+      },
+      "engines": {
+        "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
+      }
+    },
+    "node_modules/pretty-format/node_modules/ansi-styles": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/pretty-format/node_modules/react-is": {
+      "version": "17.0.2",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
+      "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/prisma": {
       "version": "6.19.3",
@@ -9613,6 +9822,16 @@
         "npm": ">=3.10.0"
       }
     },
+    "node_modules/whatwg-mimetype": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-3.0.0.tgz",
+      "integrity": "sha512-nt+N2dzIutVRxARx1nghPKGv1xHikU7HKdfafKkLNLindmPU/ch3U31NOCGGA/dmPcmb1VlofO0vnKAcsm0o/Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/which": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
@@ -9743,6 +9962,28 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/ws": {
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.0.tgz",
+      "integrity": "sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
       }
     },
     "node_modules/yocto-queue": {

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "uuid": "^10.0.0"
   },
   "devDependencies": {
+    "@testing-library/react": "^16.3.2",
     "@types/node": "22.19.17",
     "@types/react": "^19.0.0",
     "@types/react-dom": "^19.0.0",
@@ -43,6 +44,7 @@
     "@vitest/coverage-v8": "^4.1.5",
     "eslint": "^9.0.0",
     "eslint-config-next": "^15.0.0",
+    "happy-dom": "^20.9.0",
     "postcss": "^8.4.0",
     "prisma": "^6.0.0",
     "tailwindcss": "^3.4.0",

--- a/src/app/studio/[id]/page.tsx
+++ b/src/app/studio/[id]/page.tsx
@@ -41,9 +41,8 @@ import {
 import { useMicMonitor } from "@/hooks/useMicMonitor";
 import { useRemoteAudioLevels } from "@/hooks/useRemoteAudioLevels";
 import {
-  CLIP_MIN_FRAMES,
-  CLIP_THRESHOLD,
-  SHAPING_EXPONENT,
+  advanceClipHold,
+  shapeLevel,
   smoothLevel,
 } from "@/lib/audio-meter";
 import { FinishRecordingButton } from "@/components/FinishRecordingButton";
@@ -745,27 +744,24 @@ function RoomContent({
 
       const rms = Math.sqrt(sumSquares / dataArray.length);
       const normalized = Math.min(1, Math.max(0, (rms - 0.01) / 0.12));
-      const targetLevel = Math.round(Math.pow(normalized, SHAPING_EXPONENT) * 255);
+      const targetLevel = Math.round(shapeLevel(normalized) * 255);
       const smoothedLevel = Math.round(
         smoothLevel(localLevelRef.current, targetLevel)
       );
       localLevelRef.current = smoothedLevel;
 
-      // Clipping flag: peak >= -1 dBFS for CLIP_MIN_FRAMES consecutive frames,
-      // then hold the visible flag briefly so a single transient peak still
-      // registers. The hold count here is in RAF frames (~60Hz), giving ~500ms.
-      if (peak >= CLIP_THRESHOLD) {
-        localClipFramesRef.current += 1;
-        if (localClipFramesRef.current >= CLIP_MIN_FRAMES) {
-          localClipHoldRef.current = 30;
-        }
-      } else {
-        localClipFramesRef.current = 0;
-      }
-      // Compute visibility from the CURRENT hold first, then decrement, so a
-      // hold of N yields N visible frames (not N-1).
-      const isClipping = localClipHoldRef.current > 0;
-      if (isClipping) localClipHoldRef.current -= 1;
+      // Hold the visible clip flag briefly; 30 RAF frames is roughly 500ms.
+      const clipStep = advanceClipHold(
+        {
+          consecutiveClipFrames: localClipFramesRef.current,
+          holdFrames: localClipHoldRef.current,
+        },
+        peak,
+        30,
+      );
+      localClipFramesRef.current = clipStep.state.consecutiveClipFrames;
+      localClipHoldRef.current = clipStep.state.holdFrames;
+      const isClipping = clipStep.isClipping;
       // Avoid setState every frame when nothing changed.
       setLocalClipping((prev) => (prev === isClipping ? prev : isClipping));
 

--- a/src/components/UploadProgressBar.tsx
+++ b/src/components/UploadProgressBar.tsx
@@ -1,16 +1,7 @@
 "use client";
 
 import type { UploadProgress } from "@/hooks/useUploadProgress";
-
-type UploadPhase = "idle" | "uploading" | "done" | "error";
-
-function getPhase(progress: UploadProgress, recordingStopped: boolean): UploadPhase {
-  if (progress.lastError) return "error";
-  if (progress.bytesRecorded === 0) return "idle";
-  if (recordingStopped && progress.fraction >= 1 && progress.chunksInFlight === 0)
-    return "done";
-  return "uploading";
-}
+import { getUploadPhase, type UploadPhase } from "@/lib/upload-progress";
 
 export function UploadProgressBar({
   progress,
@@ -19,7 +10,7 @@ export function UploadProgressBar({
   progress: UploadProgress;
   recordingStopped: boolean;
 }) {
-  const phase = getPhase(progress, recordingStopped);
+  const phase = getUploadPhase(progress, recordingStopped);
   const pct = Math.round(progress.fraction * 100);
 
   // Colors per phase.

--- a/src/hooks/useRemoteAudioLevels.ts
+++ b/src/hooks/useRemoteAudioLevels.ts
@@ -12,8 +12,7 @@
 import { useEffect, useRef, useState } from "react";
 import type { RemoteParticipant } from "livekit-client";
 import {
-  CLIP_MIN_FRAMES,
-  CLIP_THRESHOLD,
+  advanceClipHold,
   shapeLevel,
   smoothLevel,
 } from "@/lib/audio-meter";
@@ -61,6 +60,37 @@ export function useRemoteAudioLevels(
       // Snapshot the participants so a disconnect mid-poll doesn't blow up.
       const snapshot = participants.slice();
 
+      function applyClipState(identity: string, audioLevel: number | undefined) {
+        const step = advanceClipHold(
+          {
+            consecutiveClipFrames:
+              consecutiveClipFramesRef.current.get(identity) ?? 0,
+            holdFrames: clipHoldFramesRef.current.get(identity) ?? 0,
+          },
+          audioLevel,
+          CLIP_HOLD_FRAMES,
+        );
+
+        if (step.state.consecutiveClipFrames > 0) {
+          consecutiveClipFramesRef.current.set(
+            identity,
+            step.state.consecutiveClipFrames,
+          );
+        } else {
+          consecutiveClipFramesRef.current.delete(identity);
+        }
+
+        if (step.state.holdFrames > 0) {
+          clipHoldFramesRef.current.set(identity, step.state.holdFrames);
+        } else {
+          clipHoldFramesRef.current.delete(identity);
+        }
+
+        if (step.isClipping) {
+          nextClipping.add(identity);
+        }
+      }
+
       await Promise.all(
         snapshot.map(async (participant) => {
           const identity = participant.identity;
@@ -104,50 +134,18 @@ export function useRemoteAudioLevels(
             const decayed = Math.max(0, prev * 0.85);
             smoothedRef.current.set(identity, decayed);
             nextLevels.set(identity, Math.round(decayed));
-            // Drain any clip-hold counter without retriggering. Mirror the
-            // main path: check > 0 first, THEN decrement, so the final held
-            // frame still flashes even when stats happen to be missing.
-            const hold = clipHoldFramesRef.current.get(identity) ?? 0;
-            if (hold > 0) {
-              nextClipping.add(identity);
-              const remaining = hold - 1;
-              if (remaining > 0) {
-                clipHoldFramesRef.current.set(identity, remaining);
-              } else {
-                clipHoldFramesRef.current.delete(identity);
-              }
-            } else {
-              clipHoldFramesRef.current.delete(identity);
-            }
-            consecutiveClipFramesRef.current.delete(identity);
+            applyClipState(identity, undefined);
             return;
           }
 
           // Match the local meter's perceptual curve so both look identical.
-          const target = shapeLevel(audioLevel);
+          const target = shapeLevel(audioLevel) * 255;
           const prev = smoothedRef.current.get(identity) ?? 0;
           const smoothed = smoothLevel(prev, target);
           smoothedRef.current.set(identity, smoothed);
           nextLevels.set(identity, Math.round(smoothed));
 
-          // Clipping: count consecutive frames at/over threshold; latch the
-          // visible flag for a few extra frames so single peaks register.
-          if (audioLevel >= CLIP_THRESHOLD) {
-            const n =
-              (consecutiveClipFramesRef.current.get(identity) ?? 0) + 1;
-            consecutiveClipFramesRef.current.set(identity, n);
-            if (n >= CLIP_MIN_FRAMES) {
-              clipHoldFramesRef.current.set(identity, CLIP_HOLD_FRAMES);
-            }
-          } else {
-            consecutiveClipFramesRef.current.set(identity, 0);
-          }
-
-          const hold = clipHoldFramesRef.current.get(identity) ?? 0;
-          if (hold > 0) {
-            nextClipping.add(identity);
-            clipHoldFramesRef.current.set(identity, hold - 1);
-          }
+          applyClipState(identity, audioLevel);
         }),
       );
 

--- a/src/lib/audio-meter.ts
+++ b/src/lib/audio-meter.ts
@@ -19,12 +19,22 @@ export const SHAPING_EXPONENT = 0.6;
 export const SMOOTHING_PREV_WEIGHT = 0.7;
 export const SMOOTHING_TARGET_WEIGHT = 0.3;
 
+export interface ClipHoldState {
+  consecutiveClipFrames: number;
+  holdFrames: number;
+}
+
+export interface ClipHoldStep {
+  state: ClipHoldState;
+  isClipping: boolean;
+}
+
 /**
- * Map a raw 0..1 level to the shared 0..255 meter scale (compander curve).
+ * Shape a raw 0..1 level using the shared compander curve.
  */
 export function shapeLevel(audioLevel: number): number {
   const clamped = Math.max(0, Math.min(1, audioLevel));
-  return Math.pow(clamped, SHAPING_EXPONENT) * 255;
+  return Math.pow(clamped, SHAPING_EXPONENT);
 }
 
 /**
@@ -32,4 +42,44 @@ export function shapeLevel(audioLevel: number): number {
  */
 export function smoothLevel(prev: number, target: number): number {
   return prev * SMOOTHING_PREV_WEIGHT + target * SMOOTHING_TARGET_WEIGHT;
+}
+
+/**
+ * Advance the shared clip-latch state by one meter frame.
+ *
+ * `audioLevel === undefined` means the poll produced no fresh stat and is
+ * intentionally treated like a below-threshold sample.
+ */
+export function advanceClipHold(
+  state: ClipHoldState,
+  audioLevel: number | undefined,
+  visibleHoldFrames: number,
+): ClipHoldStep {
+  const holdFrames = Math.max(0, Math.floor(visibleHoldFrames));
+  const aboveThreshold =
+    typeof audioLevel === "number" &&
+    Number.isFinite(audioLevel) &&
+    audioLevel >= CLIP_THRESHOLD;
+
+  const consecutiveClipFrames = aboveThreshold
+    ? state.consecutiveClipFrames + 1
+    : 0;
+
+  let nextHoldFrames = Math.max(0, state.holdFrames);
+  if (aboveThreshold && consecutiveClipFrames >= CLIP_MIN_FRAMES) {
+    nextHoldFrames = holdFrames;
+  }
+
+  const isClipping = nextHoldFrames > 0;
+  if (isClipping) {
+    nextHoldFrames -= 1;
+  }
+
+  return {
+    state: {
+      consecutiveClipFrames,
+      holdFrames: nextHoldFrames,
+    },
+    isClipping,
+  };
 }

--- a/src/lib/upload-progress.ts
+++ b/src/lib/upload-progress.ts
@@ -1,0 +1,14 @@
+import type { UploadProgress } from "@/hooks/useUploadProgress";
+
+export type UploadPhase = "idle" | "uploading" | "done" | "error";
+
+export function getUploadPhase(
+  progress: UploadProgress,
+  recordingStopped: boolean,
+): UploadPhase {
+  if (progress.lastError) return "error";
+  if (progress.bytesRecorded === 0) return "idle";
+  if (recordingStopped && progress.fraction >= 1 && progress.chunksInFlight === 0)
+    return "done";
+  return "uploading";
+}

--- a/tests/devices.test.ts
+++ b/tests/devices.test.ts
@@ -75,6 +75,8 @@ describe("resolveDefaultDevice", () => {
   });
 
   it("does not match an unrelated device when the parsed fallback label is empty", () => {
+    // Chrome can briefly expose "Default - " during device transitions; an
+    // empty parsed name must not match every label via endsWith("").
     const devices = [
       dev("default", "Default - ", ""),
       dev("abc123", "Focusrite Scarlett 2i2", ""),
@@ -115,5 +117,31 @@ describe("isSelectedMicBuiltIn", () => {
   it("does not warn for an unknown deviceId", () => {
     const devices = [dev("abc123", "Focusrite Scarlett 2i2", "g1")];
     expect(isSelectedMicBuiltIn(devices, "missing")).toBe(false);
+  });
+
+  it("when a USB mic shares the default label stem, no built-in warning must appear", () => {
+    const devices = [
+      dev("default", "Default - Shure MV7", ""),
+      dev("abc123", "USB Audio - Shure MV7", ""),
+      dev("xyz789", "MacBook Pro Microphone", ""),
+    ];
+    expect(isSelectedMicBuiltIn(devices, "default")).toBe(false);
+  });
+
+  it("when the device list is empty, lookup must return empty results without throwing", () => {
+    expect(resolveDefaultDevice([], "default")).toBeUndefined();
+    expect(isSelectedMicBuiltIn([], "default")).toBe(false);
+  });
+
+  it("when multiple default-like entries exist, the selected default must resolve gracefully", () => {
+    const devices = [
+      dev("default", "Default - Shure MV7", "g1"),
+      dev("communications", "Default - MacBook Pro Microphone", "g2"),
+      dev("abc123", "Shure MV7", "g1"),
+      dev("xyz789", "MacBook Pro Microphone", "g2"),
+    ];
+
+    expect(resolveDefaultDevice(devices, "default")?.deviceId).toBe("abc123");
+    expect(isSelectedMicBuiltIn(devices, "default")).toBe(false);
   });
 });

--- a/tests/hooks/useUploadProgress.test.ts
+++ b/tests/hooks/useUploadProgress.test.ts
@@ -1,0 +1,244 @@
+import { act, renderHook, waitFor } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { useUploadProgress, type UploadProgress } from "@/hooks/useUploadProgress";
+import { getUploadPhase } from "@/lib/upload-progress";
+
+function deferred() {
+  let resolve!: () => void;
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<void>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return { promise, resolve, reject };
+}
+
+function progress(overrides: Partial<UploadProgress>): UploadProgress {
+  const bytesRecorded = overrides.bytesRecorded ?? 0;
+  const bytesUploaded = overrides.bytesUploaded ?? 0;
+  const chunksInFlight = overrides.chunksInFlight ?? 0;
+  const lastError = overrides.lastError ?? null;
+  return {
+    bytesRecorded,
+    bytesUploaded,
+    chunksInFlight,
+    lastError,
+    hasInflight: overrides.hasInflight ?? chunksInFlight > 0,
+    fraction:
+      overrides.fraction ??
+      (bytesRecorded > 0 ? Math.min(1, bytesUploaded / bytesRecorded) : 0),
+  };
+}
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("useUploadProgress", () => {
+  it("when recorded chunks upload successfully, uploaded bytes must equal recorded bytes with no chunks in flight", async () => {
+    const { result } = renderHook(() => useUploadProgress());
+    const uploads = [deferred(), deferred(), deferred()];
+    const tracked: Promise<void>[] = [];
+
+    act(() => {
+      result.current.onChunkRecorded(100);
+      result.current.onChunkRecorded(250);
+      result.current.onChunkRecorded(50);
+      tracked.push(result.current.trackUpload(100, uploads[0].promise));
+      tracked.push(result.current.trackUpload(250, uploads[1].promise));
+      tracked.push(result.current.trackUpload(50, uploads[2].promise));
+    });
+
+    await waitFor(() => {
+      expect(result.current.progress.chunksInFlight).toBe(3);
+    });
+
+    await act(async () => {
+      uploads.forEach((upload) => upload.resolve());
+      await Promise.all(tracked);
+    });
+
+    expect(result.current.progress.bytesRecorded).toBe(400);
+    expect(result.current.progress.bytesUploaded).toBe(400);
+    expect(result.current.progress.chunksInFlight).toBe(0);
+    expect(result.current.progress.hasInflight).toBe(false);
+    expect(result.current.progress.fraction).toBe(1);
+  });
+
+  it("when chunks are recorded over a session, recorded bytes must never decrease", () => {
+    const { result } = renderHook(() => useUploadProgress());
+
+    for (const byteLength of [10, 0, 25, 100, 1]) {
+      const before = result.current.progress.bytesRecorded;
+      act(() => {
+        result.current.onChunkRecorded(byteLength);
+      });
+      expect(result.current.progress.bytesRecorded).toBeGreaterThanOrEqual(before);
+    }
+
+    expect(result.current.progress.bytesRecorded).toBe(136);
+  });
+
+  it("when a rethrowing upload fails, in-flight bookkeeping must settle before the error surfaces", async () => {
+    const { result } = renderHook(() => useUploadProgress());
+    const upload = deferred();
+    const error = new Error("S3 rejected the chunk");
+    let tracked!: Promise<void>;
+    let thrown: unknown;
+
+    act(() => {
+      result.current.onChunkRecorded(128);
+      tracked = result.current.trackUpload(128, upload.promise, {
+        rethrow: true,
+      });
+    });
+
+    await waitFor(() => {
+      expect(result.current.progress.chunksInFlight).toBe(1);
+    });
+
+    await act(async () => {
+      upload.reject(error);
+      try {
+        await tracked;
+      } catch (err) {
+        thrown = err;
+      }
+    });
+
+    expect(thrown).toBe(error);
+    expect(result.current.progress.chunksInFlight).toBe(0);
+    expect(result.current.progress.lastError).toBe("S3 rejected the chunk");
+    expect(result.current.progress.hasInflight).toBe(false);
+  });
+
+  it("when reset runs with chunks in flight, counters must remain unchanged", async () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const { result } = renderHook(() => useUploadProgress());
+    const upload = deferred();
+    let tracked!: Promise<void>;
+
+    act(() => {
+      result.current.onChunkRecorded(512);
+      tracked = result.current.trackUpload(512, upload.promise);
+    });
+
+    await waitFor(() => {
+      expect(result.current.progress.chunksInFlight).toBe(1);
+    });
+
+    act(() => {
+      result.current.reset();
+    });
+
+    expect(warn).toHaveBeenCalledOnce();
+    expect(result.current.progress.bytesRecorded).toBe(512);
+    expect(result.current.progress.bytesUploaded).toBe(0);
+    expect(result.current.progress.chunksInFlight).toBe(1);
+
+    await act(async () => {
+      upload.resolve();
+      await tracked;
+    });
+
+    act(() => {
+      result.current.reset();
+    });
+
+    expect(result.current.progress.bytesRecorded).toBe(0);
+    expect(result.current.progress.bytesUploaded).toBe(0);
+    expect(result.current.progress.chunksInFlight).toBe(0);
+  });
+
+  it("when recorded bytes are frozen, later chunks must still grow the denominator", () => {
+    const { result } = renderHook(() => useUploadProgress());
+
+    act(() => {
+      result.current.onChunkRecorded(300);
+      result.current.freezeRecorded();
+    });
+
+    expect(result.current.progress.bytesRecorded).toBe(300);
+
+    act(() => {
+      result.current.onChunkRecorded(75);
+    });
+
+    expect(result.current.progress.bytesRecorded).toBe(375);
+  });
+
+  it("when upload inputs describe a phase, the derived phase must match the upload truth table", () => {
+    const cases: Array<{
+      name: string;
+      progress: UploadProgress;
+      recordingStopped: boolean;
+      phase: ReturnType<typeof getUploadPhase>;
+    }> = [
+      {
+        name: "nothing recorded",
+        progress: progress({}),
+        recordingStopped: false,
+        phase: "idle",
+      },
+      {
+        name: "active chunk in flight",
+        progress: progress({
+          bytesRecorded: 200,
+          bytesUploaded: 50,
+          chunksInFlight: 1,
+        }),
+        recordingStopped: false,
+        phase: "uploading",
+      },
+      {
+        name: "recording still active after current chunks settle",
+        progress: progress({
+          bytesRecorded: 200,
+          bytesUploaded: 200,
+          chunksInFlight: 0,
+        }),
+        recordingStopped: false,
+        phase: "uploading",
+      },
+      {
+        name: "recording stopped and all bytes settled",
+        progress: progress({
+          bytesRecorded: 200,
+          bytesUploaded: 200,
+          chunksInFlight: 0,
+        }),
+        recordingStopped: true,
+        phase: "done",
+      },
+      {
+        name: "last upload error",
+        progress: progress({
+          bytesRecorded: 200,
+          bytesUploaded: 50,
+          chunksInFlight: 0,
+          lastError: "network failed",
+        }),
+        recordingStopped: true,
+        phase: "error",
+      },
+    ];
+
+    for (const testCase of cases) {
+      expect(
+        getUploadPhase(testCase.progress, testCase.recordingStopped),
+        testCase.name,
+      ).toBe(testCase.phase);
+    }
+
+    expect(
+      getUploadPhase(
+        progress({
+          bytesRecorded: 200,
+          bytesUploaded: 200,
+          chunksInFlight: 0,
+        }),
+        true,
+      ),
+    ).not.toBe("uploading");
+  });
+});

--- a/tests/lib/audio-meter.test.ts
+++ b/tests/lib/audio-meter.test.ts
@@ -1,0 +1,87 @@
+import { describe, expect, it } from "vitest";
+import {
+  CLIP_MIN_FRAMES,
+  CLIP_THRESHOLD,
+  SMOOTHING_PREV_WEIGHT,
+  SMOOTHING_TARGET_WEIGHT,
+  advanceClipHold,
+  shapeLevel,
+  smoothLevel,
+  type ClipHoldState,
+} from "@/lib/audio-meter";
+
+describe("audio meter math", () => {
+  it("when levels are shaped, output must stay clamped and monotonic from 0 to 1", () => {
+    expect(shapeLevel(0)).toBe(0);
+    expect(shapeLevel(1)).toBe(1);
+    expect(shapeLevel(-0.5)).toBe(0);
+    expect(shapeLevel(1.5)).toBe(1);
+
+    const shaped = [0.01, 0.1, 0.25, 0.5, 0.75, 0.99].map(shapeLevel);
+    for (let index = 1; index < shaped.length; index += 1) {
+      expect(shaped[index]).toBeGreaterThan(shaped[index - 1]);
+    }
+  });
+
+  it("when levels are smoothed upward, the value must converge without overshooting and use the documented weights", () => {
+    const firstStep = smoothLevel(10, 110);
+    expect(firstStep).toBeCloseTo(
+      10 * SMOOTHING_PREV_WEIGHT + 110 * SMOOTHING_TARGET_WEIGHT,
+    );
+
+    let level = 0;
+    for (let index = 0; index < 20; index += 1) {
+      const next = smoothLevel(level, 100);
+      expect(next).toBeGreaterThanOrEqual(level);
+      expect(next).toBeLessThanOrEqual(100);
+      level = next;
+    }
+    expect(level).toBeGreaterThan(99);
+  });
+
+  it("when levels are smoothed downward, the value must converge without undershooting", () => {
+    let level = 100;
+    for (let index = 0; index < 20; index += 1) {
+      const next = smoothLevel(level, 0);
+      expect(next).toBeLessThanOrEqual(level);
+      expect(next).toBeGreaterThanOrEqual(0);
+      level = next;
+    }
+    expect(level).toBeLessThan(1);
+  });
+
+  it("when clipping latches, the indicator must remain visible for exactly the configured hold frames", () => {
+    let state: ClipHoldState = { consecutiveClipFrames: 0, holdFrames: 0 };
+    const visible: boolean[] = [];
+
+    for (let index = 0; index < CLIP_MIN_FRAMES; index += 1) {
+      const step = advanceClipHold(state, CLIP_THRESHOLD, CLIP_MIN_FRAMES);
+      state = step.state;
+      visible.push(step.isClipping);
+    }
+
+    for (let index = 0; index < CLIP_MIN_FRAMES; index += 1) {
+      const step = advanceClipHold(state, 0, CLIP_MIN_FRAMES);
+      state = step.state;
+      visible.push(step.isClipping);
+    }
+
+    const release = advanceClipHold(state, 0, CLIP_MIN_FRAMES);
+
+    expect(visible).toEqual([false, true, true, false]);
+    expect(release.isClipping).toBe(false);
+    expect(release.state.holdFrames).toBe(0);
+  });
+
+  it("when stats are missing, clip hold state must advance exactly like a below-threshold sample", () => {
+    const state: ClipHoldState = {
+      consecutiveClipFrames: CLIP_MIN_FRAMES,
+      holdFrames: 3,
+    };
+
+    const missingStats = advanceClipHold(state, undefined, 4);
+    const belowThreshold = advanceClipHold(state, CLIP_THRESHOLD - 0.01, 4);
+
+    expect(missingStats).toEqual(belowThreshold);
+  });
+});

--- a/tests/lib/audio-meter.test.ts
+++ b/tests/lib/audio-meter.test.ts
@@ -52,23 +52,27 @@ describe("audio meter math", () => {
 
   it("when clipping latches, the indicator must remain visible for exactly the configured hold frames", () => {
     let state: ClipHoldState = { consecutiveClipFrames: 0, holdFrames: 0 };
+    const holdFrames = 4;
     const visible: boolean[] = [];
 
     for (let index = 0; index < CLIP_MIN_FRAMES; index += 1) {
-      const step = advanceClipHold(state, CLIP_THRESHOLD, CLIP_MIN_FRAMES);
+      const step = advanceClipHold(state, CLIP_THRESHOLD, holdFrames);
       state = step.state;
       visible.push(step.isClipping);
     }
 
-    for (let index = 0; index < CLIP_MIN_FRAMES; index += 1) {
-      const step = advanceClipHold(state, 0, CLIP_MIN_FRAMES);
+    for (let index = 1; index < holdFrames; index += 1) {
+      const step = advanceClipHold(state, 0, holdFrames);
       state = step.state;
       visible.push(step.isClipping);
     }
 
-    const release = advanceClipHold(state, 0, CLIP_MIN_FRAMES);
+    const release = advanceClipHold(state, 0, holdFrames);
 
-    expect(visible).toEqual([false, true, true, false]);
+    expect(visible).toEqual([
+      ...Array.from({ length: Math.max(0, CLIP_MIN_FRAMES - 1) }, () => false),
+      ...Array.from({ length: holdFrames }, () => true),
+    ]);
     expect(release.isClipping).toBe(false);
     expect(release.state.holdFrames).toBe(0);
   });

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -8,7 +8,7 @@ export default defineConfig({
     },
   },
   test: {
-    environment: "node",
+    environment: "happy-dom",
     include: ["tests/**/*.test.ts"],
   },
 });


### PR DESCRIPTION
## Summary

- Adds the requested Vitest hook harness with `@testing-library/react` and `happy-dom`.
- Adds invariant tests for upload progress accounting, rethrow settle behavior, reset gating, freeze semantics, and upload phase derivation.
- Extracts shared audio-meter clip hold math into a pure helper and tests shaping, smoothing, hold counts, and missing-stats behavior.
- Extends device tests for empty default labels, default-label USB mics, empty device lists, and multiple default-like entries.

Closes #64

## Verification

- `npm test -- tests/hooks/useUploadProgress.test.ts tests/lib/audio-meter.test.ts tests/devices.test.ts --run` - 26 passed
- `npm test -- --run` - 61 passed
- `npm run build` - passed

Note: `npm run build` still emits the existing Next.js warning about multiple lockfiles and workspace-root inference.
