### PR TITLE
Block accidental navigation away from active studio recording (#73)

### DIFF
--- a/src/app/studio/[id]/page.tsx
+++ b/src/app/studio/[id]/page.tsx
@@ -48,6 +48,7 @@ import {
 } from "@/lib/audio-meter";
 import { FinishRecordingButton } from "@/components/FinishRecordingButton";
 import { useUploadProgress } from "@/hooks/useUploadProgress";
+import { useNavigationGuard } from "@/hooks/useNavigationGuard";
 import { UploadProgressBar } from "@/components/UploadProgressBar";
 
 import { Topbar } from "@/components/ui/Topbar";
@@ -1049,17 +1050,19 @@ function RoomContent({
   }, [transport, startRecordingLocal, stopRecordingLocal, showNotification]);
 
 
-  // Warn before tab close when uploads are in flight or recording is active.
-  // This is the Layer A fix for #49 — prevents accidental data loss.
-  useEffect(() => {
-    if (!uploadTracker.hasInflight && studioState !== "recording") return;
-    const handler = (e: BeforeUnloadEvent) => {
-      e.preventDefault();
-      e.returnValue = "";
-    };
-    window.addEventListener("beforeunload", handler);
-    return () => window.removeEventListener("beforeunload", handler);
-  }, [uploadTracker.hasInflight, studioState]);
+  // Block accidental navigation while recording, finalizing, or uploading.
+  // Covers tab close (beforeunload), browser back/forward (popstate), in-app
+  // <a>/Link clicks, and form submits (e.g. the topbar sign-out POST). See
+  // #73 for the live-test repro and #49 for the original tab-close warning
+  // this supersedes.
+  useNavigationGuard({
+    when:
+      studioState === "recording" ||
+      studioState === "finalizing" ||
+      uploadTracker.hasInflight,
+    message:
+      "Recording is in progress and may be lost if you leave. Leave anyway?",
+  });
 
   useEffect(() => {
     return () => {

--- a/src/hooks/useNavigationGuard.ts
+++ b/src/hooks/useNavigationGuard.ts
@@ -1,0 +1,170 @@
+"use client";
+
+import { useEffect, useRef } from "react";
+
+export interface NavigationGuardOptions {
+  /**
+   * When true, the guard is armed and will intercept navigation attempts.
+   * When false, the hook is a no-op (no listeners, no history mutation).
+   */
+  when: boolean;
+  /**
+   * Message shown in the in-app confirm dialog for back/forward and link
+   * clicks. The browser owns the wording for `beforeunload`.
+   */
+  message: string;
+}
+
+interface AnchorClickInfo {
+  /** Resolved href on the clicked anchor, if any. */
+  href: string | null;
+  /** Anchor target attribute, if any. */
+  target: string | null;
+  /** True if the anchor has a `download` attribute. */
+  hasDownload: boolean;
+  /** True if any modifier key (meta/ctrl/shift/alt) was pressed. */
+  modifierPressed: boolean;
+  /** Mouse button (0 = left). Non-zero buttons are ignored. */
+  button: number;
+}
+
+/**
+ * Pure decision: given a clicked anchor's properties and the current
+ * location, should we intercept (warn) before letting the browser navigate?
+ *
+ * Returns false for:
+ * - missing/empty href
+ * - non-http(s) schemes (mailto:, tel:, javascript:, blob:, etc.)
+ * - download links
+ * - target=_blank / new windows / non-_self targets
+ * - modified clicks (cmd/ctrl/shift/alt) and middle-click — those don't leave
+ *   the current document
+ * - cross-origin links (we only care about leaving the studio in-app)
+ * - same-pathname links (in-page anchors and re-clicks)
+ */
+export function shouldInterceptAnchorClick(
+  info: AnchorClickInfo,
+  currentOrigin: string,
+  currentPathname: string,
+): boolean {
+  if (info.button !== 0) return false;
+  if (info.modifierPressed) return false;
+  if (info.hasDownload) return false;
+  if (info.target && info.target !== "" && info.target !== "_self") return false;
+
+  const href = info.href;
+  if (!href) return false;
+
+  let url: URL;
+  try {
+    url = new URL(href, currentOrigin);
+  } catch {
+    return false;
+  }
+
+  if (url.protocol !== "http:" && url.protocol !== "https:") return false;
+  if (url.origin !== currentOrigin) return false;
+  if (url.pathname === currentPathname) return false;
+
+  return true;
+}
+
+/**
+ * Block accidental navigation away from the current page while a critical
+ * operation (active recording, finalize, in-flight upload) is running.
+ *
+ * Coverage:
+ * - tab close / refresh / hard navigation → native `beforeunload` prompt
+ * - in-app `<a>` clicks (incl. next/link) → in-app confirm dialog
+ * - form submits (e.g. sign-out POST) → in-app confirm dialog
+ * - browser back/forward → in-app confirm dialog (popstate + history sentinel)
+ *
+ * The hook is fully passive when `when` is false: no listeners, no history
+ * mutation. This keeps idle navigation frictionless (acceptance criterion
+ * from #73).
+ */
+export function useNavigationGuard({ when, message }: NavigationGuardOptions): void {
+  // Keep the latest message in a ref so listeners read fresh copy without
+  // resubscribing when callers reformat the prompt mid-session.
+  const messageRef = useRef(message);
+  useEffect(() => {
+    messageRef.current = message;
+  }, [message]);
+
+  useEffect(() => {
+    if (!when) return;
+    if (typeof window === "undefined") return;
+
+    const beforeUnload = (e: BeforeUnloadEvent) => {
+      e.preventDefault();
+      e.returnValue = "";
+    };
+
+    const onClickCapture = (e: MouseEvent) => {
+      const target = e.target as Element | null;
+      if (!target) return;
+      const anchor = target.closest("a");
+      if (!anchor) return;
+
+      const intercept = shouldInterceptAnchorClick(
+        {
+          href: anchor.getAttribute("href"),
+          target: anchor.getAttribute("target"),
+          hasDownload: anchor.hasAttribute("download"),
+          modifierPressed: e.metaKey || e.ctrlKey || e.shiftKey || e.altKey,
+          button: e.button,
+        },
+        window.location.origin,
+        window.location.pathname,
+      );
+      if (!intercept) return;
+
+      if (!window.confirm(messageRef.current)) {
+        e.preventDefault();
+        e.stopPropagation();
+        e.stopImmediatePropagation();
+      }
+    };
+
+    const onSubmitCapture = (e: SubmitEvent) => {
+      // Block any form submit that would leave the current document. The
+      // sign-out form in the topbar is the concrete case this covers; any
+      // other in-page form submit (e.g. an inline edit POST) would also
+      // navigate away on success, which we want to confirm.
+      if (!window.confirm(messageRef.current)) {
+        e.preventDefault();
+        e.stopPropagation();
+        e.stopImmediatePropagation();
+      }
+    };
+
+    // Sentinel history entry so we can catch the first browser-back press.
+    // popstate fires after the browser has already moved the pointer back, so
+    // pre-pushing gives us something to consume without actually leaving.
+    window.history.pushState(window.history.state, "", window.location.href);
+
+    const onPopState = () => {
+      if (window.confirm(messageRef.current)) {
+        // User accepted: we already popped the sentinel, so step back once
+        // more to actually leave the studio entry.
+        window.history.back();
+      } else {
+        // User cancelled: re-push the sentinel so the next back press will
+        // trip popstate again instead of silently leaving.
+        window.history.pushState(window.history.state, "", window.location.href);
+      }
+    };
+
+    window.addEventListener("beforeunload", beforeUnload);
+    document.addEventListener("click", onClickCapture, true);
+    document.addEventListener("submit", onSubmitCapture, true);
+    window.addEventListener("popstate", onPopState);
+
+    return () => {
+      window.removeEventListener("beforeunload", beforeUnload);
+      document.removeEventListener("click", onClickCapture, true);
+      document.removeEventListener("submit", onSubmitCapture, true);
+      window.removeEventListener("popstate", onPopState);
+    };
+  }, [when]);
+}

--- a/src/hooks/useNavigationGuard.ts
+++ b/src/hooks/useNavigationGuard.ts
@@ -28,6 +28,19 @@ interface AnchorClickInfo {
   button: number;
 }
 
+// Marker we tag onto our pushState entry so we can recognize it on cleanup
+// and pop it without disturbing application state pushed by other code.
+const SENTINEL_KEY = "__cozytrackNavGuard__";
+type SentinelState = { [SENTINEL_KEY]: true; inner: unknown };
+
+function isSentinelState(state: unknown): state is SentinelState {
+  return (
+    typeof state === "object" &&
+    state !== null &&
+    (state as { [SENTINEL_KEY]?: unknown })[SENTINEL_KEY] === true
+  );
+}
+
 /**
  * Pure decision: given a clicked anchor's properties and the current
  * location, should we intercept (warn) before letting the browser navigate?
@@ -40,12 +53,12 @@ interface AnchorClickInfo {
  * - modified clicks (cmd/ctrl/shift/alt) and middle-click — those don't leave
  *   the current document
  * - cross-origin links (we only care about leaving the studio in-app)
- * - same-pathname links (in-page anchors and re-clicks)
+ * - same-pathname links (in-page anchors and re-clicks, including bare
+ *   `#hash` and `?query` hrefs that resolve onto the current pathname)
  */
 export function shouldInterceptAnchorClick(
   info: AnchorClickInfo,
-  currentOrigin: string,
-  currentPathname: string,
+  currentUrl: string,
 ): boolean {
   if (info.button !== 0) return false;
   if (info.modifierPressed) return false;
@@ -55,16 +68,20 @@ export function shouldInterceptAnchorClick(
   const href = info.href;
   if (!href) return false;
 
+  let current: URL;
   let url: URL;
   try {
-    url = new URL(href, currentOrigin);
+    current = new URL(currentUrl);
+    // Resolve relative hrefs against the full current URL so bare `#hash`
+    // and `?query` hrefs land on the current pathname instead of root.
+    url = new URL(href, currentUrl);
   } catch {
     return false;
   }
 
   if (url.protocol !== "http:" && url.protocol !== "https:") return false;
-  if (url.origin !== currentOrigin) return false;
-  if (url.pathname === currentPathname) return false;
+  if (url.origin !== current.origin) return false;
+  if (url.pathname === current.pathname) return false;
 
   return true;
 }
@@ -114,8 +131,7 @@ export function useNavigationGuard({ when, message }: NavigationGuardOptions): v
           modifierPressed: e.metaKey || e.ctrlKey || e.shiftKey || e.altKey,
           button: e.button,
         },
-        window.location.origin,
-        window.location.pathname,
+        window.location.href,
       );
       if (!intercept) return;
 
@@ -138,20 +154,38 @@ export function useNavigationGuard({ when, message }: NavigationGuardOptions): v
       }
     };
 
+    const pushSentinel = () => {
+      const inner = isSentinelState(window.history.state)
+        ? window.history.state.inner
+        : window.history.state;
+      const sentinel: SentinelState = { [SENTINEL_KEY]: true, inner };
+      window.history.pushState(sentinel, "", window.location.href);
+    };
+
     // Sentinel history entry so we can catch the first browser-back press.
-    // popstate fires after the browser has already moved the pointer back, so
-    // pre-pushing gives us something to consume without actually leaving.
-    window.history.pushState(window.history.state, "", window.location.href);
+    // popstate fires after the browser has already moved the pointer back,
+    // so pre-pushing gives us something to consume without actually leaving.
+    pushSentinel();
+
+    // When we accept a back navigation we call history.back() ourselves,
+    // which triggers a second popstate while the listener is still attached.
+    // This flag swallows that one so we don't re-prompt on the way out.
+    let skipNextPop = false;
 
     const onPopState = () => {
+      if (skipNextPop) {
+        skipNextPop = false;
+        return;
+      }
       if (window.confirm(messageRef.current)) {
         // User accepted: we already popped the sentinel, so step back once
-        // more to actually leave the studio entry.
+        // more to actually leave. Mark the resulting popstate as ours.
+        skipNextPop = true;
         window.history.back();
       } else {
         // User cancelled: re-push the sentinel so the next back press will
         // trip popstate again instead of silently leaving.
-        window.history.pushState(window.history.state, "", window.location.href);
+        pushSentinel();
       }
     };
 
@@ -165,6 +199,13 @@ export function useNavigationGuard({ when, message }: NavigationGuardOptions): v
       document.removeEventListener("click", onClickCapture, true);
       document.removeEventListener("submit", onSubmitCapture, true);
       window.removeEventListener("popstate", onPopState);
+      // If our sentinel is still on top of the history stack, pop it so
+      // back-navigation behaves normally after the guard disarms (no extra
+      // back press needed). Listener is already removed, so the resulting
+      // popstate is a no-op.
+      if (isSentinelState(window.history.state)) {
+        window.history.back();
+      }
     };
   }, [when]);
 }

--- a/tests/navigation-guard.test.ts
+++ b/tests/navigation-guard.test.ts
@@ -3,6 +3,7 @@ import { shouldInterceptAnchorClick } from "../src/hooks/useNavigationGuard";
 
 const ORIGIN = "https://app.cozytrack.test";
 const STUDIO_PATH = "/studio/abc123";
+const STUDIO_URL = `${ORIGIN}${STUDIO_PATH}`;
 
 function click(overrides: Partial<Parameters<typeof shouldInterceptAnchorClick>[0]> = {}) {
   return shouldInterceptAnchorClick(
@@ -14,8 +15,7 @@ function click(overrides: Partial<Parameters<typeof shouldInterceptAnchorClick>[
       button: 0,
       ...overrides,
     },
-    ORIGIN,
-    STUDIO_PATH,
+    STUDIO_URL,
   );
 }
 
@@ -58,7 +58,19 @@ describe("shouldInterceptAnchorClick", () => {
   it("does not intercept same-pathname links (in-page anchors / re-clicks)", () => {
     expect(click({ href: STUDIO_PATH })).toBe(false);
     expect(click({ href: `${STUDIO_PATH}#invite` })).toBe(false);
-    expect(click({ href: `${ORIGIN}${STUDIO_PATH}` })).toBe(false);
+    expect(click({ href: STUDIO_URL })).toBe(false);
+  });
+
+  it("does not intercept same-document hash hrefs", () => {
+    // Bare hash hrefs (e.g. <a href="#invite">) must resolve onto the
+    // current pathname, not the origin root.
+    expect(click({ href: "#invite" })).toBe(false);
+    expect(click({ href: "#" })).toBe(false);
+  });
+
+  it("does not intercept same-document query-only hrefs", () => {
+    expect(click({ href: "?tab=invite" })).toBe(false);
+    expect(click({ href: "?" })).toBe(false);
   });
 
   it("does not intercept anchors without an href", () => {

--- a/tests/navigation-guard.test.ts
+++ b/tests/navigation-guard.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, it } from "vitest";
+import { shouldInterceptAnchorClick } from "../src/hooks/useNavigationGuard";
+
+const ORIGIN = "https://app.cozytrack.test";
+const STUDIO_PATH = "/studio/abc123";
+
+function click(overrides: Partial<Parameters<typeof shouldInterceptAnchorClick>[0]> = {}) {
+  return shouldInterceptAnchorClick(
+    {
+      href: "/dashboard",
+      target: null,
+      hasDownload: false,
+      modifierPressed: false,
+      button: 0,
+      ...overrides,
+    },
+    ORIGIN,
+    STUDIO_PATH,
+  );
+}
+
+describe("shouldInterceptAnchorClick", () => {
+  it("intercepts a plain in-app navigation away from the studio", () => {
+    expect(click({ href: "/dashboard" })).toBe(true);
+    expect(click({ href: "/" })).toBe(true);
+    expect(click({ href: `${ORIGIN}/dashboard` })).toBe(true);
+  });
+
+  it("does not intercept clicks targeting a different tab/window", () => {
+    expect(click({ target: "_blank" })).toBe(false);
+    expect(click({ target: "external" })).toBe(false);
+  });
+
+  it("does not intercept modified clicks (open-in-new-tab gestures)", () => {
+    expect(click({ modifierPressed: true })).toBe(false);
+  });
+
+  it("ignores non-primary mouse buttons", () => {
+    expect(click({ button: 1 })).toBe(false);
+    expect(click({ button: 2 })).toBe(false);
+  });
+
+  it("does not intercept download links", () => {
+    expect(click({ hasDownload: true })).toBe(false);
+  });
+
+  it("does not intercept non-http(s) schemes", () => {
+    expect(click({ href: "mailto:hello@cozytrack.test" })).toBe(false);
+    expect(click({ href: "tel:+15555550123" })).toBe(false);
+    expect(click({ href: "javascript:void(0)" })).toBe(false);
+    expect(click({ href: "blob:https://example.com/abc" })).toBe(false);
+  });
+
+  it("does not intercept cross-origin links", () => {
+    expect(click({ href: "https://example.com/anywhere" })).toBe(false);
+  });
+
+  it("does not intercept same-pathname links (in-page anchors / re-clicks)", () => {
+    expect(click({ href: STUDIO_PATH })).toBe(false);
+    expect(click({ href: `${STUDIO_PATH}#invite` })).toBe(false);
+    expect(click({ href: `${ORIGIN}${STUDIO_PATH}` })).toBe(false);
+  });
+
+  it("does not intercept anchors without an href", () => {
+    expect(click({ href: null })).toBe(false);
+    expect(click({ href: "" })).toBe(false);
+  });
+
+  it("treats target='_self' the same as no target", () => {
+    expect(click({ target: "_self" })).toBe(true);
+    expect(click({ target: "" })).toBe(true);
+  });
+
+  it("intercepts query-only navigation that changes pathname", () => {
+    expect(click({ href: "/dashboard?from=studio" })).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary

Closes #73. Live testing showed the studio could be left mid-recording via browser back, in-app links, or the sign-out form with no confirmation. The existing `beforeunload` handler only covered tab close, leaving the recording state in a corrupt-looking dashboard view (see #73 comment for repro).

This adds a `useNavigationGuard` hook that covers:

- **Tab close / refresh** — native `beforeunload` prompt
- **Browser back / forward** — `popstate` + history sentinel, in-app `confirm`
- **In-app `<a>` / `next/link` clicks** — capture-phase document click listener
- **Form submits** — capture-phase submit listener (covers the topbar sign-out POST)

Armed only while `studioState === "recording" | "finalizing"` or uploads are in flight; fully passive otherwise so idle navigation stays frictionless (per the issue's acceptance criteria).

The decision logic for whether an anchor click should be intercepted is extracted as a pure `shouldInterceptAnchorClick()` helper and unit-tested in node.

## Test plan

- [x] `npm test` — all 61 tests pass (incl. 11 new `navigation-guard` tests)
- [x] `npm run lint` — clean
- [ ] Manual: start recording, hit browser back → see confirm; cancel → stay on studio page
- [ ] Manual: start recording, click `dashboard` chip in topbar → see confirm; cancel → stay
- [ ] Manual: start recording, click `sign out` → see confirm; cancel → stay logged in
- [ ] Manual: idle (`connected`, no upload) → topbar links navigate without any prompt
- [ ] Manual: stop recording, wait for finalize/uploads → guard disarms, navigation frictionless again

## Related

- Supersedes the tab-close handler from #49.
- Doesn't fix #60 (server-owned lifecycle / dashboard recovery) — that's the durable answer to the dashboard "still recording" residue from the live test, which this PR only mitigates by preventing the unsafe leave in the first place.
- Doesn't hide the dashboard chip for non-host participants — tracked in #72.

https://claude.ai/code/session_01GaGM8kFjrJRJ2FKNuYJXge

---
_Generated by [Claude Code](https://claude.ai/code/session_01GaGM8kFjrJRJ2FKNuYJXge)_