### PR TITLE
[codex] Add ingest purge flow for S3 recordings

### DIFF
--- a/README.md
+++ b/README.md
@@ -211,6 +211,17 @@ External ingest tools (e.g. podline's `sd ct-ingest`) hit a separate `/api/inges
 
 Long-term plan: this scheme gets replaced by podflow-as-IdP (see `pashafateev/podflow#11`, `pashafateev/cozytrack#36`, `pashafateev/cozytrack#37`). The JWT primitive stays; only the token issuer changes.
 
+## Ingest cleanup
+
+After a downstream processor has downloaded and processed a ready session, it can purge raw recording files:
+
+```http
+POST /api/ingest/sessions/:id/purge-files
+X-API-Key: <COZYTRACK_API_KEY>
+```
+
+The purge deletes all S3 objects under `sessions/<id>/` and stamps `s3PurgedAt` on that session's tracks. Repeated calls for already-purged sessions are safe. Browser and ingest track download endpoints return `410 Gone` for purged tracks.
+
 ## Finishing a recording
 
 When a recorder is done capturing in the studio:

--- a/prisma/migrations/20260510000000_add_track_s3_purged_at/migration.sql
+++ b/prisma/migrations/20260510000000_add_track_s3_purged_at/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "Track" ADD COLUMN "s3PurgedAt" TIMESTAMP(3);

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -31,6 +31,7 @@ model Track {
   durationMs      Int?
   format          String   @default("webm")
   status          String   @default("recording") // recording | uploading | complete | failed
+  s3PurgedAt      DateTime?
   deviceLabel     String?
   deviceId        String?
   isBuiltInMic    Boolean  @default(false)

--- a/src/app/api/ingest/sessions/[id]/purge-files/route.ts
+++ b/src/app/api/ingest/sessions/[id]/purge-files/route.ts
@@ -1,0 +1,89 @@
+import { NextRequest, NextResponse } from "next/server";
+import { db } from "@/lib/db";
+import { deleteSessionObjects } from "@/lib/s3";
+
+function latestPurgedAt(
+  tracks: Array<{ s3PurgedAt: Date | null }>
+): Date | null {
+  return tracks.reduce<Date | null>((latest, track) => {
+    if (!track.s3PurgedAt) {
+      return latest;
+    }
+
+    if (!latest || track.s3PurgedAt > latest) {
+      return track.s3PurgedAt;
+    }
+
+    return latest;
+  }, null);
+}
+
+export async function POST(
+  _req: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  try {
+    const { id } = await params;
+
+    const session = await db.session.findUnique({
+      where: { id },
+      include: {
+        tracks: {
+          select: {
+            id: true,
+            s3PurgedAt: true,
+          },
+        },
+      },
+    });
+
+    if (!session) {
+      return NextResponse.json(
+        { error: "Session not found" },
+        { status: 404 }
+      );
+    }
+
+    if (session.status !== "ready") {
+      return NextResponse.json(
+        { error: "Session is not ready" },
+        { status: 409 }
+      );
+    }
+
+    const purgedTracks = session.tracks.length;
+    const existingPurgedAt = latestPurgedAt(session.tracks);
+    const alreadyPurged =
+      purgedTracks > 0 && session.tracks.every((track) => track.s3PurgedAt);
+
+    if (alreadyPurged && existingPurgedAt) {
+      return NextResponse.json({
+        sessionId: id,
+        deletedObjects: 0,
+        purgedTracks,
+        s3PurgedAt: existingPurgedAt,
+      });
+    }
+
+    const deletedObjects = await deleteSessionObjects(id);
+    const s3PurgedAt = new Date();
+
+    await db.track.updateMany({
+      where: { sessionId: id },
+      data: { s3PurgedAt },
+    });
+
+    return NextResponse.json({
+      sessionId: id,
+      deletedObjects,
+      purgedTracks,
+      s3PurgedAt,
+    });
+  } catch (error) {
+    console.error("Failed to purge session files:", error);
+    return NextResponse.json(
+      { error: "Failed to purge session files" },
+      { status: 500 }
+    );
+  }
+}

--- a/src/app/api/ingest/sessions/[id]/purge-files/route.ts
+++ b/src/app/api/ingest/sessions/[id]/purge-files/route.ts
@@ -51,16 +51,16 @@ export async function POST(
       );
     }
 
-    const purgedTracks = session.tracks.length;
     const existingPurgedAt = latestPurgedAt(session.tracks);
     const alreadyPurged =
-      purgedTracks > 0 && session.tracks.every((track) => track.s3PurgedAt);
+      session.tracks.length > 0 &&
+      session.tracks.every((track) => track.s3PurgedAt);
 
     if (alreadyPurged && existingPurgedAt) {
       return NextResponse.json({
         sessionId: id,
         deletedObjects: 0,
-        purgedTracks,
+        purgedTracks: 0,
         s3PurgedAt: existingPurgedAt,
       });
     }
@@ -68,15 +68,15 @@ export async function POST(
     const deletedObjects = await deleteSessionObjects(id);
     const s3PurgedAt = new Date();
 
-    await db.track.updateMany({
-      where: { sessionId: id },
+    const updateResult = await db.track.updateMany({
+      where: { sessionId: id, s3PurgedAt: null },
       data: { s3PurgedAt },
     });
 
     return NextResponse.json({
       sessionId: id,
       deletedObjects,
-      purgedTracks,
+      purgedTracks: updateResult.count,
       s3PurgedAt,
     });
   } catch (error) {

--- a/src/app/api/ingest/tracks/[id]/download/route.ts
+++ b/src/app/api/ingest/tracks/[id]/download/route.ts
@@ -20,6 +20,13 @@ export async function GET(
       );
     }
 
+    if (track.s3PurgedAt) {
+      return NextResponse.json(
+        { error: "Track recording has been purged" },
+        { status: 410 }
+      );
+    }
+
     if (!track.s3Key) {
       return NextResponse.json(
         { error: "Track recording not available" },

--- a/src/app/api/tracks/[id]/download/route.ts
+++ b/src/app/api/tracks/[id]/download/route.ts
@@ -27,6 +27,13 @@ export async function GET(
       );
     }
 
+    if (track.s3PurgedAt) {
+      return NextResponse.json(
+        { error: "Track recording has been purged" },
+        { status: 410 }
+      );
+    }
+
     if (!track.s3Key) {
       return NextResponse.json(
         { error: "Track recording not available" },

--- a/src/lib/s3.ts
+++ b/src/lib/s3.ts
@@ -153,32 +153,36 @@ export async function deleteTrackChunks(
   sessionId: string,
   trackId: string
 ): Promise<void> {
-  const prefix = trackPrefix(sessionId, trackId);
-  const finalKey = trackRecordingKey(sessionId, trackId);
-  const chunkKeyPattern = /^\d+\.webm$/;
-  let continuationToken: string | undefined;
+  try {
+    const prefix = trackPrefix(sessionId, trackId);
+    const finalKey = trackRecordingKey(sessionId, trackId);
+    const chunkKeyPattern = /^\d+\.webm$/;
+    let continuationToken: string | undefined;
 
-  do {
-    const response = await s3.send(
-      new ListObjectsV2Command({
-        Bucket: bucket,
-        Prefix: prefix,
-        ContinuationToken: continuationToken,
-      })
-    );
-
-    const keysToDelete = (response.Contents ?? [])
-      .map((object) => object.Key)
-      .filter((key): key is string => Boolean(key))
-      .filter(
-        (key) =>
-          key !== finalKey && chunkKeyPattern.test(key.slice(prefix.length))
+    do {
+      const response = await s3.send(
+        new ListObjectsV2Command({
+          Bucket: bucket,
+          Prefix: prefix,
+          ContinuationToken: continuationToken,
+        })
       );
 
-    await deleteObjects(keysToDelete);
+      const keysToDelete = (response.Contents ?? [])
+        .map((object) => object.Key)
+        .filter((key): key is string => Boolean(key))
+        .filter(
+          (key) =>
+            key !== finalKey && chunkKeyPattern.test(key.slice(prefix.length))
+        );
 
-    continuationToken = response.IsTruncated
-      ? response.NextContinuationToken
-      : undefined;
-  } while (continuationToken);
+      await deleteObjects(keysToDelete);
+
+      continuationToken = response.IsTruncated
+        ? response.NextContinuationToken
+        : undefined;
+    } while (continuationToken);
+  } catch (error) {
+    console.error("Failed to delete track chunks:", error);
+  }
 }

--- a/src/lib/s3.ts
+++ b/src/lib/s3.ts
@@ -76,6 +76,10 @@ export function trackPrefix(sessionId: string, trackId: string): string {
   return `sessions/${sessionId}/tracks/${trackId}/`;
 }
 
+export function sessionPrefix(sessionId: string): string {
+  return `sessions/${sessionId}/`;
+}
+
 export async function getPresignedPutUrl(key: string): Promise<string> {
   const command = new PutObjectCommand({
     Bucket: bucket,
@@ -91,6 +95,58 @@ export async function getPresignedGetUrl(key: string): Promise<string> {
     Key: key,
   });
   return getSignedUrl(s3, command, { expiresIn: 3600 });
+}
+
+async function deleteObjects(keysToDelete: string[]): Promise<void> {
+  if (keysToDelete.length === 0) {
+    return;
+  }
+
+  const response = await s3.send(
+    new DeleteObjectsCommand({
+      Bucket: bucket,
+      Delete: {
+        Objects: keysToDelete.map((Key) => ({ Key })),
+        Quiet: true,
+      },
+    })
+  );
+
+  if (response.Errors && response.Errors.length > 0) {
+    const keys = response.Errors.map((error) => error.Key).filter(Boolean);
+    throw new Error(
+      `Failed to delete S3 objects${keys.length ? `: ${keys.join(", ")}` : ""}`
+    );
+  }
+}
+
+export async function deleteSessionObjects(sessionId: string): Promise<number> {
+  const prefix = sessionPrefix(sessionId);
+  let continuationToken: string | undefined;
+  let deletedObjects = 0;
+
+  do {
+    const response = await s3.send(
+      new ListObjectsV2Command({
+        Bucket: bucket,
+        Prefix: prefix,
+        ContinuationToken: continuationToken,
+      })
+    );
+
+    const keysToDelete = (response.Contents ?? [])
+      .map((object) => object.Key)
+      .filter((key): key is string => Boolean(key));
+
+    await deleteObjects(keysToDelete);
+    deletedObjects += keysToDelete.length;
+
+    continuationToken = response.IsTruncated
+      ? response.NextContinuationToken
+      : undefined;
+  } while (continuationToken);
+
+  return deletedObjects;
 }
 
 export async function deleteTrackChunks(
@@ -119,17 +175,7 @@ export async function deleteTrackChunks(
           key !== finalKey && chunkKeyPattern.test(key.slice(prefix.length))
       );
 
-    if (keysToDelete.length > 0) {
-      await s3.send(
-        new DeleteObjectsCommand({
-          Bucket: bucket,
-          Delete: {
-            Objects: keysToDelete.map((Key) => ({ Key })),
-            Quiet: true,
-          },
-        })
-      );
-    }
+    await deleteObjects(keysToDelete);
 
     continuationToken = response.IsTruncated
       ? response.NextContinuationToken

--- a/tests/download-routes.test.ts
+++ b/tests/download-routes.test.ts
@@ -1,0 +1,87 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+
+type Track = {
+  id: string;
+  s3Key: string;
+  s3PurgedAt: Date | null;
+};
+
+const mocks = vi.hoisted(() => ({
+  trackStore: new Map<string, Track>(),
+  getPresignedGetUrl: vi.fn(async () => "https://example.com/download"),
+  verifyHostCookie: vi.fn(async () => ({ kind: "host" })),
+}));
+
+vi.mock("@/lib/db", () => ({
+  db: {
+    track: {
+      findUnique: vi.fn(
+        async ({ where: { id } }: { where: { id: string } }) => {
+          const track = mocks.trackStore.get(id);
+          return track ? { ...track } : null;
+        },
+      ),
+    },
+  },
+}));
+
+vi.mock("@/lib/s3", () => ({
+  getPresignedGetUrl: mocks.getPresignedGetUrl,
+}));
+
+vi.mock("@/lib/auth", () => ({
+  AUTH_COOKIES: { host: "ct_host" },
+  verifyHostCookie: mocks.verifyHostCookie,
+}));
+
+import { NextRequest } from "next/server";
+import { GET as browserDownload } from "@/app/api/tracks/[id]/download/route";
+import { GET as ingestDownload } from "@/app/api/ingest/tracks/[id]/download/route";
+
+function req(path: string): NextRequest {
+  return new NextRequest(`http://localhost:3001${path}`);
+}
+
+beforeEach(() => {
+  mocks.trackStore.clear();
+  vi.clearAllMocks();
+});
+
+describe("track download routes", () => {
+  it("returns 410 for purged browser downloads", async () => {
+    mocks.trackStore.set("t1", {
+      id: "t1",
+      s3Key: "sessions/s1/tracks/t1/recording.webm",
+      s3PurgedAt: new Date("2026-05-10T12:00:00.000Z"),
+    });
+
+    const res = await browserDownload(req("/api/tracks/t1/download"), {
+      params: Promise.resolve({ id: "t1" }),
+    });
+
+    expect(res.status).toBe(410);
+    const body = (await res.json()) as { error: string };
+    expect(body.error).toBe("Track recording has been purged");
+    expect(mocks.getPresignedGetUrl).not.toHaveBeenCalled();
+  });
+
+  it("returns 410 for purged ingest downloads", async () => {
+    mocks.trackStore.set("t2", {
+      id: "t2",
+      s3Key: "sessions/s1/tracks/t2/recording.webm",
+      s3PurgedAt: new Date("2026-05-10T12:00:00.000Z"),
+    });
+
+    const res = await ingestDownload(
+      req("/api/ingest/tracks/t2/download"),
+      {
+        params: Promise.resolve({ id: "t2" }),
+      },
+    );
+
+    expect(res.status).toBe(410);
+    const body = (await res.json()) as { error: string };
+    expect(body.error).toBe("Track recording has been purged");
+    expect(mocks.getPresignedGetUrl).not.toHaveBeenCalled();
+  });
+});

--- a/tests/purge-files.test.ts
+++ b/tests/purge-files.test.ts
@@ -1,0 +1,210 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+
+type Track = {
+  id: string;
+  s3PurgedAt: Date | null;
+};
+
+type Session = {
+  id: string;
+  name: string;
+  status: string;
+  tracks: Track[];
+};
+
+const mocks = vi.hoisted(() => ({
+  sessionStore: new Map<string, Session>(),
+  deleteSessionObjects: vi.fn(),
+}));
+
+function cloneSession(session: Session): Session {
+  return {
+    ...session,
+    tracks: session.tracks.map((track) => ({ ...track })),
+  };
+}
+
+vi.mock("@/lib/db", () => ({
+  db: {
+    session: {
+      findUnique: vi.fn(
+        async ({ where: { id } }: { where: { id: string } }) => {
+          const session = mocks.sessionStore.get(id);
+          return session ? cloneSession(session) : null;
+        },
+      ),
+    },
+    track: {
+      updateMany: vi.fn(
+        async ({
+          where,
+          data,
+        }: {
+          where: { sessionId: string };
+          data: { s3PurgedAt: Date };
+        }) => {
+          const session = mocks.sessionStore.get(where.sessionId);
+          if (!session) {
+            return { count: 0 };
+          }
+
+          for (const track of session.tracks) {
+            track.s3PurgedAt = data.s3PurgedAt;
+          }
+
+          return { count: session.tracks.length };
+        },
+      ),
+    },
+  },
+}));
+
+vi.mock("@/lib/s3", () => ({
+  deleteSessionObjects: mocks.deleteSessionObjects,
+}));
+
+import { NextRequest } from "next/server";
+import { POST } from "@/app/api/ingest/sessions/[id]/purge-files/route";
+
+function req(sessionId: string): NextRequest {
+  return new NextRequest(
+    `http://localhost:3001/api/ingest/sessions/${sessionId}/purge-files`,
+    { method: "POST" },
+  );
+}
+
+async function updateManyMock() {
+  const { db } = (await import("@/lib/db")) as unknown as {
+    db: {
+      track: {
+        updateMany: ReturnType<typeof vi.fn>;
+      };
+    };
+  };
+  return db.track.updateMany;
+}
+
+beforeEach(() => {
+  mocks.sessionStore.clear();
+  vi.clearAllMocks();
+  mocks.deleteSessionObjects.mockResolvedValue(0);
+});
+
+describe("POST /api/ingest/sessions/[id]/purge-files", () => {
+  it("returns 404 when the session does not exist", async () => {
+    const res = await POST(req("missing"), {
+      params: Promise.resolve({ id: "missing" }),
+    });
+
+    expect(res.status).toBe(404);
+    expect(mocks.deleteSessionObjects).not.toHaveBeenCalled();
+  });
+
+  it("returns 409 when the session is not ready", async () => {
+    mocks.sessionStore.set("s1", {
+      id: "s1",
+      name: "demo",
+      status: "recording",
+      tracks: [{ id: "t1", s3PurgedAt: null }],
+    });
+
+    const res = await POST(req("s1"), {
+      params: Promise.resolve({ id: "s1" }),
+    });
+
+    expect(res.status).toBe(409);
+    const body = (await res.json()) as { error: string };
+    expect(body.error).toBe("Session is not ready");
+    expect(mocks.deleteSessionObjects).not.toHaveBeenCalled();
+  });
+
+  it("deletes session objects and marks all tracks as purged", async () => {
+    mocks.deleteSessionObjects.mockResolvedValueOnce(4);
+    mocks.sessionStore.set("s2", {
+      id: "s2",
+      name: "demo",
+      status: "ready",
+      tracks: [
+        { id: "t1", s3PurgedAt: null },
+        { id: "t2", s3PurgedAt: null },
+      ],
+    });
+
+    const before = Date.now();
+    const res = await POST(req("s2"), {
+      params: Promise.resolve({ id: "s2" }),
+    });
+
+    expect(res.status).toBe(200);
+    expect(mocks.deleteSessionObjects).toHaveBeenCalledWith("s2");
+
+    const body = (await res.json()) as {
+      sessionId: string;
+      deletedObjects: number;
+      purgedTracks: number;
+      s3PurgedAt: string;
+    };
+    expect(body.sessionId).toBe("s2");
+    expect(body.deletedObjects).toBe(4);
+    expect(body.purgedTracks).toBe(2);
+    expect(new Date(body.s3PurgedAt).getTime()).toBeGreaterThanOrEqual(before);
+
+    const purgedAtValues = mocks.sessionStore
+      .get("s2")!
+      .tracks.map((track) => track.s3PurgedAt?.toISOString());
+    expect(purgedAtValues[0]).toBe(body.s3PurgedAt);
+    expect(purgedAtValues[1]).toBe(body.s3PurgedAt);
+  });
+
+  it("is idempotent when all tracks are already purged", async () => {
+    const s3PurgedAt = new Date("2026-05-10T12:00:00.000Z");
+    mocks.sessionStore.set("s3", {
+      id: "s3",
+      name: "demo",
+      status: "ready",
+      tracks: [
+        { id: "t1", s3PurgedAt },
+        { id: "t2", s3PurgedAt },
+      ],
+    });
+
+    const res = await POST(req("s3"), {
+      params: Promise.resolve({ id: "s3" }),
+    });
+
+    expect(res.status).toBe(200);
+    expect(mocks.deleteSessionObjects).not.toHaveBeenCalled();
+    expect(await updateManyMock()).not.toHaveBeenCalled();
+
+    const body = (await res.json()) as {
+      sessionId: string;
+      deletedObjects: number;
+      purgedTracks: number;
+      s3PurgedAt: string;
+    };
+    expect(body).toEqual({
+      sessionId: "s3",
+      deletedObjects: 0,
+      purgedTracks: 2,
+      s3PurgedAt: s3PurgedAt.toISOString(),
+    });
+  });
+
+  it("does not write purge timestamps when S3 deletion fails", async () => {
+    mocks.deleteSessionObjects.mockRejectedValueOnce(new Error("S3 failed"));
+    mocks.sessionStore.set("s4", {
+      id: "s4",
+      name: "demo",
+      status: "ready",
+      tracks: [{ id: "t1", s3PurgedAt: null }],
+    });
+
+    const res = await POST(req("s4"), {
+      params: Promise.resolve({ id: "s4" }),
+    });
+
+    expect(res.status).toBe(500);
+    expect(mocks.sessionStore.get("s4")!.tracks[0].s3PurgedAt).toBeNull();
+    expect(await updateManyMock()).not.toHaveBeenCalled();
+  });
+});

--- a/tests/purge-files.test.ts
+++ b/tests/purge-files.test.ts
@@ -40,7 +40,7 @@ vi.mock("@/lib/db", () => ({
           where,
           data,
         }: {
-          where: { sessionId: string };
+          where: { sessionId: string; s3PurgedAt?: null };
           data: { s3PurgedAt: Date };
         }) => {
           const session = mocks.sessionStore.get(where.sessionId);
@@ -48,11 +48,17 @@ vi.mock("@/lib/db", () => ({
             return { count: 0 };
           }
 
+          let count = 0;
           for (const track of session.tracks) {
+            if (where.s3PurgedAt === null && track.s3PurgedAt !== null) {
+              continue;
+            }
+
             track.s3PurgedAt = data.s3PurgedAt;
+            count += 1;
           }
 
-          return { count: session.tracks.length };
+          return { count };
         },
       ),
     },
@@ -185,8 +191,45 @@ describe("POST /api/ingest/sessions/[id]/purge-files", () => {
     expect(body).toEqual({
       sessionId: "s3",
       deletedObjects: 0,
-      purgedTracks: 2,
+      purgedTracks: 0,
       s3PurgedAt: s3PurgedAt.toISOString(),
+    });
+  });
+
+  it("preserves existing purge timestamps when only some tracks are unpurged", async () => {
+    mocks.deleteSessionObjects.mockResolvedValueOnce(1);
+    const existingPurgedAt = new Date("2026-05-10T12:00:00.000Z");
+    mocks.sessionStore.set("s5", {
+      id: "s5",
+      name: "demo",
+      status: "ready",
+      tracks: [
+        { id: "t1", s3PurgedAt: existingPurgedAt },
+        { id: "t2", s3PurgedAt: null },
+      ],
+    });
+
+    const res = await POST(req("s5"), {
+      params: Promise.resolve({ id: "s5" }),
+    });
+
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as {
+      deletedObjects: number;
+      purgedTracks: number;
+      s3PurgedAt: string;
+    };
+    expect(body.deletedObjects).toBe(1);
+    expect(body.purgedTracks).toBe(1);
+
+    const tracks = mocks.sessionStore.get("s5")!.tracks;
+    expect(tracks[0].s3PurgedAt?.toISOString()).toBe(
+      existingPurgedAt.toISOString(),
+    );
+    expect(tracks[1].s3PurgedAt?.toISOString()).toBe(body.s3PurgedAt);
+    expect(await updateManyMock()).toHaveBeenCalledWith({
+      where: { sessionId: "s5", s3PurgedAt: null },
+      data: { s3PurgedAt: expect.any(Date) },
     });
   });
 

--- a/tests/s3-delete.test.ts
+++ b/tests/s3-delete.test.ts
@@ -1,0 +1,71 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  send: vi.fn(),
+  consoleError: vi.spyOn(console, "error").mockImplementation(() => {}),
+}));
+
+vi.mock("@aws-sdk/client-s3", () => ({
+  S3Client: vi.fn(function S3Client() {
+    return { send: mocks.send };
+  }),
+  PutObjectCommand: vi.fn(function PutObjectCommand(input) {
+    return { input, type: "PutObjectCommand" };
+  }),
+  GetObjectCommand: vi.fn(function GetObjectCommand(input) {
+    return { input, type: "GetObjectCommand" };
+  }),
+  ListObjectsV2Command: vi.fn(function ListObjectsV2Command(input) {
+    return { input, type: "ListObjectsV2Command" };
+  }),
+  DeleteObjectsCommand: vi.fn(function DeleteObjectsCommand(input) {
+    return { input, type: "DeleteObjectsCommand" };
+  }),
+}));
+
+vi.mock("@aws-sdk/s3-request-presigner", () => ({
+  getSignedUrl: vi.fn(),
+}));
+
+import { deleteSessionObjects, deleteTrackChunks } from "@/lib/s3";
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("S3 deletion helpers", () => {
+  it("keeps track chunk cleanup best-effort when S3 delete reports errors", async () => {
+    mocks.send
+      .mockResolvedValueOnce({
+        Contents: [
+          { Key: "sessions/s1/tracks/t1/1.webm" },
+          { Key: "sessions/s1/tracks/t1/recording.webm" },
+        ],
+        IsTruncated: false,
+      })
+      .mockResolvedValueOnce({
+        Errors: [{ Key: "sessions/s1/tracks/t1/1.webm" }],
+      });
+
+    await expect(deleteTrackChunks("s1", "t1")).resolves.toBeUndefined();
+    expect(mocks.consoleError).toHaveBeenCalledWith(
+      "Failed to delete track chunks:",
+      expect.any(Error),
+    );
+  });
+
+  it("keeps session purge deletion strict when S3 delete reports errors", async () => {
+    mocks.send
+      .mockResolvedValueOnce({
+        Contents: [{ Key: "sessions/s1/tracks/t1/recording.webm" }],
+        IsTruncated: false,
+      })
+      .mockResolvedValueOnce({
+        Errors: [{ Key: "sessions/s1/tracks/t1/recording.webm" }],
+      });
+
+    await expect(deleteSessionObjects("s1")).rejects.toThrow(
+      "Failed to delete S3 objects: sessions/s1/tracks/t1/recording.webm",
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- add `Track.s3PurgedAt` with a Prisma migration
- add `POST /api/ingest/sessions/:id/purge-files` for ready-session S3 cleanup
- return `410 Gone` for purged track downloads from browser and ingest routes
- document the ingest cleanup endpoint

## Validation
- `npm test -- tests/purge-files.test.ts tests/download-routes.test.ts`
- `npm test`
- `npm run build`