### PR TITLE
Timing diagnostics for cross-track drift investigation (#7)

### DIFF
--- a/src/app/studio/[id]/page.tsx
+++ b/src/app/studio/[id]/page.tsx
@@ -40,6 +40,7 @@ import {
 } from "@/components/MicMonitorToggle";
 import { useMicMonitor } from "@/hooks/useMicMonitor";
 import { useRemoteAudioLevels } from "@/hooks/useRemoteAudioLevels";
+import { useTimingDiagnostics } from "@/hooks/useTimingDiagnostics";
 import {
   CLIP_MIN_FRAMES,
   CLIP_THRESHOLD,
@@ -792,6 +793,21 @@ function RoomContent({
   // flagged a participant as "speaking" — fine for grid highlights but useless
   // for level monitoring (silent talkers + no clipping signal). See #47.
   const remoteAudio = useRemoteAudioLevels(remoteParticipants);
+
+  // Issue #7 investigation: ?timing=1 enables structured [TIMING] console logs
+  // (getStats snapshots + chunk/start/stop events) for cross-track drift
+  // analysis. No-op without the flag.
+  const timingDebug = useMemo(
+    () =>
+      typeof window !== "undefined" &&
+      new URLSearchParams(window.location.search).get("timing") === "1",
+    [],
+  );
+  useTimingDiagnostics({
+    enabled: timingDebug,
+    localParticipant,
+    remoteParticipants,
+  });
   // Merge remote levels into the same audioLevels map the local meter feeds.
   useEffect(() => {
     setAudioLevels((prev) => {
@@ -881,6 +897,20 @@ function RoomContent({
         const byteLength = chunk.size;
         trackerOnChunkRecorded(byteLength);
 
+        if (timingDebug) {
+          console.log(
+            "[TIMING]",
+            JSON.stringify({
+              event: "chunk",
+              t: Date.now(),
+              perfNow: performance.now(),
+              trackId,
+              chunkIndex: index,
+              chunkBytes: byteLength,
+            }),
+          );
+        }
+
         const uploadPromise = (async () => {
           const url = await getPresignedUploadUrl(sessionId, trackId, index);
           await uploadChunk(url, chunk);
@@ -891,6 +921,20 @@ function RoomContent({
 
       recorderRef.current = recorder;
       recordingStartRef.current = Date.now();
+
+      if (timingDebug) {
+        console.log(
+          "[TIMING]",
+          JSON.stringify({
+            event: "record-start",
+            t: recordingStartRef.current,
+            perfNow: performance.now(),
+            sessionStartedAt: sessionStartedAtIso,
+            trackId,
+            participant: participantName,
+          }),
+        );
+      }
 
       try {
         await recorder.start(5000);
@@ -922,6 +966,7 @@ function RoomContent({
       trackerReset,
       trackerOnChunkRecorded,
       trackerTrackUpload,
+      timingDebug,
     ],
   );
 
@@ -944,6 +989,21 @@ function RoomContent({
     try {
       const blob = await recorder.stop();
       const durationMs = Date.now() - startedAt;
+
+      if (timingDebug) {
+        console.log(
+          "[TIMING]",
+          JSON.stringify({
+            event: "record-stop",
+            t: Date.now(),
+            perfNow: performance.now(),
+            trackId,
+            startedAt,
+            durationMs,
+            finalBlobBytes: blob.size,
+          }),
+        );
+      }
 
       // Freeze denominator — recording is done, no more chunks will arrive.
       trackerFreezeRecorded();
@@ -995,6 +1055,7 @@ function RoomContent({
     trackerOnChunkRecorded,
     trackerTrackUpload,
     trackerWaitForUploads,
+    timingDebug,
   ]);
 
   // Button handler: broadcast first so remote participants start close to our

--- a/src/hooks/useTimingDiagnostics.ts
+++ b/src/hooks/useTimingDiagnostics.ts
@@ -1,0 +1,185 @@
+"use client";
+
+// Diagnostic hook for issue #7: cross-track conversation latency.
+//
+// When `enabled`, polls getStats every 5s and emits one JSON line per snapshot
+// to console under the `[TIMING]` tag. Captures the WebRTC fields needed to
+// reconstruct cross-participant clock drift after a test recording:
+//   - estimatedPlayoutTimestamp (NTP via RTCP SR) → shared time reference
+//   - totalSamples{Received,Duration} → encoder/decoder wall vs media time
+//   - concealedSamples / silentConcealedSamples → packet-loss compensation
+//   - insertedSamplesForDeceleration / removedSamplesForAcceleration →
+//     jitter-buffer's measurement of sender↔receiver clock skew
+//   - jitterBufferDelay / jitterBufferEmittedCount → buffer pressure
+//   - packetsReceived / packetsLost / jitter → network conditions
+//
+// Disabled (default): one boolean check, no effect, no listeners.
+
+import { useEffect } from "react";
+import type { LocalParticipant, RemoteParticipant } from "livekit-client";
+
+const POLL_INTERVAL_MS = 5000;
+
+type StatField = string | number | undefined;
+
+interface InboundSnapshot {
+  identity: string;
+  ssrc?: StatField;
+  estimatedPlayoutTimestamp?: StatField;
+  lastPacketReceivedTimestamp?: StatField;
+  totalSamplesReceived?: StatField;
+  totalSamplesDuration?: StatField;
+  concealedSamples?: StatField;
+  silentConcealedSamples?: StatField;
+  insertedSamplesForDeceleration?: StatField;
+  removedSamplesForAcceleration?: StatField;
+  jitterBufferDelay?: StatField;
+  jitterBufferEmittedCount?: StatField;
+  jitter?: StatField;
+  packetsReceived?: StatField;
+  packetsLost?: StatField;
+}
+
+interface OutboundSnapshot {
+  ssrc?: StatField;
+  packetsSent?: StatField;
+  bytesSent?: StatField;
+  totalSamplesDuration?: StatField;
+  audioLevel?: StatField;
+}
+
+export function useTimingDiagnostics(opts: {
+  enabled: boolean;
+  localParticipant: LocalParticipant | undefined;
+  remoteParticipants: ReadonlyArray<RemoteParticipant>;
+}): void {
+  const { enabled, localParticipant, remoteParticipants } = opts;
+
+  useEffect(() => {
+    if (!enabled) return;
+
+    let cancelled = false;
+    let timer: ReturnType<typeof setTimeout> | null = null;
+
+    async function snapshot() {
+      const inbound: InboundSnapshot[] = [];
+      const outbound: OutboundSnapshot[] = [];
+
+      await Promise.all(
+        remoteParticipants.map(async (p) => {
+          const identity = p.identity;
+          if (!identity) return;
+          for (const pub of p.audioTrackPublications.values()) {
+            const track = pub.track;
+            if (!track) continue;
+            try {
+              const report = await track.getRTCStatsReport();
+              if (!report) continue;
+              report.forEach((entry) => {
+                const e = entry as Record<string, unknown>;
+                if (e.type === "inbound-rtp" && e.kind === "audio") {
+                  inbound.push({
+                    identity,
+                    ssrc: e.ssrc as StatField,
+                    estimatedPlayoutTimestamp: e.estimatedPlayoutTimestamp as StatField,
+                    lastPacketReceivedTimestamp: e.lastPacketReceivedTimestamp as StatField,
+                    totalSamplesReceived: e.totalSamplesReceived as StatField,
+                    totalSamplesDuration: e.totalSamplesDuration as StatField,
+                    concealedSamples: e.concealedSamples as StatField,
+                    silentConcealedSamples: e.silentConcealedSamples as StatField,
+                    insertedSamplesForDeceleration: e.insertedSamplesForDeceleration as StatField,
+                    removedSamplesForAcceleration: e.removedSamplesForAcceleration as StatField,
+                    jitterBufferDelay: e.jitterBufferDelay as StatField,
+                    jitterBufferEmittedCount: e.jitterBufferEmittedCount as StatField,
+                    jitter: e.jitter as StatField,
+                    packetsReceived: e.packetsReceived as StatField,
+                    packetsLost: e.packetsLost as StatField,
+                  });
+                }
+              });
+            } catch {
+              // Receiver mid-teardown — ignore.
+            }
+          }
+        }),
+      );
+
+      if (localParticipant) {
+        for (const pub of localParticipant.audioTrackPublications.values()) {
+          const track = pub.track;
+          if (!track) continue;
+          try {
+            const report = await track.getRTCStatsReport();
+            if (!report) continue;
+            const mediaSourceLevels = new Map<string, StatField>();
+            const mediaSourceDurations = new Map<string, StatField>();
+            report.forEach((entry) => {
+              const e = entry as Record<string, unknown>;
+              if (e.type === "media-source" && e.kind === "audio") {
+                const id = String(e.id ?? "");
+                mediaSourceLevels.set(id, e.audioLevel as StatField);
+                mediaSourceDurations.set(id, e.totalSamplesDuration as StatField);
+              }
+            });
+            report.forEach((entry) => {
+              const e = entry as Record<string, unknown>;
+              if (e.type === "outbound-rtp" && e.kind === "audio") {
+                const sourceId = String(e.mediaSourceId ?? "");
+                outbound.push({
+                  ssrc: e.ssrc as StatField,
+                  packetsSent: e.packetsSent as StatField,
+                  bytesSent: e.bytesSent as StatField,
+                  totalSamplesDuration: mediaSourceDurations.get(sourceId),
+                  audioLevel: mediaSourceLevels.get(sourceId),
+                });
+              }
+            });
+          } catch {
+            // Sender mid-teardown — ignore.
+          }
+        }
+      }
+
+      if (cancelled) return;
+
+      console.log(
+        "[TIMING]",
+        JSON.stringify({
+          event: "stats",
+          t: Date.now(),
+          perfNow: performance.now(),
+          inbound,
+          outbound,
+        }),
+      );
+    }
+
+    function loop() {
+      if (cancelled) return;
+      void snapshot().finally(() => {
+        if (cancelled) return;
+        timer = setTimeout(loop, POLL_INTERVAL_MS);
+      });
+    }
+
+    console.log(
+      "[TIMING]",
+      JSON.stringify({
+        event: "diagnostics-enabled",
+        t: Date.now(),
+        perfNow: performance.now(),
+        localIdentity: localParticipant?.identity,
+        remoteIdentities: remoteParticipants.map((p) => p.identity),
+        pollIntervalMs: POLL_INTERVAL_MS,
+        userAgent: typeof navigator !== "undefined" ? navigator.userAgent : undefined,
+      }),
+    );
+
+    loop();
+
+    return () => {
+      cancelled = true;
+      if (timer) clearTimeout(timer);
+    };
+  }, [enabled, localParticipant, remoteParticipants]);
+}


### PR DESCRIPTION
## Summary
- Adds a `useTimingDiagnostics` hook gated by `?timing=1` that polls `getStats()` every 5s and emits structured `[TIMING]` console logs with the WebRTC fields needed to reconstruct cross-participant clock drift
- Adds `record-start` / `record-stop` / per-`chunk` `[TIMING]` events from the recorder lifecycle so wall-clock vs encoder-time can be cross-checked
- Zero runtime cost when the flag is off (one boolean check, the diagnostic effect early-returns)

Captured fields per remote participant: `estimatedPlayoutTimestamp` (NTP via RTCP SR), `lastPacketReceivedTimestamp`, `totalSamplesReceived`, `totalSamplesDuration`, `concealedSamples`, `silentConcealedSamples`, `insertedSamplesForDeceleration`, `removedSamplesForAcceleration`, `jitterBufferDelay`, `jitterBufferEmittedCount`, `jitter`, `packetsReceived`, `packetsLost`. Plus local outbound-rtp / media-source for the sender side.

This is investigation infrastructure for [#7](https://github.com/pashafateev/cozytrack/issues/7), not a fix. Run a real 1-hour session with `?timing=1` on each participant, save the console log, and the data is sufficient to determine whether observed drift is constant offset, linear, or step-shaped from dropped samples — which decides whether the fix is a single start-anchor, end-to-end resampling, or periodic in-band beacons.

## Test plan
- [ ] Open studio without `?timing=1` — confirm no `[TIMING]` logs appear
- [ ] Open studio with `?timing=1` — confirm `diagnostics-enabled` log on connect, `stats` logs every 5s, `record-start` / `chunk` / `record-stop` logs around a recording
- [ ] Run a full 1-hour two-participant session with the flag on both ends, save logs, verify they have enough data for offline drift analysis

🤖 Generated with [Claude Code](https://claude.com/claude-code)