### PR TITLE
Make recording controls host-only and spam-safe (#74)

### DIFF
--- a/src/app/api/livekit-token/route.ts
+++ b/src/app/api/livekit-token/route.ts
@@ -37,8 +37,16 @@ export async function POST(req: NextRequest) {
       );
     }
 
+    // Stamp the principal's role into the LiveKit token metadata. Receivers
+    // read `participant.metadata` off the LiveKit room to verify that
+    // host-only control messages (e.g. recording_start/stop) actually came
+    // from a host. Forging this requires forging a LiveKit token, which
+    // requires the server-held LIVEKIT_API_SECRET, so the role is trustworthy
+    // at the room edge.
+    const metadata = JSON.stringify({ role: principal.kind });
     const at = new AccessToken(apiKey, apiSecret, {
       identity: participantName,
+      metadata,
     });
     at.addGrant({ roomJoin: true, room: roomName });
     const token = await at.toJwt();

--- a/src/app/studio/[id]/page.tsx
+++ b/src/app/studio/[id]/page.tsx
@@ -30,7 +30,7 @@ import { CozyRecorder } from "@/lib/recorder";
 import { forceMonoStream, getTrackChannelCount } from "@/lib/audio-downmix";
 import { getPresignedUploadUrl, uploadChunk, completeUpload } from "@/lib/upload";
 import { getToken, LIVEKIT_URL } from "@/lib/livekit";
-import { useTransport } from "@/lib/transport";
+import { useTransport, isHostSender } from "@/lib/transport";
 import { isSelectedMicBuiltIn } from "@/lib/devices";
 import { BuiltInMicWarningModal } from "@/components/BuiltInMicWarningModal";
 import {
@@ -1058,50 +1058,92 @@ function RoomContent({
     timingDebug,
   ]);
 
+  // Synchronous "request in flight" guards. Set true at the top of the click
+  // handler before any await so a rapid second click is dropped immediately
+  // (issue #74). studioStateRef is only updated mid-way through
+  // startRecordingLocal/stopRecordingLocal — between the click and that
+  // update there's an `await transport.sendControlMessage(...)` window where
+  // a second click would otherwise pass every existing guard. These refs
+  // close that window. Cleared in the finally block so a failed send does
+  // not permanently lock out the button.
+  const startingRef = useRef(false);
+  const stoppingRef = useRef(false);
+
   // Button handler: broadcast first so remote participants start close to our
   // own start time, then start locally. sessionStartedAt uses our local clock
   // so all participants share a single reference timestamp on the Track row.
   const handleStartRecording = useCallback(async () => {
+    // Host-only: guests should never reach this codepath because the button
+    // is hidden for them, but defend in depth — a guest with devtools could
+    // call this, and we still want correctness.
+    if (!isHost) return;
     // Hard invariant from issue #61: cannot start a new recording while a
     // previous one is finalizing. The button itself is disabled in that state,
     // but enforce here too for the broadcast/control-message path.
     if (
+      startingRef.current ||
       studioStateRef.current === "recording" ||
       studioStateRef.current === "finalizing" ||
       recorderRef.current
     )
       return;
-    const sessionStartedAt = new Date().toISOString();
+    startingRef.current = true;
     try {
-      await transport.sendControlMessage({ type: "recording_start", sessionStartedAt });
-    } catch (err) {
-      console.error("Failed to broadcast recording_start:", err);
+      const sessionStartedAt = new Date().toISOString();
+      try {
+        await transport.sendControlMessage({ type: "recording_start", sessionStartedAt });
+      } catch (err) {
+        console.error("Failed to broadcast recording_start:", err);
+      }
+      await startRecordingLocal(sessionStartedAt);
+    } finally {
+      startingRef.current = false;
     }
-    await startRecordingLocal(sessionStartedAt);
-  }, [transport, startRecordingLocal]);
+  }, [isHost, transport, startRecordingLocal]);
 
   const handleStopRecording = useCallback(async () => {
+    if (!isHost) return;
+    if (stoppingRef.current) return;
+    stoppingRef.current = true;
     try {
-      await transport.sendControlMessage({ type: "recording_stop" });
-    } catch (err) {
-      console.error("Failed to broadcast recording_stop:", err);
+      try {
+        await transport.sendControlMessage({ type: "recording_stop" });
+      } catch (err) {
+        console.error("Failed to broadcast recording_stop:", err);
+      }
+      await stopRecordingLocal();
+    } finally {
+      stoppingRef.current = false;
     }
-    await stopRecordingLocal();
-  }, [transport, stopRecordingLocal]);
+  }, [isHost, transport, stopRecordingLocal]);
 
   // Subscribe to remote control messages. LiveKit does not echo the sender's
   // own messages back, but startRecordingLocal/stopRecordingLocal are
   // idempotent anyway as a belt-and-braces guard.
+  //
+  // Host-only enforcement: recording_start/stop are session-wide controls.
+  // We only honor them when the sender's LiveKit token metadata identifies
+  // them as a host (see participant-role.ts). A guest cannot mint a token
+  // claiming role: "host" without LIVEKIT_API_SECRET, so this is sufficient
+  // for the trust model documented in issue #74.
   useEffect(() => {
-    const unsub = transport.onControlMessage((msg, fromParticipant) => {
+    const unsub = transport.onControlMessage((msg, sender) => {
+      if (msg.type === "recording_start" || msg.type === "recording_stop") {
+        if (!isHostSender(sender.metadata)) {
+          console.warn(
+            `Ignoring ${msg.type} from non-host sender ${sender.identity || "<unknown>"}`,
+          );
+          return;
+        }
+      }
       if (msg.type === "recording_start") {
         showNotification(
-          `Recording started by ${fromParticipant || "another participant"}`,
+          `Recording started by ${sender.identity || "another participant"}`,
         );
         void startRecordingLocal(msg.sessionStartedAt);
       } else if (msg.type === "recording_stop") {
         showNotification(
-          `Recording stopped by ${fromParticipant || "another participant"}`,
+          `Recording stopped by ${sender.identity || "another participant"}`,
         );
         void stopRecordingLocal();
       }
@@ -1291,42 +1333,70 @@ function RoomContent({
         >
           <div className="flex flex-col items-center gap-3 flex-1 justify-center">
             <div className="relative">
-              <button
-                type="button"
-                onClick={() => (isRecording ? handleStopRecording() : handleStartRecording())}
-                disabled={isFinalizing}
-                className={`w-[60px] h-[60px] rounded-full flex items-center justify-center border-2 ${
-                  isRecording ? "rec-ring" : ""
-                } ${isFinalizing ? "cursor-not-allowed" : "cursor-pointer"}`}
-                style={{
-                  background: isRecording ? "rgba(232,80,80,0.1)" : "var(--card)",
-                  borderColor: isRecording ? "var(--rec)" : "var(--border-hi)",
-                  opacity: isFinalizing ? 0.5 : 1,
-                  transition: "all 200ms ease",
-                }}
-                aria-label={
-                  isFinalizing
-                    ? "Finalizing previous recording"
-                    : isRecording
-                    ? "Stop recording"
-                    : "Start recording"
-                }
-                title={
-                  isFinalizing ? "Finalizing previous recording…" : undefined
-                }
-              >
-                {isRecording ? (
-                  <div
-                    className="w-5 h-5 rounded-[3px]"
-                    style={{ background: "var(--rec)" }}
-                  />
-                ) : (
+              {isHost ? (
+                <button
+                  type="button"
+                  onClick={() => (isRecording ? handleStopRecording() : handleStartRecording())}
+                  disabled={isFinalizing}
+                  className={`w-[60px] h-[60px] rounded-full flex items-center justify-center border-2 ${
+                    isRecording ? "rec-ring" : ""
+                  } ${isFinalizing ? "cursor-not-allowed" : "cursor-pointer"}`}
+                  style={{
+                    background: isRecording ? "rgba(232,80,80,0.1)" : "var(--card)",
+                    borderColor: isRecording ? "var(--rec)" : "var(--border-hi)",
+                    opacity: isFinalizing ? 0.5 : 1,
+                    transition: "all 200ms ease",
+                  }}
+                  aria-label={
+                    isFinalizing
+                      ? "Finalizing previous recording"
+                      : isRecording
+                      ? "Stop recording"
+                      : "Start recording"
+                  }
+                  title={
+                    isFinalizing ? "Finalizing previous recording…" : undefined
+                  }
+                >
+                  {isRecording ? (
+                    <div
+                      className="w-5 h-5 rounded-[3px]"
+                      style={{ background: "var(--rec)" }}
+                    />
+                  ) : (
+                    <div
+                      className="w-6 h-6 rounded-full"
+                      style={{ background: "var(--rec)" }}
+                    />
+                  )}
+                </button>
+              ) : (
+                // Non-host: passive indicator. Guests must not be able to
+                // start or stop the room recording (issue #74). They still
+                // see the elapsed time + upload progress below so they know
+                // their local capture is in sync with the host's lifecycle.
+                <div
+                  role="status"
+                  aria-label={isRecording ? "Recording in progress" : "Idle"}
+                  className={`w-[60px] h-[60px] rounded-full flex items-center justify-center border-2 ${
+                    isRecording ? "rec-ring" : ""
+                  }`}
+                  style={{
+                    background: isRecording ? "rgba(232,80,80,0.1)" : "var(--card)",
+                    borderColor: isRecording ? "var(--rec)" : "var(--border)",
+                    opacity: isRecording ? 1 : 0.6,
+                    transition: "all 200ms ease",
+                  }}
+                >
                   <div
                     className="w-6 h-6 rounded-full"
-                    style={{ background: "var(--rec)" }}
+                    style={{
+                      background: isRecording ? "var(--rec)" : "var(--text-3)",
+                      opacity: isRecording ? 1 : 0.4,
+                    }}
                   />
-                )}
-              </button>
+                </div>
+              )}
             </div>
             <span
               className="font-mono text-[10px] font-medium tracking-[0.08em] text-center"
@@ -1341,8 +1411,12 @@ function RoomContent({
               {isFinalizing
                 ? "FINALIZING…"
                 : isRecording
-                ? "STOP"
-                : "REC"}
+                ? isHost
+                  ? "STOP"
+                  : "REC"
+                : isHost
+                ? "REC"
+                : "IDLE"}
             </span>
             <div
               className="font-mono text-[13px] tracking-[0.06em]"
@@ -1356,6 +1430,11 @@ function RoomContent({
             {isFinalizing && (
               <span className="font-sans text-[10px] text-text-3 text-center px-2 max-w-[100px] leading-tight">
                 Finalizing previous recording…
+              </span>
+            )}
+            {!isHost && (
+              <span className="font-sans text-[10px] text-text-3 text-center px-2 max-w-[100px] leading-tight">
+                Host controls recording
               </span>
             )}
           </div>

--- a/src/lib/transport/index.ts
+++ b/src/lib/transport/index.ts
@@ -17,6 +17,8 @@ export type {
   Transport,
   TransportEvents,
 } from "./types";
+export type { ParticipantRole } from "./participant-role";
+export { isHostSender, parseParticipantRole } from "./participant-role";
 export { useTransport } from "./use-transport";
 
 /**

--- a/src/lib/transport/livekit-transport.ts
+++ b/src/lib/transport/livekit-transport.ts
@@ -151,7 +151,10 @@ export class LiveKitTransport implements Transport {
   }
 
   onControlMessage(
-    handler: (msg: ControlMessage, fromParticipant: string) => void,
+    handler: (
+      msg: ControlMessage,
+      sender: { identity: string; metadata?: string },
+    ) => void,
   ): () => void {
     const fn = (
       payload: Uint8Array,
@@ -172,7 +175,10 @@ export class LiveKitTransport implements Transport {
         console.warn("onControlMessage: ignoring invalid control message", raw);
         return;
       }
-      handler(parsed, participant?.identity ?? "");
+      handler(parsed, {
+        identity: participant?.identity ?? "",
+        metadata: participant?.metadata,
+      });
     };
     this.room.on(RoomEvent.DataReceived, fn);
     return () => {

--- a/src/lib/transport/participant-role.ts
+++ b/src/lib/transport/participant-role.ts
@@ -1,0 +1,40 @@
+// Helpers for reading the participant role that the LiveKit token route
+// stamps into `participant.metadata`. Pure functions so they can be unit
+// tested without spinning up a Room.
+//
+// The trust model: LiveKit token metadata is signed server-side with
+// LIVEKIT_API_SECRET (see src/app/api/livekit-token/route.ts). A guest
+// cannot mint a token claiming role: "host" without the secret, so when
+// `participant.metadata` parses to `{ role: "host" }` we trust it.
+
+export type ParticipantRole = "host" | "guest";
+
+/**
+ * Parse the participant role from a LiveKit metadata string.
+ * Returns null if the metadata is missing or unparseable, or if the role
+ * value isn't one we recognize.
+ */
+export function parseParticipantRole(
+  metadata: string | undefined,
+): ParticipantRole | null {
+  if (!metadata) return null;
+  try {
+    const obj = JSON.parse(metadata) as unknown;
+    if (obj === null || typeof obj !== "object") return null;
+    const role = (obj as Record<string, unknown>).role;
+    if (role === "host" || role === "guest") return role;
+    return null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Whether a control message from a participant with the given metadata should
+ * be honored. Host-only control messages (recording_start, recording_stop) are
+ * accepted only when the sender's metadata parses to role: "host". Unknown or
+ * missing roles are rejected.
+ */
+export function isHostSender(metadata: string | undefined): boolean {
+  return parseParticipantRole(metadata) === "host";
+}

--- a/src/lib/transport/types.ts
+++ b/src/lib/transport/types.ts
@@ -57,9 +57,18 @@ export interface Transport {
 
   /**
    * Subscribe to control messages from other participants.
-   * Returns an unsubscribe function. The sender identity is passed so handlers
-   * can distinguish echoes of their own messages (though LiveKit's data channel
-   * does not echo to the sender — idempotency should still be enforced by state).
+   * Returns an unsubscribe function. The sender's identity and (optional)
+   * room-level metadata are passed so handlers can distinguish echoes of
+   * their own messages (though LiveKit's data channel does not echo to the
+   * sender — idempotency should still be enforced by state) and verify
+   * sender role for host-only messages. Metadata is whatever string the
+   * server stamped onto the participant's token; in cozytrack that's a JSON
+   * blob like `{"role":"host"}`. See src/lib/transport/participant-role.ts.
    */
-  onControlMessage(handler: (msg: ControlMessage, fromParticipant: string) => void): () => void;
+  onControlMessage(
+    handler: (
+      msg: ControlMessage,
+      sender: { identity: string; metadata?: string },
+    ) => void,
+  ): () => void;
 }

--- a/tests/participant-role.test.ts
+++ b/tests/participant-role.test.ts
@@ -1,0 +1,66 @@
+import { describe, it, expect } from "vitest";
+import {
+  isHostSender,
+  parseParticipantRole,
+} from "../src/lib/transport/participant-role";
+
+describe("parseParticipantRole", () => {
+  it("returns 'host' when metadata declares role: host", () => {
+    expect(parseParticipantRole(JSON.stringify({ role: "host" }))).toBe("host");
+  });
+
+  it("returns 'guest' when metadata declares role: guest", () => {
+    expect(parseParticipantRole(JSON.stringify({ role: "guest" }))).toBe(
+      "guest",
+    );
+  });
+
+  it("returns null for unknown role values", () => {
+    expect(parseParticipantRole(JSON.stringify({ role: "admin" }))).toBeNull();
+    expect(parseParticipantRole(JSON.stringify({ role: 42 }))).toBeNull();
+  });
+
+  it("returns null when metadata is missing", () => {
+    expect(parseParticipantRole(undefined)).toBeNull();
+    expect(parseParticipantRole("")).toBeNull();
+  });
+
+  it("returns null for unparseable JSON", () => {
+    expect(parseParticipantRole("not-json")).toBeNull();
+  });
+
+  it("returns null when JSON parses to a non-object", () => {
+    expect(parseParticipantRole(JSON.stringify("host"))).toBeNull();
+    expect(parseParticipantRole(JSON.stringify(null))).toBeNull();
+    expect(parseParticipantRole(JSON.stringify(["host"]))).toBeNull();
+  });
+
+  it("ignores extra fields", () => {
+    expect(
+      parseParticipantRole(JSON.stringify({ role: "host", extra: "x" })),
+    ).toBe("host");
+  });
+});
+
+describe("isHostSender", () => {
+  it("accepts senders whose metadata declares role: host", () => {
+    expect(isHostSender(JSON.stringify({ role: "host" }))).toBe(true);
+  });
+
+  it("rejects guest senders", () => {
+    expect(isHostSender(JSON.stringify({ role: "guest" }))).toBe(false);
+  });
+
+  it("rejects senders with no metadata (no token claim)", () => {
+    expect(isHostSender(undefined)).toBe(false);
+    expect(isHostSender("")).toBe(false);
+  });
+
+  it("rejects senders with malformed metadata", () => {
+    // A malicious guest could try to spoof by sending malformed JSON. The
+    // parser must reject — the trust boundary is the LiveKit-signed token,
+    // not the data-channel payload.
+    expect(isHostSender("{bogus")).toBe(false);
+    expect(isHostSender(JSON.stringify({ role: "HOST" }))).toBe(false);
+  });
+});


### PR DESCRIPTION
Closes #74.

## Summary

- Stamp the principal's role (`host` / `guest`) into LiveKit token metadata so receivers can verify the sender of a control message.
- Studio rejects `recording_start` / `recording_stop` data-channel messages from non-host senders. Forging this requires forging a LiveKit token, which requires `LIVEKIT_API_SECRET`.
- Hide the record button for non-host participants and replace it with a passive recording indicator. Guests still see the active state, elapsed time, and upload progress for their own local capture.
- Add synchronous `startingRef` / `stoppingRef` guards on the host's click handlers. The previous guards lived behind an `await transport.sendControlMessage(...)`, leaving a window where a rapid second click could pass every check; these refs close that window without depending on async React state.
- Tests cover the role parser and host-only guard at the pure-logic boundary (`tests/participant-role.test.ts`).

## Trust model

Token metadata is signed with `LIVEKIT_API_SECRET` server-side. A guest cannot forge a token claiming `role: "host"` without the secret, so honoring `participant.metadata` at the room edge is sufficient for this scope. Server-owned recording lifecycle (full enforcement) remains scoped to #60.

## Test plan

- [ ] As host: rapid double-clicks on Record produce one recording lifecycle.
- [ ] As host: clicking Record then Stop works as before.
- [ ] As guest: no Record button is visible; passive "Recording" indicator appears when host starts.
- [ ] Forge a `recording_start` from a guest tab via devtools → host/other guests log a warning and ignore it.
- [ ] `npm test` passes (61 → 74 tests).


---
_Generated by [Claude Code](https://claude.ai/code/session_014dJsMpcsQVX4NJ138qhHDv)_