### PR TITLE
Add local MinIO storage mode

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -11,12 +11,19 @@ LIVEKIT_API_KEY=devkey
 LIVEKIT_API_SECRET=cozytrack-local-livekit-secret-32
 LIVEKIT_URL=ws://localhost:7880
 
-# AWS S3
-# Optional if you use a local AWS profile or other default AWS SDK credentials.
-AWS_ACCESS_KEY_ID=
-AWS_SECRET_ACCESS_KEY=
-AWS_REGION=us-west-2
-S3_BUCKET_NAME=cozytrack-dev-pasha
+# S3-compatible storage
+# Defaults target the local MinIO service from docker-compose.yml.
+AWS_ACCESS_KEY_ID=minioadmin
+AWS_SECRET_ACCESS_KEY=minioadmin
+AWS_REGION=us-east-1
+S3_BUCKET_NAME=cozytrack-local
+S3_ENDPOINT=http://localhost:9000
+S3_FORCE_PATH_STYLE=true
+
+# MinIO container credentials. Keep these aligned with the local AWS values
+# above unless you intentionally change both sides.
+MINIO_ROOT_USER=minioadmin
+MINIO_ROOT_PASSWORD=minioadmin
 
 # App
 NEXT_PUBLIC_LIVEKIT_URL=ws://localhost:7880

--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ Self-hosted podcast recording studio. A Riverside.fm alternative focused on loca
    npm run dev:local
    ```
 
-   This starts Docker services, creates the MinIO bucket, pushes the Prisma schema, and starts Next.js on port 3001.
+   This starts Docker services with the local MinIO profile enabled, creates the MinIO bucket, pushes the Prisma schema, and starts Next.js on port 3001. `dev:local` always overrides storage settings to use local MinIO, even if `.env` contains cloud-backed S3 values.
 
 4. **Open** [http://localhost:3001](http://localhost:3001)
 
@@ -123,7 +123,7 @@ To use a real AWS S3 bucket during local development:
 
 `npm run dev` checks AWS auth up front when no custom S3 endpoint is configured and fails fast if the current AWS session is expired. Reauthenticate with `aws login` and rerun the command if needed.
 
-The local MinIO console is available at [http://localhost:9001](http://localhost:9001) with the `MINIO_ROOT_USER` and `MINIO_ROOT_PASSWORD` values from `.env`.
+The local MinIO console is available after `npm run dev:local` at [http://localhost:9001](http://localhost:9001) with the `MINIO_ROOT_USER` and `MINIO_ROOT_PASSWORD` values from `.env`.
 
 ### Local Reset
 
@@ -134,7 +134,7 @@ npm run reset:local
 ```
 
 This will:
-- start local Docker services if needed
+- start local Docker services if needed, enabling MinIO only when the configured S3 endpoint is local
 - reset the local Prisma database
 - empty the configured local MinIO bucket, or fully empty an AWS-backed dev bucket including versioned objects and delete markers
 
@@ -170,7 +170,7 @@ src/
 │   └── upload.ts              # Client-side upload functions
 prisma/
 │   └── schema.prisma          # Database schema
-docker-compose.yml             # LiveKit + Postgres + Redis + MinIO
+docker-compose.yml             # LiveKit + Postgres + Redis, plus opt-in MinIO
 livekit.yaml                   # LiveKit server config
 ```
 

--- a/README.md
+++ b/README.md
@@ -179,6 +179,7 @@ livekit.yaml                   # LiveKit server config
 | Variable | Description | Default |
 |----------|-------------|---------|
 | `DATABASE_URL` | PostgreSQL connection string | `postgresql://cozytrack:cozytrack@localhost:5433/cozytrack` |
+| `DIRECT_DATABASE_URL` | Direct PostgreSQL connection for Prisma migrations and schema pushes. Locally this can match `DATABASE_URL`; `npm run dev:local` fills it from `DATABASE_URL` if omitted. | `postgresql://cozytrack:cozytrack@localhost:5433/cozytrack` |
 | `LIVEKIT_API_KEY` | LiveKit API key | `devkey` |
 | `LIVEKIT_API_SECRET` | LiveKit API secret | `cozytrack-local-livekit-secret-32` |
 | `LIVEKIT_URL` | LiveKit server URL (server-side) | `ws://localhost:7880` |
@@ -191,6 +192,7 @@ livekit.yaml                   # LiveKit server config
 | `S3_FORCE_PATH_STYLE` | Forces path-style S3 URLs for MinIO and other local endpoints. | `true` |
 | `MINIO_ROOT_USER` | Local MinIO console and API user. | `minioadmin` |
 | `MINIO_ROOT_PASSWORD` | Local MinIO console and API password. | `minioadmin` |
+| `MINIO_API_CORS_ALLOW_ORIGIN` | Comma-separated origins allowed by local MinIO. | `http://localhost:3000,http://127.0.0.1:3000,http://localhost:3001,http://127.0.0.1:3001` |
 | `AUTH_SECRET` | 32+ char secret for signing host + guest session JWTs. Generate with `openssl rand -hex 32`. | — (required) |
 | `HOST_PASSWORD` | Plaintext password for host sign-in. **Minimum 12 characters.** Hashed with scrypt at startup. | — (required) |
 | `COZYTRACK_API_KEY` | Shared secret checked against the `X-API-Key` header on `/api/ingest/*` (external-consumer endpoints used by tools like podline's `sd ct-ingest`). Browser-facing routes under `/api/sessions*` and `/api/tracks/*` are not gated by this key. Skipped in `NODE_ENV=development` for requests from `127.0.0.1` / `::1`. | — |

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Self-hosted podcast recording studio. A Riverside.fm alternative focused on loca
 │  ┌──────────────┐  ┌──────────────┐  ┌───────────────────┐  │
 │  │  LiveKit SDK  │  │  RecordRTC   │  │   Upload Client   │  │
 │  │ (WebRTC room) │  │ (local mic   │  │ (chunked upload   │  │
-│  │              │  │  recording)  │  │  to S3 via        │  │
+│  │              │  │  recording)  │  │  to S3-compatible │  │
 │  │  Audio/Video  │  │  WebM/Opus   │  │  presigned URLs)  │  │
 │  │  Preview      │  │              │  │                   │  │
 │  └──────┬───────┘  └──────┬───────┘  └────────┬──────────┘  │
@@ -20,8 +20,8 @@ Self-hosted podcast recording studio. A Riverside.fm alternative focused on loca
           │                 │                    │
           ▼                 │                    ▼
 ┌──────────────────┐        │          ┌──────────────────┐
-│   LiveKit Server │        │          │     AWS S3       │
-│   (WebRTC SFU)   │        │          │  (audio storage) │
+│   LiveKit Server │        │          │ S3-compatible   │
+│   (WebRTC SFU)   │        │          │ storage          │
 │   Port: 7880     │        │          │                  │
 └──────────────────┘        │          └──────────────────┘
                             │
@@ -44,9 +44,9 @@ Self-hosted podcast recording studio. A Riverside.fm alternative focused on loca
 
 ### How It Works
 
-1. **Local-first recording**: Each participant records their own microphone locally using RecordRTC. Audio never passes through the server — it goes straight from the browser to S3.
+1. **Local-first recording**: Each participant records their own microphone locally using RecordRTC. Audio never passes through the server — it goes straight from the browser to S3-compatible storage.
 2. **Live preview via WebRTC**: LiveKit provides real-time audio/video preview between participants so everyone can hear each other during recording.
-3. **Crash-safe uploads**: Audio is chunked every 5 seconds and uploaded to S3 via presigned URLs. If the browser crashes, you only lose the last few seconds.
+3. **Crash-safe uploads**: Audio is chunked every 5 seconds and uploaded to S3-compatible storage via presigned URLs. If the browser crashes, you only lose the last few seconds.
 4. **No transcoding needed**: Each track is stored as a separate WebM/Opus file. Download individual tracks and mix in your DAW.
 
 ## Tech Stack
@@ -54,11 +54,11 @@ Self-hosted podcast recording studio. A Riverside.fm alternative focused on loca
 - **Next.js 15** (App Router, TypeScript) — Frontend + API
 - **LiveKit** — WebRTC rooms for live audio/video preview
 - **RecordRTC** — Local browser audio recording
-- **AWS S3** — Audio file storage
+- **S3-compatible storage** — Audio file storage via AWS S3 in production or MinIO for fully local dev
 - **PostgreSQL** — Session and track metadata
 - **Prisma** — Database ORM
 - **Tailwind CSS** — Styling
-- **Docker Compose** — Local dev services (LiveKit, Postgres, Redis)
+- **Docker Compose** — Local dev services (LiveKit, Postgres, Redis, MinIO)
 
 ## Quick Start
 
@@ -66,7 +66,7 @@ Self-hosted podcast recording studio. A Riverside.fm alternative focused on loca
 
 - Node.js 20.19+ (or Node.js 22.12+)
 - Docker & Docker Compose
-- AWS account with S3 bucket configured
+- AWS account with S3 bucket configured only if you are not using the default local MinIO flow
 
 ### Setup
 
@@ -82,31 +82,48 @@ Self-hosted podcast recording studio. A Riverside.fm alternative focused on loca
 
    ```bash
    cp .env.example .env
-    # Edit .env with your AWS credentials or ensure your local AWS profile is configured
    ```
 
-3. **Start infrastructure:**
+   Edit `.env` and set `AUTH_SECRET` and `HOST_PASSWORD`. The storage defaults already point at local MinIO.
+
+3. **Start the fully local dev stack:**
+
+   ```bash
+   npm run dev:local
+   ```
+
+   This starts Docker services, creates the MinIO bucket, pushes the Prisma schema, and starts Next.js on port 3001.
+
+4. **Open** [http://localhost:3001](http://localhost:3001)
+
+### Cloud-backed S3 Dev
+
+The default `.env.example` uses local MinIO:
+
+```env
+S3_BUCKET_NAME=cozytrack-local
+S3_ENDPOINT=http://localhost:9000
+S3_FORCE_PATH_STYLE=true
+AWS_ACCESS_KEY_ID=minioadmin
+AWS_SECRET_ACCESS_KEY=minioadmin
+```
+
+To use a real AWS S3 bucket during local development:
+
+1. Set `S3_BUCKET_NAME` to your dev bucket.
+2. Clear `S3_ENDPOINT` and `S3_FORCE_PATH_STYLE`.
+3. Replace the local fake AWS credentials with real credentials, or remove them and rely on your local AWS profile.
+4. Start services and the app:
 
    ```bash
    docker compose up -d
-   ```
-
-4. **Run database migrations:**
-
-   ```bash
-   npx prisma migrate dev --name init
-   ```
-
-5. **Start the dev server:**
-
-   ```bash
+   npm run db:push
    npm run dev
    ```
 
-   `npm run dev` now checks local AWS auth up front and fails fast if the current session is expired.
-   Reauthenticate with `aws login` and rerun the command if needed.
+`npm run dev` checks AWS auth up front when no custom S3 endpoint is configured and fails fast if the current AWS session is expired. Reauthenticate with `aws login` and rerun the command if needed.
 
-6. **Open** [http://localhost:3001](http://localhost:3001)
+The local MinIO console is available at [http://localhost:9001](http://localhost:9001) with the `MINIO_ROOT_USER` and `MINIO_ROOT_PASSWORD` values from `.env`.
 
 ### Local Reset
 
@@ -119,7 +136,7 @@ npm run reset:local
 This will:
 - start local Docker services if needed
 - reset the local Prisma database
-- fully empty the configured S3 bucket, including versioned objects and delete markers
+- empty the configured local MinIO bucket, or fully empty an AWS-backed dev bucket including versioned objects and delete markers
 
 Safety guard:
 - the reset script refuses to run unless `S3_BUCKET_NAME` contains `dev`, `local`, or `test`
@@ -153,7 +170,7 @@ src/
 │   └── upload.ts              # Client-side upload functions
 prisma/
 │   └── schema.prisma          # Database schema
-docker-compose.yml             # LiveKit + Postgres + Redis
+docker-compose.yml             # LiveKit + Postgres + Redis + MinIO
 livekit.yaml                   # LiveKit server config
 ```
 
@@ -166,10 +183,14 @@ livekit.yaml                   # LiveKit server config
 | `LIVEKIT_API_SECRET` | LiveKit API secret | `cozytrack-local-livekit-secret-32` |
 | `LIVEKIT_URL` | LiveKit server URL (server-side) | `ws://localhost:7880` |
 | `NEXT_PUBLIC_LIVEKIT_URL` | LiveKit server URL (client-side) | `ws://localhost:7880` |
-| `AWS_ACCESS_KEY_ID` | Optional AWS access key for local env-based auth | — |
-| `AWS_SECRET_ACCESS_KEY` | Optional AWS secret key for local env-based auth | — |
-| `AWS_REGION` | AWS region | `us-west-2` |
-| `S3_BUCKET_NAME` | S3 bucket for recordings | `cozytrack-dev-pasha` |
+| `AWS_ACCESS_KEY_ID` | AWS-compatible access key. Defaults to local MinIO credentials. | `minioadmin` |
+| `AWS_SECRET_ACCESS_KEY` | AWS-compatible secret key. Defaults to local MinIO credentials. | `minioadmin` |
+| `AWS_REGION` | S3 signing region | `us-east-1` |
+| `S3_BUCKET_NAME` | S3-compatible bucket for recordings | `cozytrack-local` |
+| `S3_ENDPOINT` | Optional S3-compatible endpoint. Set to local MinIO for fully local dev; leave empty for AWS S3. | `http://localhost:9000` |
+| `S3_FORCE_PATH_STYLE` | Forces path-style S3 URLs for MinIO and other local endpoints. | `true` |
+| `MINIO_ROOT_USER` | Local MinIO console and API user. | `minioadmin` |
+| `MINIO_ROOT_PASSWORD` | Local MinIO console and API password. | `minioadmin` |
 | `AUTH_SECRET` | 32+ char secret for signing host + guest session JWTs. Generate with `openssl rand -hex 32`. | — (required) |
 | `HOST_PASSWORD` | Plaintext password for host sign-in. **Minimum 12 characters.** Hashed with scrypt at startup. | — (required) |
 | `COZYTRACK_API_KEY` | Shared secret checked against the `X-API-Key` header on `/api/ingest/*` (external-consumer endpoints used by tools like podline's `sd ct-ingest`). Browser-facing routes under `/api/sessions*` and `/api/tracks/*` are not gated by this key. Skipped in `NODE_ENV=development` for requests from `127.0.0.1` / `::1`. | — |

--- a/README.md
+++ b/README.md
@@ -186,7 +186,8 @@ livekit.yaml                   # LiveKit server config
 | `NEXT_PUBLIC_LIVEKIT_URL` | LiveKit server URL (client-side) | `ws://localhost:7880` |
 | `AWS_ACCESS_KEY_ID` | AWS-compatible access key. Defaults to local MinIO credentials. | `minioadmin` |
 | `AWS_SECRET_ACCESS_KEY` | AWS-compatible secret key. Defaults to local MinIO credentials. | `minioadmin` |
-| `AWS_REGION` | S3 signing region | `us-east-1` |
+| `AWS_REGION` | S3 signing region. `npm run dev:local` ignores this and uses `LOCAL_AWS_REGION` instead. | `us-east-1` |
+| `LOCAL_AWS_REGION` | Optional local-only signing region override for `npm run dev:local`. | `us-east-1` |
 | `S3_BUCKET_NAME` | S3-compatible bucket for recordings | `cozytrack-local` |
 | `S3_ENDPOINT` | Optional S3-compatible endpoint. Set to local MinIO for fully local dev; leave empty for AWS S3. | `http://localhost:9000` |
 | `S3_FORCE_PATH_STYLE` | Forces path-style S3 URLs for MinIO and other local endpoints. | `true` |

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -27,5 +27,51 @@ services:
     ports:
       - "6379:6379"
 
+  minio:
+    image: quay.io/minio/minio:latest
+    ports:
+      - "9000:9000"
+      - "9001:9001"
+    environment:
+      MINIO_ROOT_USER: ${MINIO_ROOT_USER:-minioadmin}
+      MINIO_ROOT_PASSWORD: ${MINIO_ROOT_PASSWORD:-minioadmin}
+    volumes:
+      - miniodata:/data
+    command: server /data --console-address ":9001"
+
+  minio-init:
+    image: quay.io/minio/mc:latest
+    depends_on:
+      - minio
+    environment:
+      MINIO_ENDPOINT: http://minio:9000
+      MINIO_ROOT_USER: ${MINIO_ROOT_USER:-minioadmin}
+      MINIO_ROOT_PASSWORD: ${MINIO_ROOT_PASSWORD:-minioadmin}
+      S3_BUCKET_NAME: ${S3_BUCKET_NAME:-cozytrack-local}
+      MINIO_CORS_FILE: /tmp/s3-cors-console.json
+    volumes:
+      - ./scripts/minio-bucket.sh:/scripts/minio-bucket.sh:ro
+      - ./infra/s3-cors-console.json:/tmp/s3-cors-console.json:ro
+    entrypoint: ["/bin/sh"]
+    command: ["/scripts/minio-bucket.sh", "provision"]
+
+  minio-mc:
+    image: quay.io/minio/mc:latest
+    profiles:
+      - tools
+    depends_on:
+      - minio
+    environment:
+      MINIO_ENDPOINT: http://minio:9000
+      MINIO_ROOT_USER: ${MINIO_ROOT_USER:-minioadmin}
+      MINIO_ROOT_PASSWORD: ${MINIO_ROOT_PASSWORD:-minioadmin}
+      S3_BUCKET_NAME: ${S3_BUCKET_NAME:-cozytrack-local}
+      MINIO_CORS_FILE: /tmp/s3-cors-console.json
+    volumes:
+      - ./scripts/minio-bucket.sh:/scripts/minio-bucket.sh:ro
+      - ./infra/s3-cors-console.json:/tmp/s3-cors-console.json:ro
+    entrypoint: ["/bin/sh"]
+
 volumes:
   pgdata:
+  miniodata:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -29,6 +29,8 @@ services:
 
   minio:
     image: quay.io/minio/minio:latest
+    profiles:
+      - local-storage
     ports:
       - "9000:9000"
       - "9001:9001"
@@ -42,6 +44,8 @@ services:
 
   minio-init:
     image: quay.io/minio/mc:latest
+    profiles:
+      - local-storage
     depends_on:
       - minio
     environment:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -35,6 +35,7 @@ services:
     environment:
       MINIO_ROOT_USER: ${MINIO_ROOT_USER:-minioadmin}
       MINIO_ROOT_PASSWORD: ${MINIO_ROOT_PASSWORD:-minioadmin}
+      MINIO_API_CORS_ALLOW_ORIGIN: ${MINIO_API_CORS_ALLOW_ORIGIN:-http://localhost:3000,http://127.0.0.1:3000,http://localhost:3001,http://127.0.0.1:3001}
     volumes:
       - miniodata:/data
     command: server /data --console-address ":9001"
@@ -48,10 +49,8 @@ services:
       MINIO_ROOT_USER: ${MINIO_ROOT_USER:-minioadmin}
       MINIO_ROOT_PASSWORD: ${MINIO_ROOT_PASSWORD:-minioadmin}
       S3_BUCKET_NAME: ${S3_BUCKET_NAME:-cozytrack-local}
-      MINIO_CORS_FILE: /tmp/s3-cors-console.json
     volumes:
       - ./scripts/minio-bucket.sh:/scripts/minio-bucket.sh:ro
-      - ./infra/s3-cors-console.json:/tmp/s3-cors-console.json:ro
     entrypoint: ["/bin/sh"]
     command: ["/scripts/minio-bucket.sh", "provision"]
 
@@ -66,10 +65,8 @@ services:
       MINIO_ROOT_USER: ${MINIO_ROOT_USER:-minioadmin}
       MINIO_ROOT_PASSWORD: ${MINIO_ROOT_PASSWORD:-minioadmin}
       S3_BUCKET_NAME: ${S3_BUCKET_NAME:-cozytrack-local}
-      MINIO_CORS_FILE: /tmp/s3-cors-console.json
     volumes:
       - ./scripts/minio-bucket.sh:/scripts/minio-bucket.sh:ro
-      - ./infra/s3-cors-console.json:/tmp/s3-cors-console.json:ro
     entrypoint: ["/bin/sh"]
 
 volumes:

--- a/infra/README.md
+++ b/infra/README.md
@@ -12,6 +12,9 @@ Two files, same rules, different shape:
 - **`s3-cors.json`** — wrapped as `{ "CORSRules": [...] }`. Use with the AWS CLI / SDK.
 - **`s3-cors-console.json`** — just the array `[...]`. Paste into the AWS Console's CORS editor.
 
+Local MinIO does not use these bucket-level files. Docker Compose configures
+local CORS with `MINIO_API_CORS_ALLOW_ORIGIN` on the MinIO service instead.
+
 ### Via AWS Console
 
 1. S3 → Buckets → `cozytrack` → Permissions tab

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   },
   "scripts": {
     "dev": "bash ./scripts/check-aws-auth.sh && next dev -p 3001",
-    "dev:local": "docker compose up -d && npm run db:push && npm run dev",
+    "dev:local": "bash ./scripts/dev-local.sh",
     "init:local": "npm run reset:local && npm run dev",
     "reset:local": "bash ./scripts/reset-local.sh",
     "build": "next build",

--- a/scripts/check-aws-auth.sh
+++ b/scripts/check-aws-auth.sh
@@ -5,12 +5,14 @@ set -euo pipefail
 ROOT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
 cd "$ROOT_DIR"
 
-set -a
-[ -f ./.env ] && . ./.env
-[ -f ./.env.local ] && . ./.env.local
-set +a
+. ./scripts/local-env.sh
+load_local_env
 
 if [ -z "${S3_BUCKET_NAME:-}" ]; then
+  exit 0
+fi
+
+if [ -n "${S3_ENDPOINT:-}" ]; then
   exit 0
 fi
 

--- a/scripts/dev-local.sh
+++ b/scripts/dev-local.sh
@@ -8,26 +8,18 @@ cd "$ROOT_DIR"
 . ./scripts/local-env.sh
 load_local_env
 
-if [ -z "${S3_ENDPOINT:-}" ]; then
-  export S3_ENDPOINT="http://localhost:9000"
-  export S3_BUCKET_NAME="${LOCAL_S3_BUCKET_NAME:-cozytrack-local}"
-fi
+export S3_ENDPOINT="http://localhost:9000"
+export MINIO_ROOT_USER="${MINIO_ROOT_USER:-minioadmin}"
+export MINIO_ROOT_PASSWORD="${MINIO_ROOT_PASSWORD:-minioadmin}"
+export AWS_ACCESS_KEY_ID="$MINIO_ROOT_USER"
+export AWS_SECRET_ACCESS_KEY="$MINIO_ROOT_PASSWORD"
+export AWS_REGION="${AWS_REGION:-us-east-1}"
+export S3_BUCKET_NAME="${LOCAL_S3_BUCKET_NAME:-cozytrack-local}"
+export S3_FORCE_PATH_STYLE="true"
 
-if is_local_s3_endpoint; then
-  export MINIO_ROOT_USER="${MINIO_ROOT_USER:-minioadmin}"
-  export MINIO_ROOT_PASSWORD="${MINIO_ROOT_PASSWORD:-minioadmin}"
-  export AWS_ACCESS_KEY_ID="$MINIO_ROOT_USER"
-  export AWS_SECRET_ACCESS_KEY="$MINIO_ROOT_PASSWORD"
-  export AWS_REGION="${AWS_REGION:-us-east-1}"
-  export S3_BUCKET_NAME="${LOCAL_S3_BUCKET_NAME:-${S3_BUCKET_NAME:-cozytrack-local}}"
-  export S3_FORCE_PATH_STYLE="${S3_FORCE_PATH_STYLE:-true}"
-fi
+docker compose --profile local-storage up -d
 
-docker compose up -d
-
-if is_local_s3_endpoint; then
-  docker compose run --rm minio-mc /scripts/minio-bucket.sh provision
-fi
+docker compose --profile local-storage --profile tools run --rm minio-mc /scripts/minio-bucket.sh provision
 
 npm run db:push
-npm run dev
+./node_modules/.bin/next dev -p 3001

--- a/scripts/dev-local.sh
+++ b/scripts/dev-local.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$ROOT_DIR"
+
+. ./scripts/local-env.sh
+load_local_env
+
+if [ -z "${S3_ENDPOINT:-}" ]; then
+  export S3_ENDPOINT="http://localhost:9000"
+  export S3_BUCKET_NAME="${LOCAL_S3_BUCKET_NAME:-cozytrack-local}"
+fi
+
+if is_local_s3_endpoint; then
+  export MINIO_ROOT_USER="${MINIO_ROOT_USER:-minioadmin}"
+  export MINIO_ROOT_PASSWORD="${MINIO_ROOT_PASSWORD:-minioadmin}"
+  export AWS_ACCESS_KEY_ID="$MINIO_ROOT_USER"
+  export AWS_SECRET_ACCESS_KEY="$MINIO_ROOT_PASSWORD"
+  export AWS_REGION="${AWS_REGION:-us-east-1}"
+  export S3_BUCKET_NAME="${LOCAL_S3_BUCKET_NAME:-${S3_BUCKET_NAME:-cozytrack-local}}"
+  export S3_FORCE_PATH_STYLE="${S3_FORCE_PATH_STYLE:-true}"
+fi
+
+docker compose up -d
+
+if is_local_s3_endpoint; then
+  docker compose run --rm minio-mc /scripts/minio-bucket.sh provision
+fi
+
+npm run db:push
+npm run dev

--- a/scripts/dev-local.sh
+++ b/scripts/dev-local.sh
@@ -13,7 +13,7 @@ export MINIO_ROOT_USER="${MINIO_ROOT_USER:-minioadmin}"
 export MINIO_ROOT_PASSWORD="${MINIO_ROOT_PASSWORD:-minioadmin}"
 export AWS_ACCESS_KEY_ID="$MINIO_ROOT_USER"
 export AWS_SECRET_ACCESS_KEY="$MINIO_ROOT_PASSWORD"
-export AWS_REGION="${AWS_REGION:-us-east-1}"
+export AWS_REGION="${LOCAL_AWS_REGION:-us-east-1}"
 export S3_BUCKET_NAME="${LOCAL_S3_BUCKET_NAME:-cozytrack-local}"
 export S3_FORCE_PATH_STYLE="true"
 

--- a/scripts/local-env.sh
+++ b/scripts/local-env.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+
+load_local_env() {
+  set -a
+  [ -f ./.env ] && . ./.env
+  [ -f ./.env.local ] && . ./.env.local
+  set +a
+}
+
+is_local_s3_endpoint() {
+  case "${S3_ENDPOINT:-}" in
+    http://localhost:*|https://localhost:*|http://127.0.0.1:*|https://127.0.0.1:*|http://0.0.0.0:*|https://0.0.0.0:*|http://minio:*|https://minio:*|http://host.docker.internal:*|https://host.docker.internal:*)
+      return 0
+      ;;
+    *)
+      return 1
+      ;;
+  esac
+}

--- a/scripts/local-env.sh
+++ b/scripts/local-env.sh
@@ -5,6 +5,10 @@ load_local_env() {
   [ -f ./.env ] && . ./.env
   [ -f ./.env.local ] && . ./.env.local
   set +a
+
+  if [ -z "${DIRECT_DATABASE_URL:-}" ] && [ -n "${DATABASE_URL:-}" ]; then
+    export DIRECT_DATABASE_URL="$DATABASE_URL"
+  fi
 }
 
 is_local_s3_endpoint() {

--- a/scripts/minio-bucket.sh
+++ b/scripts/minio-bucket.sh
@@ -1,0 +1,37 @@
+#!/bin/sh
+
+set -eu
+
+action="${1:-provision}"
+
+case "$action" in
+  provision|empty)
+    ;;
+  *)
+    echo "Usage: minio-bucket.sh [provision|empty]" >&2
+    exit 64
+    ;;
+esac
+
+: "${MINIO_ENDPOINT:=http://minio:9000}"
+: "${MINIO_ROOT_USER:=minioadmin}"
+: "${MINIO_ROOT_PASSWORD:=minioadmin}"
+: "${S3_BUCKET_NAME:=cozytrack-local}"
+: "${MINIO_CORS_FILE:=/tmp/s3-cors-console.json}"
+
+until mc alias set local "$MINIO_ENDPOINT" "$MINIO_ROOT_USER" "$MINIO_ROOT_PASSWORD" >/dev/null 2>&1; do
+  echo "Waiting for MinIO at $MINIO_ENDPOINT"
+  sleep 1
+done
+
+mc mb --ignore-existing "local/$S3_BUCKET_NAME" >/dev/null
+
+if [ "$action" = "empty" ]; then
+  mc rm --recursive --force "local/$S3_BUCKET_NAME" >/dev/null
+fi
+
+if [ -f "$MINIO_CORS_FILE" ]; then
+  mc cors set "local/$S3_BUCKET_NAME" "$MINIO_CORS_FILE" >/dev/null
+fi
+
+echo "MinIO bucket $S3_BUCKET_NAME is ready"

--- a/scripts/minio-bucket.sh
+++ b/scripts/minio-bucket.sh
@@ -17,9 +17,18 @@ esac
 : "${MINIO_ROOT_USER:=minioadmin}"
 : "${MINIO_ROOT_PASSWORD:=minioadmin}"
 : "${S3_BUCKET_NAME:=cozytrack-local}"
+: "${MINIO_READY_RETRIES:=60}"
 
+attempt=1
 until mc alias set local "$MINIO_ENDPOINT" "$MINIO_ROOT_USER" "$MINIO_ROOT_PASSWORD" >/dev/null 2>&1; do
-  echo "Waiting for MinIO at $MINIO_ENDPOINT"
+  if [ "$attempt" -ge "$MINIO_READY_RETRIES" ]; then
+    echo "Timed out waiting for MinIO at $MINIO_ENDPOINT after $MINIO_READY_RETRIES attempts." >&2
+    echo "Check that MinIO is running and the configured credentials are correct." >&2
+    exit 1
+  fi
+
+  echo "Waiting for MinIO at $MINIO_ENDPOINT ($attempt/$MINIO_READY_RETRIES)"
+  attempt=$((attempt + 1))
   sleep 1
 done
 

--- a/scripts/minio-bucket.sh
+++ b/scripts/minio-bucket.sh
@@ -17,7 +17,6 @@ esac
 : "${MINIO_ROOT_USER:=minioadmin}"
 : "${MINIO_ROOT_PASSWORD:=minioadmin}"
 : "${S3_BUCKET_NAME:=cozytrack-local}"
-: "${MINIO_CORS_FILE:=/tmp/s3-cors-console.json}"
 
 until mc alias set local "$MINIO_ENDPOINT" "$MINIO_ROOT_USER" "$MINIO_ROOT_PASSWORD" >/dev/null 2>&1; do
   echo "Waiting for MinIO at $MINIO_ENDPOINT"
@@ -28,10 +27,6 @@ mc mb --ignore-existing "local/$S3_BUCKET_NAME" >/dev/null
 
 if [ "$action" = "empty" ]; then
   mc rm --recursive --force "local/$S3_BUCKET_NAME" >/dev/null
-fi
-
-if [ -f "$MINIO_CORS_FILE" ]; then
-  mc cors set "local/$S3_BUCKET_NAME" "$MINIO_CORS_FILE" >/dev/null
 fi
 
 echo "MinIO bucket $S3_BUCKET_NAME is ready"

--- a/scripts/reset-local.sh
+++ b/scripts/reset-local.sh
@@ -5,10 +5,8 @@ set -euo pipefail
 ROOT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
 cd "$ROOT_DIR"
 
-set -a
-[ -f ./.env ] && . ./.env
-[ -f ./.env.local ] && . ./.env.local
-set +a
+. ./scripts/local-env.sh
+load_local_env
 
 : "${S3_BUCKET_NAME:?S3_BUCKET_NAME is required}"
 
@@ -26,18 +24,40 @@ docker compose up -d
 echo "Resetting database"
 npx prisma db push --force-reset --accept-data-loss >/dev/null
 
+if is_local_s3_endpoint; then
+  echo "Emptying MinIO bucket $S3_BUCKET_NAME"
+  docker compose run --rm minio-mc /scripts/minio-bucket.sh empty
+  echo "Local reset complete"
+  exit 0
+fi
+
+if ! command -v aws >/dev/null 2>&1; then
+  echo "AWS CLI is required to reset an AWS-backed bucket." >&2
+  exit 1
+fi
+
+if ! command -v jq >/dev/null 2>&1; then
+  echo "jq is required to reset an AWS-backed bucket." >&2
+  exit 1
+fi
+
+aws_endpoint_args=()
+if [ -n "${S3_ENDPOINT:-}" ]; then
+  aws_endpoint_args=(--endpoint-url "$S3_ENDPOINT")
+fi
+
 echo "Emptying s3://$S3_BUCKET_NAME"
 
 while true; do
   delete_payload="$({
-    aws s3api list-object-versions --bucket "$S3_BUCKET_NAME" --output json
+    aws "${aws_endpoint_args[@]}" s3api list-object-versions --bucket "$S3_BUCKET_NAME" --output json
   } | jq -c '{Objects: ((.Versions // []) + (.DeleteMarkers // []) | map({Key, VersionId})), Quiet: true}')"
 
   if [ "$(printf '%s' "$delete_payload" | jq '.Objects | length')" -eq 0 ]; then
     break
   fi
 
-  aws s3api delete-objects --bucket "$S3_BUCKET_NAME" --delete "$delete_payload" >/dev/null
+  aws "${aws_endpoint_args[@]}" s3api delete-objects --bucket "$S3_BUCKET_NAME" --delete "$delete_payload" >/dev/null
 done
 
 echo "Local reset complete"

--- a/scripts/reset-local.sh
+++ b/scripts/reset-local.sh
@@ -19,14 +19,18 @@ case "$S3_BUCKET_NAME" in
     ;;
 esac
 
-docker compose up -d
+if is_local_s3_endpoint; then
+  docker compose --profile local-storage up -d
+else
+  docker compose up -d
+fi
 
 echo "Resetting database"
 npx prisma db push --force-reset --accept-data-loss >/dev/null
 
 if is_local_s3_endpoint; then
   echo "Emptying MinIO bucket $S3_BUCKET_NAME"
-  docker compose run --rm minio-mc /scripts/minio-bucket.sh empty
+  docker compose --profile local-storage --profile tools run --rm minio-mc /scripts/minio-bucket.sh empty
   echo "Local reset complete"
   exit 0
 fi

--- a/src/lib/s3.ts
+++ b/src/lib/s3.ts
@@ -7,9 +7,50 @@ import {
 } from "@aws-sdk/client-s3";
 import { getSignedUrl } from "@aws-sdk/s3-request-presigner";
 
-export const s3 = new S3Client({
-  region: process.env.AWS_REGION!,
-});
+type S3ClientConfig = NonNullable<ConstructorParameters<typeof S3Client>[0]>;
+
+function cleanEnv(value: string | undefined): string | undefined {
+  const trimmed = value?.trim();
+  return trimmed ? trimmed : undefined;
+}
+
+function booleanEnv(value: string | undefined): boolean | undefined {
+  if (value === undefined) {
+    return undefined;
+  }
+
+  const normalized = value.trim().toLowerCase();
+  if (["1", "true", "yes"].includes(normalized)) {
+    return true;
+  }
+  if (["0", "false", "no"].includes(normalized)) {
+    return false;
+  }
+
+  return undefined;
+}
+
+export function buildS3ClientConfig(
+  env: NodeJS.ProcessEnv = process.env,
+): S3ClientConfig {
+  const endpoint = cleanEnv(env.S3_ENDPOINT);
+  const forcePathStyle = booleanEnv(env.S3_FORCE_PATH_STYLE) ?? Boolean(endpoint);
+  const config: S3ClientConfig = {
+    region: env.AWS_REGION!,
+  };
+
+  if (endpoint) {
+    config.endpoint = endpoint;
+  }
+
+  if (forcePathStyle) {
+    config.forcePathStyle = true;
+  }
+
+  return config;
+}
+
+export const s3 = new S3Client(buildS3ClientConfig());
 
 const bucket = process.env.S3_BUCKET_NAME!;
 

--- a/tests/s3-config.test.ts
+++ b/tests/s3-config.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from "vitest";
+import { buildS3ClientConfig } from "@/lib/s3";
+
+describe("buildS3ClientConfig", () => {
+  it("keeps AWS S3 behavior unchanged when no endpoint is configured", () => {
+    const config = buildS3ClientConfig({
+      AWS_REGION: "us-west-2",
+      S3_BUCKET_NAME: "cozytrack-dev",
+    });
+
+    expect(config).toEqual({ region: "us-west-2" });
+  });
+
+  it("uses path-style addressing for local S3-compatible endpoints by default", () => {
+    const config = buildS3ClientConfig({
+      AWS_REGION: "us-east-1",
+      S3_ENDPOINT: "http://localhost:9000",
+      S3_BUCKET_NAME: "cozytrack-local",
+    });
+
+    expect(config).toMatchObject({
+      region: "us-east-1",
+      endpoint: "http://localhost:9000",
+      forcePathStyle: true,
+    });
+  });
+
+  it("allows explicitly disabling path-style addressing for custom endpoints", () => {
+    const config = buildS3ClientConfig({
+      AWS_REGION: "us-east-1",
+      S3_ENDPOINT: "https://storage.example.com",
+      S3_FORCE_PATH_STYLE: "false",
+    });
+
+    expect(config).toEqual({
+      region: "us-east-1",
+      endpoint: "https://storage.example.com",
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- add MinIO and MinIO Client services to Docker Compose
- add local bucket provisioning and reset helpers
- let the S3 client target S3-compatible endpoints with path-style URLs for MinIO
- make `.env.example` and `npm run dev:local` default to fully local storage
- document local MinIO dev and cloud-backed S3 dev

Closes #70

## Verification

- `npm test -- tests/s3-config.test.ts --run` - 1 test file passed, 3 tests passed
- `bash -n scripts/dev-local.sh scripts/check-aws-auth.sh scripts/reset-local.sh scripts/local-env.sh` - passed
- `sh -n scripts/minio-bucket.sh` - passed
- `docker compose config` - passed
- `docker compose --profile tools config` - passed
- `npm test -- --run` - 7 test files passed, 50 tests passed
- `npm run build` - passed; emitted the existing Next.js workspace-root warning about multiple lockfiles

## Not run

- `docker compose up -d minio minio-init` could not run because Docker Desktop is not running in this environment: `failed to connect to the docker API at unix:///Users/pasha/.docker/run/docker.sock`.