### PR TITLE
[codex] Confirm peer recording status

### DIFF
--- a/src/app/studio/[id]/page.tsx
+++ b/src/app/studio/[id]/page.tsx
@@ -30,7 +30,7 @@ import { CozyRecorder } from "@/lib/recorder";
 import { forceMonoStream, getTrackChannelCount } from "@/lib/audio-downmix";
 import { getPresignedUploadUrl, uploadChunk, completeUpload } from "@/lib/upload";
 import { getToken, LIVEKIT_URL } from "@/lib/livekit";
-import { useTransport } from "@/lib/transport";
+import { useTransport, type RecordingStatusState } from "@/lib/transport";
 import { isSelectedMicBuiltIn } from "@/lib/devices";
 import { BuiltInMicWarningModal } from "@/components/BuiltInMicWarningModal";
 import {
@@ -65,6 +65,12 @@ import {
 
 type StudioState = "prejoin" | "connected" | "recording" | "finalizing";
 type AudioQualityMode = "full" | "bandwidth-saving";
+type RemoteRecordingStatus = {
+  state: RecordingStatusState;
+  sessionStartedAt?: string;
+  reason?: string;
+  updatedAt: number;
+};
 
 // ---------- Audio Quality Presets ----------
 
@@ -78,6 +84,8 @@ const BANDWIDTH_SAVING_PUBLISH = {
   dtx: true,
 } as const;
 
+const RECORDING_CONFIRMATION_TIMEOUT_MS = 4000;
+
 // ---------- Helpers ----------
 
 function formatElapsed(totalMs: number): string {
@@ -86,6 +94,11 @@ function formatElapsed(totalMs: number): string {
   const m = Math.floor((totalSec % 3600) / 60).toString().padStart(2, "0");
   const s = (totalSec % 60).toString().padStart(2, "0");
   return `${h}:${m}:${s}`;
+}
+
+function formatParticipantList(names: string[]): string {
+  if (names.length <= 2) return names.join(" and ");
+  return `${names.slice(0, -1).join(", ")}, and ${names[names.length - 1]}`;
 }
 
 function isMobileBrowser(navigatorInfo: Navigator): boolean {
@@ -593,6 +606,37 @@ function RoomContent({
   const [elapsedMs, setElapsedMs] = useState(0);
   const elapsedTimerRef = useRef<ReturnType<typeof setInterval> | null>(null);
 
+  const [recordingSessionStartedAt, setRecordingSessionStartedAt] =
+    useState<string | null>(null);
+  const recordingSessionStartedAtRef = useRef<string | null>(null);
+  const setRecordingSessionStartedAtSync = useCallback((next: string | null) => {
+    recordingSessionStartedAtRef.current = next;
+    setRecordingSessionStartedAt(next);
+  }, []);
+  const [remoteRecordingStatuses, setRemoteRecordingStatuses] = useState<
+    Map<string, RemoteRecordingStatus>
+  >(() => new Map());
+  const remoteRecordingStatusesRef = useRef(remoteRecordingStatuses);
+  const [expectedRecordingParticipants, setExpectedRecordingParticipants] =
+    useState<Set<string>>(() => new Set());
+  const expectedRecordingParticipantsRef = useRef<Set<string>>(new Set());
+  const [
+    unconfirmedRecordingParticipants,
+    setUnconfirmedRecordingParticipants,
+  ] = useState<Set<string>>(() => new Set());
+  const recordingConfirmationTimerRef =
+    useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  useEffect(() => {
+    remoteRecordingStatusesRef.current = remoteRecordingStatuses;
+  }, [remoteRecordingStatuses]);
+
+  const clearRecordingConfirmationTimer = useCallback(() => {
+    if (!recordingConfirmationTimerRef.current) return;
+    clearTimeout(recordingConfirmationTimerRef.current);
+    recordingConfirmationTimerRef.current = null;
+  }, []);
+
   const showNotification = useCallback((message: string) => {
     if (notificationTimerRef.current) clearTimeout(notificationTimerRef.current);
     setNotification(message);
@@ -607,6 +651,75 @@ function RoomContent({
       if (notificationTimerRef.current) clearTimeout(notificationTimerRef.current);
     };
   }, []);
+
+  useEffect(() => clearRecordingConfirmationTimer, [
+    clearRecordingConfirmationTimer,
+  ]);
+
+  const updateRemoteRecordingStatus = useCallback(
+    (identity: string, status: RemoteRecordingStatus) => {
+      setRemoteRecordingStatuses((prev) => {
+        const next = new Map(prev);
+        next.set(identity, status);
+        remoteRecordingStatusesRef.current = next;
+        return next;
+      });
+    },
+    [],
+  );
+
+  const scheduleRecordingConfirmationCheck = useCallback(
+    (sessionStartedAt: string) => {
+      const expected = new Set(
+        remoteParticipants.map((p) => p.identity).filter(Boolean),
+      );
+      expectedRecordingParticipantsRef.current = expected;
+      setExpectedRecordingParticipants(expected);
+      setUnconfirmedRecordingParticipants(new Set());
+      clearRecordingConfirmationTimer();
+
+      if (expected.size === 0) return;
+
+      recordingConfirmationTimerRef.current = setTimeout(() => {
+        if (recordingSessionStartedAtRef.current !== sessionStartedAt) return;
+
+        const statuses = remoteRecordingStatusesRef.current;
+        const unconfirmed = Array.from(expected).filter((identity) => {
+          const status = statuses.get(identity);
+          if (status?.sessionStartedAt !== sessionStartedAt) return true;
+          return status.state !== "recording" && status.state !== "failed";
+        });
+
+        if (unconfirmed.length === 0) return;
+
+        setUnconfirmedRecordingParticipants(new Set(unconfirmed));
+        showNotification(
+          `Recording not confirmed by ${formatParticipantList(unconfirmed)}`,
+        );
+      }, RECORDING_CONFIRMATION_TIMEOUT_MS);
+    },
+    [clearRecordingConfirmationTimer, remoteParticipants, showNotification],
+  );
+
+  const broadcastRecordingStatus = useCallback(
+    async (
+      state: RecordingStatusState,
+      sessionStartedAt?: string,
+      reason?: string,
+    ) => {
+      try {
+        await transport.sendControlMessage({
+          type: "recording_status",
+          state,
+          ...(sessionStartedAt ? { sessionStartedAt } : {}),
+          ...(reason ? { reason } : {}),
+        });
+      } catch (err) {
+        console.error("Failed to broadcast recording_status:", err);
+      }
+    },
+    [transport],
+  );
 
   const switchAudioQuality = useCallback(
     async (mode: AudioQualityMode): Promise<boolean> => {
@@ -809,6 +922,37 @@ function RoomContent({
     });
   }, [remoteAudio.levels, participantName]);
 
+  useEffect(() => {
+    const liveIdentities = new Set(remoteParticipants.map((p) => p.identity));
+
+    setRemoteRecordingStatuses((prev) => {
+      let next = prev;
+      for (const identity of prev.keys()) {
+        if (!liveIdentities.has(identity)) {
+          if (next === prev) next = new Map(prev);
+          next.delete(identity);
+        }
+      }
+      remoteRecordingStatusesRef.current = next;
+      return next;
+    });
+
+    setExpectedRecordingParticipants((prev) => {
+      const next = new Set(
+        Array.from(prev).filter((identity) => liveIdentities.has(identity)),
+      );
+      expectedRecordingParticipantsRef.current = next;
+      return next;
+    });
+
+    setUnconfirmedRecordingParticipants(
+      (prev) =>
+        new Set(
+          Array.from(prev).filter((identity) => liveIdentities.has(identity)),
+        ),
+    );
+  }, [remoteParticipants]);
+
   // Tick the elapsed-time display while recording. The interval is bound to
   // `recording`, NOT `finalizing` — once we enter `finalizing` the timer tears
   // down and the displayed value freezes at the stop-moment value. If we
@@ -851,10 +995,33 @@ function RoomContent({
       // (control-message) start paths honor the invariant.
       if (studioStateRef.current === "finalizing") {
         console.warn("Ignoring recording_start: currently finalizing previous recording");
-        return;
+        void broadcastRecordingStatus(
+          "failed",
+          sessionStartedAtIso,
+          "still finalizing previous recording",
+        );
+        return false;
       }
-      if (studioStateRef.current === "recording" || recorderRef.current) return;
-      if (!streamRef.current) return;
+      if (studioStateRef.current === "recording" || recorderRef.current) {
+        void broadcastRecordingStatus(
+          "recording",
+          recordingSessionStartedAtRef.current ?? sessionStartedAtIso,
+        );
+        return true;
+      }
+
+      setRecordingSessionStartedAtSync(sessionStartedAtIso);
+      scheduleRecordingConfirmationCheck(sessionStartedAtIso);
+
+      if (!streamRef.current) {
+        console.warn("Cannot start recording: microphone stream unavailable");
+        void broadcastRecordingStatus(
+          "failed",
+          sessionStartedAtIso,
+          "microphone stream unavailable",
+        );
+        return false;
+      }
 
       trackIdRef.current = uuidv4();
       const trackId = trackIdRef.current;
@@ -870,7 +1037,12 @@ function RoomContent({
         });
       } catch (err) {
         console.error("Failed to initialize upload:", err);
-        return;
+        void broadcastRecordingStatus(
+          "failed",
+          sessionStartedAtIso,
+          "upload initialization failed",
+        );
+        return false;
       }
 
       trackerReset();
@@ -897,10 +1069,16 @@ function RoomContent({
       } catch (err) {
         console.error("Failed to start recorder:", err);
         recorderRef.current = null;
-        return;
+        void broadcastRecordingStatus(
+          "failed",
+          sessionStartedAtIso,
+          "recorder failed to start",
+        );
+        return false;
       }
 
       setStudioStateSync("recording");
+      void broadcastRecordingStatus("recording", sessionStartedAtIso);
 
       // Auto-switch to bandwidth-saving mode for the LiveKit preview
       const switched = await switchAudioQuality("bandwidth-saving");
@@ -909,18 +1087,22 @@ function RoomContent({
       } else {
         showNotification("Couldn't switch audio quality — check console");
       }
+      return true;
     },
     [
-      sessionId,
+      broadcastRecordingStatus,
       participantName,
+      scheduleRecordingConfirmationCheck,
       selectedMic,
-      selectedMicLabel,
       selectedMicIsBuiltIn,
+      selectedMicLabel,
+      sessionId,
+      setRecordingSessionStartedAtSync,
       setStudioStateSync,
       showNotification,
       switchAudioQuality,
-      trackerReset,
       trackerOnChunkRecorded,
+      trackerReset,
       trackerTrackUpload,
     ],
   );
@@ -928,7 +1110,18 @@ function RoomContent({
   // Core recording stop. Idempotent: no-op when we have no active recorder or
   // we're already finalizing.
   const stopRecordingLocal = useCallback(async () => {
-    if (!recorderRef.current) return;
+    const sessionStartedAtForStatus =
+      recordingSessionStartedAtRef.current ?? undefined;
+    clearRecordingConfirmationTimer();
+    expectedRecordingParticipantsRef.current = new Set();
+    setExpectedRecordingParticipants(new Set());
+    setUnconfirmedRecordingParticipants(new Set());
+
+    if (!recorderRef.current) {
+      setRecordingSessionStartedAtSync(null);
+      void broadcastRecordingStatus("connected", sessionStartedAtForStatus);
+      return;
+    }
     if (studioStateRef.current === "finalizing") return;
 
     // Snapshot per-recording state into local consts BEFORE any await so a
@@ -940,6 +1133,7 @@ function RoomContent({
     const trackId = trackIdRef.current;
     const startedAt = recordingStartRef.current;
     setStudioStateSync("finalizing");
+    void broadcastRecordingStatus("finalizing", sessionStartedAtForStatus);
 
     try {
       const blob = await recorder.stop();
@@ -981,6 +1175,8 @@ function RoomContent({
         console.error("Failed while draining chunk uploads:", drainErr);
       }
       setStudioStateSync("connected");
+      setRecordingSessionStartedAtSync(null);
+      void broadcastRecordingStatus("connected", sessionStartedAtForStatus);
       // Best-effort restoration of full-quality preview. Fire-and-forget —
       // a failure here must not keep us stuck in `finalizing`.
       void switchAudioQuality("full").catch((err) => {
@@ -988,7 +1184,10 @@ function RoomContent({
       });
     }
   }, [
+    broadcastRecordingStatus,
+    clearRecordingConfirmationTimer,
     sessionId,
+    setRecordingSessionStartedAtSync,
     setStudioStateSync,
     switchAudioQuality,
     trackerFreezeRecorded,
@@ -1008,25 +1207,39 @@ function RoomContent({
       studioStateRef.current === "recording" ||
       studioStateRef.current === "finalizing" ||
       recorderRef.current
-    )
+    ) {
       return;
+    }
+
     const sessionStartedAt = new Date().toISOString();
     try {
       await transport.sendControlMessage({ type: "recording_start", sessionStartedAt });
     } catch (err) {
       console.error("Failed to broadcast recording_start:", err);
+      showNotification("Couldn't tell the room to start recording");
+      return;
     }
-    await startRecordingLocal(sessionStartedAt);
-  }, [transport, startRecordingLocal]);
+
+    const started = await startRecordingLocal(sessionStartedAt);
+    if (!started) {
+      showNotification("Couldn't start your recorder — stopping the room");
+      try {
+        await transport.sendControlMessage({ type: "recording_stop" });
+      } catch (err) {
+        console.error("Failed to broadcast recording_stop after start failure:", err);
+      }
+    }
+  }, [transport, startRecordingLocal, showNotification]);
 
   const handleStopRecording = useCallback(async () => {
     try {
       await transport.sendControlMessage({ type: "recording_stop" });
     } catch (err) {
       console.error("Failed to broadcast recording_stop:", err);
+      showNotification("Couldn't tell the room to stop recording");
     }
     await stopRecordingLocal();
-  }, [transport, stopRecordingLocal]);
+  }, [transport, stopRecordingLocal, showNotification]);
 
   // Subscribe to remote control messages. LiveKit does not echo the sender's
   // own messages back, but startRecordingLocal/stopRecordingLocal are
@@ -1037,16 +1250,51 @@ function RoomContent({
         showNotification(
           `Recording started by ${fromParticipant || "another participant"}`,
         );
-        void startRecordingLocal(msg.sessionStartedAt);
+        void startRecordingLocal(msg.sessionStartedAt).then((started) => {
+          if (!started) {
+            showNotification("Couldn't start your recorder — check your mic");
+          }
+        });
       } else if (msg.type === "recording_stop") {
         showNotification(
           `Recording stopped by ${fromParticipant || "another participant"}`,
         );
         void stopRecordingLocal();
+      } else if (msg.type === "recording_status") {
+        if (!fromParticipant) return;
+        updateRemoteRecordingStatus(fromParticipant, {
+          state: msg.state,
+          sessionStartedAt: msg.sessionStartedAt,
+          reason: msg.reason,
+          updatedAt: Date.now(),
+        });
+
+        if (msg.sessionStartedAt === recordingSessionStartedAtRef.current) {
+          setUnconfirmedRecordingParticipants((prev) => {
+            if (!prev.has(fromParticipant)) return prev;
+            const next = new Set(prev);
+            next.delete(fromParticipant);
+            return next;
+          });
+        }
+
+        if (msg.state === "failed") {
+          showNotification(
+            `${fromParticipant} could not start recording${
+              msg.reason ? `: ${msg.reason}` : ""
+            }`,
+          );
+        }
       }
     });
     return unsub;
-  }, [transport, startRecordingLocal, stopRecordingLocal, showNotification]);
+  }, [
+    transport,
+    startRecordingLocal,
+    stopRecordingLocal,
+    showNotification,
+    updateRemoteRecordingStatus,
+  ]);
 
 
   // Warn before tab close when uploads are in flight or recording is active.
@@ -1086,11 +1334,64 @@ function RoomContent({
 
   const isRecording = studioState === "recording";
   const isFinalizing = studioState === "finalizing";
-  // Treat `finalizing` as still uploading: the recorder has stopped but
-  // chunks are draining, so the sidebar indicator should not look idle.
-  const isUploading = isRecording || isFinalizing;
 
-  const localStatus: Status = isUploading ? "recording" : "connected";
+  const localStatus: Status = isFinalizing
+    ? "uploading"
+    : isRecording
+    ? "recording"
+    : "connected";
+
+  const getRemoteStatus = useCallback(
+    (identity: string): Status => {
+      const remoteStatus = remoteRecordingStatuses.get(identity);
+      const matchesCurrentSession =
+        recordingSessionStartedAt !== null &&
+        remoteStatus?.sessionStartedAt === recordingSessionStartedAt;
+
+      if (
+        remoteStatus?.state === "failed" &&
+        (recordingSessionStartedAt === null || matchesCurrentSession)
+      ) {
+        return "failed";
+      }
+      if (
+        remoteStatus?.state === "finalizing" &&
+        (recordingSessionStartedAt === null || matchesCurrentSession)
+      ) {
+        return "uploading";
+      }
+      if (
+        remoteStatus?.state === "recording" &&
+        (recordingSessionStartedAt === null || matchesCurrentSession)
+      ) {
+        return "recording";
+      }
+      if (
+        remoteStatus?.state === "connected" &&
+        (recordingSessionStartedAt === null || matchesCurrentSession)
+      ) {
+        return "connected";
+      }
+      if (unconfirmedRecordingParticipants.has(identity)) {
+        return "unconfirmed";
+      }
+      if (
+        recordingSessionStartedAt !== null &&
+        isRecording &&
+        expectedRecordingParticipants.has(identity)
+      ) {
+        return "starting";
+      }
+      return "connected";
+    },
+    [
+      expectedRecordingParticipants,
+      isRecording,
+      recordingSessionStartedAt,
+      remoteRecordingStatuses,
+      unconfirmedRecordingParticipants,
+    ],
+  );
 
   return (
     <div className="flex flex-col flex-1 min-h-0">
@@ -1184,11 +1485,7 @@ function RoomContent({
               micLabel={undefined /* Remote mic label — needs #28 (LiveKit metadata propagation). */}
               isBuiltIn={false /* Remote built-in detection — needs #28. */}
               level={audioLevels.get(p.identity) ?? 0}
-              // studioState is local-only, so showing localStatus on remote
-              // strips was misleading (guests appeared to be "Recording" whenever
-              // the host hit record). Remote per-participant status is tracked
-              // in #30; until then we show a stable "connected" for remotes.
-              status="connected"
+              status={getRemoteStatus(p.identity)}
               clipping={remoteAudio.clipping.has(p.identity)}
             />
           ))}

--- a/src/app/studio/[id]/page.tsx
+++ b/src/app/studio/[id]/page.tsx
@@ -637,6 +637,17 @@ function RoomContent({
     recordingConfirmationTimerRef.current = null;
   }, []);
 
+  const clearRecordingConfirmationState = useCallback(
+    (clearSession = true) => {
+      clearRecordingConfirmationTimer();
+      expectedRecordingParticipantsRef.current = new Set();
+      setExpectedRecordingParticipants(new Set());
+      setUnconfirmedRecordingParticipants(new Set());
+      if (clearSession) setRecordingSessionStartedAtSync(null);
+    },
+    [clearRecordingConfirmationTimer, setRecordingSessionStartedAtSync],
+  );
+
   const showNotification = useCallback((message: string) => {
     if (notificationTimerRef.current) clearTimeout(notificationTimerRef.current);
     setNotification(message);
@@ -684,7 +695,8 @@ function RoomContent({
         if (recordingSessionStartedAtRef.current !== sessionStartedAt) return;
 
         const statuses = remoteRecordingStatusesRef.current;
-        const unconfirmed = Array.from(expected).filter((identity) => {
+        const currentExpected = expectedRecordingParticipantsRef.current;
+        const unconfirmed = Array.from(currentExpected).filter((identity) => {
           const status = statuses.get(identity);
           if (status?.sessionStartedAt !== sessionStartedAt) return true;
           return status.state !== "recording" && status.state !== "failed";
@@ -711,8 +723,8 @@ function RoomContent({
         await transport.sendControlMessage({
           type: "recording_status",
           state,
-          ...(sessionStartedAt ? { sessionStartedAt } : {}),
-          ...(reason ? { reason } : {}),
+          ...(sessionStartedAt !== undefined ? { sessionStartedAt } : {}),
+          ...(reason !== undefined ? { reason } : {}),
         });
       } catch (err) {
         console.error("Failed to broadcast recording_status:", err);
@@ -1010,11 +1022,9 @@ function RoomContent({
         return true;
       }
 
-      setRecordingSessionStartedAtSync(sessionStartedAtIso);
-      scheduleRecordingConfirmationCheck(sessionStartedAtIso);
-
       if (!streamRef.current) {
         console.warn("Cannot start recording: microphone stream unavailable");
+        clearRecordingConfirmationState();
         void broadcastRecordingStatus(
           "failed",
           sessionStartedAtIso,
@@ -1037,6 +1047,7 @@ function RoomContent({
         });
       } catch (err) {
         console.error("Failed to initialize upload:", err);
+        clearRecordingConfirmationState();
         void broadcastRecordingStatus(
           "failed",
           sessionStartedAtIso,
@@ -1069,6 +1080,7 @@ function RoomContent({
       } catch (err) {
         console.error("Failed to start recorder:", err);
         recorderRef.current = null;
+        clearRecordingConfirmationState();
         void broadcastRecordingStatus(
           "failed",
           sessionStartedAtIso,
@@ -1077,6 +1089,8 @@ function RoomContent({
         return false;
       }
 
+      setRecordingSessionStartedAtSync(sessionStartedAtIso);
+      scheduleRecordingConfirmationCheck(sessionStartedAtIso);
       setStudioStateSync("recording");
       void broadcastRecordingStatus("recording", sessionStartedAtIso);
 
@@ -1091,6 +1105,7 @@ function RoomContent({
     },
     [
       broadcastRecordingStatus,
+      clearRecordingConfirmationState,
       participantName,
       scheduleRecordingConfirmationCheck,
       selectedMic,
@@ -1112,17 +1127,14 @@ function RoomContent({
   const stopRecordingLocal = useCallback(async () => {
     const sessionStartedAtForStatus =
       recordingSessionStartedAtRef.current ?? undefined;
-    clearRecordingConfirmationTimer();
-    expectedRecordingParticipantsRef.current = new Set();
-    setExpectedRecordingParticipants(new Set());
-    setUnconfirmedRecordingParticipants(new Set());
+    if (studioStateRef.current === "finalizing") return;
+    clearRecordingConfirmationState(false);
 
     if (!recorderRef.current) {
       setRecordingSessionStartedAtSync(null);
       void broadcastRecordingStatus("connected", sessionStartedAtForStatus);
       return;
     }
-    if (studioStateRef.current === "finalizing") return;
 
     // Snapshot per-recording state into local consts BEFORE any await so a
     // hypothetical concurrent attempt to re-record (blocked by the
@@ -1185,7 +1197,7 @@ function RoomContent({
     }
   }, [
     broadcastRecordingStatus,
-    clearRecordingConfirmationTimer,
+    clearRecordingConfirmationState,
     sessionId,
     setRecordingSessionStartedAtSync,
     setStudioStateSync,

--- a/src/components/ui/StatusDot.tsx
+++ b/src/components/ui/StatusDot.tsx
@@ -5,14 +5,23 @@
  * compact "is this track connected / recording / uploading?" indicator.
  */
 
-type Status = "connected" | "recording" | "uploading" | "failed" | "idle";
+type Status =
+  | "connected"
+  | "starting"
+  | "recording"
+  | "uploading"
+  | "unconfirmed"
+  | "failed"
+  | "idle";
 
 const MAP: Record<Status, { label: string; color: string; blink: boolean }> = {
-  connected: { label: "Connected", color: "var(--ok)",   blink: false },
-  recording: { label: "Recording", color: "var(--rec)",  blink: true  },
-  uploading: { label: "Uploading…",color: "var(--warn)", blink: false },
-  failed:    { label: "Failed",    color: "var(--rec)",  blink: false },
-  idle:      { label: "Idle",      color: "var(--text-3)",blink: false },
+  connected:   { label: "Connected",   color: "var(--ok)",     blink: false },
+  starting:    { label: "Starting…",   color: "var(--warn)",   blink: true  },
+  recording:   { label: "Recording",   color: "var(--rec)",    blink: true  },
+  uploading:   { label: "Uploading…",  color: "var(--warn)",   blink: false },
+  unconfirmed: { label: "Unconfirmed", color: "var(--warn)",   blink: false },
+  failed:      { label: "Failed",      color: "var(--rec)",    blink: false },
+  idle:        { label: "Idle",        color: "var(--text-3)", blink: false },
 };
 
 export function StatusDot({ status }: { status: Status }) {

--- a/src/lib/transport/index.ts
+++ b/src/lib/transport/index.ts
@@ -14,6 +14,7 @@ import type { Transport } from "./types";
 export type {
   ControlMessage,
   RemoteParticipant,
+  RecordingStatusState,
   Transport,
   TransportEvents,
 } from "./types";

--- a/src/lib/transport/livekit-transport.ts
+++ b/src/lib/transport/livekit-transport.ts
@@ -19,14 +19,28 @@ import {
 import type {
   ControlMessage,
   RemoteParticipant,
+  RecordingStatusState,
   Transport,
   TransportEvents,
 } from "./types";
 
 const CONTROL_TOPIC = "control";
+const RECORDING_STATUS_STATES = new Set<RecordingStatusState>([
+  "connected",
+  "recording",
+  "finalizing",
+  "failed",
+]);
 
 function toRemoteParticipant(p: LKRemoteParticipant): RemoteParticipant {
   return { identity: p.identity, name: p.name };
+}
+
+function isRecordingStatusState(value: unknown): value is RecordingStatusState {
+  return (
+    typeof value === "string" &&
+    RECORDING_STATUS_STATES.has(value as RecordingStatusState)
+  );
 }
 
 // Runtime guard: validate that an arbitrary parsed JSON value matches the
@@ -42,6 +56,21 @@ function parseControlMessage(raw: unknown): ControlMessage | null {
   }
   if (obj.type === "recording_stop") {
     return { type: "recording_stop" };
+  }
+  if (obj.type === "recording_status") {
+    if (!isRecordingStatusState(obj.state)) return null;
+    if (
+      obj.sessionStartedAt !== undefined &&
+      typeof obj.sessionStartedAt !== "string"
+    )
+      return null;
+    if (obj.reason !== undefined && typeof obj.reason !== "string") return null;
+    return {
+      type: "recording_status",
+      state: obj.state,
+      ...(obj.sessionStartedAt ? { sessionStartedAt: obj.sessionStartedAt } : {}),
+      ...(obj.reason ? { reason: obj.reason } : {}),
+    };
   }
   return null;
 }

--- a/src/lib/transport/livekit-transport.ts
+++ b/src/lib/transport/livekit-transport.ts
@@ -68,8 +68,10 @@ function parseControlMessage(raw: unknown): ControlMessage | null {
     return {
       type: "recording_status",
       state: obj.state,
-      ...(obj.sessionStartedAt ? { sessionStartedAt: obj.sessionStartedAt } : {}),
-      ...(obj.reason ? { reason: obj.reason } : {}),
+      ...(obj.sessionStartedAt !== undefined
+        ? { sessionStartedAt: obj.sessionStartedAt }
+        : {}),
+      ...(obj.reason !== undefined ? { reason: obj.reason } : {}),
     };
   }
   return null;

--- a/src/lib/transport/types.ts
+++ b/src/lib/transport/types.ts
@@ -18,9 +18,21 @@ export interface TransportEvents {
 // Discriminated union of control messages broadcast between participants via
 // the data channel. Extend this union (not a generic payload) so all senders
 // and handlers get type-checked.
+export type RecordingStatusState =
+  | "connected"
+  | "recording"
+  | "finalizing"
+  | "failed";
+
 export type ControlMessage =
   | { type: "recording_start"; sessionStartedAt: string /* ISO8601 */ }
-  | { type: "recording_stop" };
+  | { type: "recording_stop" }
+  | {
+      type: "recording_status";
+      state: RecordingStatusState;
+      sessionStartedAt?: string /* ISO8601 */;
+      reason?: string;
+    };
 
 export interface Transport {
   /**


### PR DESCRIPTION
## Summary

- Add a `recording_status` control message so each participant confirms their own recorder state.
- Show remote participant strips as `Starting`, `Recording`, `Unconfirmed`, `Failed`, or `Uploading` based on those acknowledgements instead of hard-coding remotes as connected.
- Broadcast failure/connected/finalizing status around local recorder start and stop so peers can validate whether everyone is actually recording.

## Why

When one participant pressed record, their own strip showed `Recording`, but remote strips still showed `Connected` because the UI only knew local recorder state. This made each participant see themselves as recording and everyone else as merely connected.

## Validation

- `npm run build`
- `npm test`