### PR TITLE
[codex] Add historical S3 cleanup scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -222,6 +222,17 @@ X-API-Key: <COZYTRACK_API_KEY>
 
 The purge deletes all S3 objects under `sessions/<id>/` and stamps `s3PurgedAt` on that session's tracks. Repeated calls for already-purged sessions are safe. Browser and ingest track download endpoints return `410 Gone` for purged tracks.
 
+For historical cleanup, use dry-run scripts first:
+
+```sh
+npm run purge:ready -- --base-url https://<app-host>
+npm run purge:orphans
+```
+
+`purge:ready` finds ready DB sessions with unpurged tracks and calls the purge endpoint when rerun with `--yes`. `purge:orphans` compares `sessions/<id>/` S3 prefixes against DB `Session.id` rows and deletes only S3-only prefixes when rerun with `--yes`. For bucket names that do not include `dev`, `local`, or `test`, orphan deletion also requires `--allow-production-bucket`.
+
+Both scripts load `.env` and `.env.local`. `purge:ready` needs DB access for discovery plus `COZYTRACK_API_KEY` and `--base-url`/`COZYTRACK_PURGE_BASE_URL` when using `--yes`. `purge:orphans` needs DB access plus the S3 env vars.
+
 ## Finishing a recording
 
 When a recorder is done capturing in the studio:

--- a/package.json
+++ b/package.json
@@ -10,6 +10,8 @@
     "dev:local": "bash ./scripts/dev-local.sh",
     "init:local": "npm run reset:local && npm run dev",
     "reset:local": "bash ./scripts/reset-local.sh",
+    "purge:ready": "node scripts/purge-ready-sessions.mjs",
+    "purge:orphans": "node scripts/purge-orphan-s3-sessions.mjs",
     "build": "next build",
     "vercel-build": "if [ \"$VERCEL_ENV\" = \"production\" ]; then prisma migrate deploy; fi && next build",
     "start": "next start",

--- a/scripts/purge-orphan-s3-sessions.mjs
+++ b/scripts/purge-orphan-s3-sessions.mjs
@@ -1,54 +1,18 @@
 #!/usr/bin/env node
 
-import fs from "node:fs";
 import { PrismaClient } from "@prisma/client";
 import {
   DeleteObjectsCommand,
   ListObjectsV2Command,
   S3Client,
 } from "@aws-sdk/client-s3";
+import {
+  loadEnv,
+  parsePositiveInteger,
+  readOptionValue,
+} from "./script-utils.mjs";
 
-function loadEnvFile(path, { override = false } = {}) {
-  if (!fs.existsSync(path)) {
-    return;
-  }
-
-  const lines = fs.readFileSync(path, "utf8").split(/\r?\n/);
-  for (const line of lines) {
-    const trimmed = line.trim();
-    if (!trimmed || trimmed.startsWith("#")) {
-      continue;
-    }
-
-    const match = trimmed.match(/^([A-Za-z_][A-Za-z0-9_]*)=(.*)$/);
-    if (!match) {
-      continue;
-    }
-
-    const [, key, rawValue] = match;
-    if (!override && process.env[key] !== undefined) {
-      continue;
-    }
-
-    let value = rawValue.trim();
-    if (
-      (value.startsWith('"') && value.endsWith('"')) ||
-      (value.startsWith("'") && value.endsWith("'"))
-    ) {
-      value = value.slice(1, -1);
-    }
-
-    process.env[key] = value;
-  }
-}
-
-function loadEnv() {
-  loadEnvFile(".env");
-  loadEnvFile(".env.local", { override: true });
-  if (!process.env.DIRECT_DATABASE_URL && process.env.DATABASE_URL) {
-    process.env.DIRECT_DATABASE_URL = process.env.DATABASE_URL;
-  }
-}
+const DB_LOOKUP_BATCH_SIZE = 500;
 
 function usage() {
   console.log(`Usage: node scripts/purge-orphan-s3-sessions.mjs [options]
@@ -78,11 +42,8 @@ function parseArgs(argv) {
     } else if (arg === "--allow-production-bucket") {
       options.allowProductionBucket = true;
     } else if (arg === "--limit") {
-      const limit = Number(argv[++i]);
-      if (!Number.isInteger(limit) || limit < 1) {
-        throw new Error("--limit must be a positive integer");
-      }
-      options.limit = limit;
+      options.limit = parsePositiveInteger(readOptionValue(argv, i, arg), arg);
+      i += 1;
     } else if (arg === "--help" || arg === "-h") {
       options.help = true;
     } else {
@@ -128,7 +89,7 @@ function buildS3ClientConfig() {
 }
 
 function isProtectedBucketName(bucket) {
-  return !/(dev|local|test)/i.test(bucket);
+  return !/(^|[.-])(dev|local|test)([.-]|$)/i.test(bucket);
 }
 
 function sessionIdFromPrefix(prefix) {
@@ -165,11 +126,24 @@ async function listSessionPrefixes({ s3, bucket }) {
 }
 
 async function getExistingSessionIds({ prisma, sessionIds }) {
-  const rows = await prisma.session.findMany({
-    where: { id: { in: sessionIds } },
-    select: { id: true },
-  });
-  return new Set(rows.map((row) => row.id));
+  const existingSessionIds = new Set();
+
+  for (let index = 0; index < sessionIds.length; index += DB_LOOKUP_BATCH_SIZE) {
+    const batch = sessionIds.slice(index, index + DB_LOOKUP_BATCH_SIZE);
+    if (batch.length === 0) {
+      continue;
+    }
+
+    const rows = await prisma.session.findMany({
+      where: { id: { in: batch } },
+      select: { id: true },
+    });
+    for (const row of rows) {
+      existingSessionIds.add(row.id);
+    }
+  }
+
+  return existingSessionIds;
 }
 
 async function deletePrefix({ s3, bucket, prefix }) {
@@ -258,7 +232,10 @@ async function main() {
   try {
     const prefixes = await listSessionPrefixes({ s3, bucket });
     const sessionIds = prefixes.map(sessionIdFromPrefix).filter(Boolean);
-    const existingSessionIds = await getExistingSessionIds({ prisma, sessionIds });
+    const existingSessionIds = await getExistingSessionIds({
+      prisma,
+      sessionIds,
+    });
     const orphanPrefixes = prefixes
       .filter((prefix) => {
         const sessionId = sessionIdFromPrefix(prefix);

--- a/scripts/purge-orphan-s3-sessions.mjs
+++ b/scripts/purge-orphan-s3-sessions.mjs
@@ -1,0 +1,302 @@
+#!/usr/bin/env node
+
+import fs from "node:fs";
+import { PrismaClient } from "@prisma/client";
+import {
+  DeleteObjectsCommand,
+  ListObjectsV2Command,
+  S3Client,
+} from "@aws-sdk/client-s3";
+
+function loadEnvFile(path, { override = false } = {}) {
+  if (!fs.existsSync(path)) {
+    return;
+  }
+
+  const lines = fs.readFileSync(path, "utf8").split(/\r?\n/);
+  for (const line of lines) {
+    const trimmed = line.trim();
+    if (!trimmed || trimmed.startsWith("#")) {
+      continue;
+    }
+
+    const match = trimmed.match(/^([A-Za-z_][A-Za-z0-9_]*)=(.*)$/);
+    if (!match) {
+      continue;
+    }
+
+    const [, key, rawValue] = match;
+    if (!override && process.env[key] !== undefined) {
+      continue;
+    }
+
+    let value = rawValue.trim();
+    if (
+      (value.startsWith('"') && value.endsWith('"')) ||
+      (value.startsWith("'") && value.endsWith("'"))
+    ) {
+      value = value.slice(1, -1);
+    }
+
+    process.env[key] = value;
+  }
+}
+
+function loadEnv() {
+  loadEnvFile(".env");
+  loadEnvFile(".env.local", { override: true });
+  if (!process.env.DIRECT_DATABASE_URL && process.env.DATABASE_URL) {
+    process.env.DIRECT_DATABASE_URL = process.env.DATABASE_URL;
+  }
+}
+
+function usage() {
+  console.log(`Usage: node scripts/purge-orphan-s3-sessions.mjs [options]
+
+Deletes S3 session prefixes that have no matching Session row in the DB.
+Dry-run by default.
+
+Options:
+  --yes                       Actually delete objects. Without this, only prints.
+  --allow-production-bucket   Allow deletion when bucket name lacks dev/local/test.
+  --limit <n>                 Limit number of orphan prefixes deleted.
+  --help                      Show this help.
+`);
+}
+
+function parseArgs(argv) {
+  const options = {
+    yes: false,
+    allowProductionBucket: false,
+    limit: undefined,
+  };
+
+  for (let i = 0; i < argv.length; i += 1) {
+    const arg = argv[i];
+    if (arg === "--yes") {
+      options.yes = true;
+    } else if (arg === "--allow-production-bucket") {
+      options.allowProductionBucket = true;
+    } else if (arg === "--limit") {
+      const limit = Number(argv[++i]);
+      if (!Number.isInteger(limit) || limit < 1) {
+        throw new Error("--limit must be a positive integer");
+      }
+      options.limit = limit;
+    } else if (arg === "--help" || arg === "-h") {
+      options.help = true;
+    } else {
+      throw new Error(`Unknown option: ${arg}`);
+    }
+  }
+
+  return options;
+}
+
+function booleanEnv(value) {
+  if (value === undefined) {
+    return undefined;
+  }
+
+  const normalized = value.trim().toLowerCase();
+  if (["1", "true", "yes"].includes(normalized)) {
+    return true;
+  }
+  if (["0", "false", "no"].includes(normalized)) {
+    return false;
+  }
+
+  return undefined;
+}
+
+function buildS3ClientConfig() {
+  const endpoint = process.env.S3_ENDPOINT?.trim() || undefined;
+  const forcePathStyle =
+    booleanEnv(process.env.S3_FORCE_PATH_STYLE) ?? Boolean(endpoint);
+  const config = {
+    region: process.env.AWS_REGION,
+  };
+
+  if (endpoint) {
+    config.endpoint = endpoint;
+  }
+  if (forcePathStyle) {
+    config.forcePathStyle = true;
+  }
+
+  return config;
+}
+
+function isProtectedBucketName(bucket) {
+  return !/(dev|local|test)/i.test(bucket);
+}
+
+function sessionIdFromPrefix(prefix) {
+  const match = prefix.match(/^sessions\/([^/]+)\/$/);
+  return match?.[1];
+}
+
+async function listSessionPrefixes({ s3, bucket }) {
+  const prefixes = [];
+  let continuationToken;
+
+  do {
+    const response = await s3.send(
+      new ListObjectsV2Command({
+        Bucket: bucket,
+        Prefix: "sessions/",
+        Delimiter: "/",
+        ContinuationToken: continuationToken,
+      }),
+    );
+
+    for (const commonPrefix of response.CommonPrefixes ?? []) {
+      if (commonPrefix.Prefix) {
+        prefixes.push(commonPrefix.Prefix);
+      }
+    }
+
+    continuationToken = response.IsTruncated
+      ? response.NextContinuationToken
+      : undefined;
+  } while (continuationToken);
+
+  return prefixes;
+}
+
+async function getExistingSessionIds({ prisma, sessionIds }) {
+  const rows = await prisma.session.findMany({
+    where: { id: { in: sessionIds } },
+    select: { id: true },
+  });
+  return new Set(rows.map((row) => row.id));
+}
+
+async function deletePrefix({ s3, bucket, prefix }) {
+  let continuationToken;
+  let deletedObjects = 0;
+
+  do {
+    const response = await s3.send(
+      new ListObjectsV2Command({
+        Bucket: bucket,
+        Prefix: prefix,
+        ContinuationToken: continuationToken,
+      }),
+    );
+
+    const keys = (response.Contents ?? [])
+      .map((object) => object.Key)
+      .filter(Boolean);
+
+    for (let index = 0; index < keys.length; index += 1000) {
+      const batch = keys.slice(index, index + 1000);
+      if (batch.length === 0) {
+        continue;
+      }
+
+      const deleteResponse = await s3.send(
+        new DeleteObjectsCommand({
+          Bucket: bucket,
+          Delete: {
+            Objects: batch.map((Key) => ({ Key })),
+            Quiet: true,
+          },
+        }),
+      );
+
+      if (deleteResponse.Errors && deleteResponse.Errors.length > 0) {
+        const failedKeys = deleteResponse.Errors.map((error) => error.Key)
+          .filter(Boolean)
+          .join(", ");
+        throw new Error(
+          `Failed to delete objects under ${prefix}${
+            failedKeys ? `: ${failedKeys}` : ""
+          }`,
+        );
+      }
+
+      deletedObjects += batch.length;
+    }
+
+    continuationToken = response.IsTruncated
+      ? response.NextContinuationToken
+      : undefined;
+  } while (continuationToken);
+
+  return deletedObjects;
+}
+
+async function main() {
+  loadEnv();
+  const options = parseArgs(process.argv.slice(2));
+  if (options.help) {
+    usage();
+    return;
+  }
+
+  const bucket = process.env.S3_BUCKET_NAME;
+  if (!bucket) {
+    throw new Error("S3_BUCKET_NAME is required");
+  }
+  if (!process.env.AWS_REGION) {
+    throw new Error("AWS_REGION is required");
+  }
+  if (
+    options.yes &&
+    isProtectedBucketName(bucket) &&
+    !options.allowProductionBucket
+  ) {
+    throw new Error(
+      `Refusing to delete from bucket '${bucket}' without --allow-production-bucket`,
+    );
+  }
+
+  const prisma = new PrismaClient();
+  const s3 = new S3Client(buildS3ClientConfig());
+
+  try {
+    const prefixes = await listSessionPrefixes({ s3, bucket });
+    const sessionIds = prefixes.map(sessionIdFromPrefix).filter(Boolean);
+    const existingSessionIds = await getExistingSessionIds({ prisma, sessionIds });
+    const orphanPrefixes = prefixes
+      .filter((prefix) => {
+        const sessionId = sessionIdFromPrefix(prefix);
+        return sessionId && !existingSessionIds.has(sessionId);
+      })
+      .slice(0, options.limit);
+
+    if (orphanPrefixes.length === 0) {
+      console.log("No orphan S3 session prefixes found.");
+      return;
+    }
+
+    console.log(
+      `${options.yes ? "Deleting" : "Dry run:"} ${orphanPrefixes.length} orphan S3 session prefix(es) from s3://${bucket}.`,
+    );
+    for (const prefix of orphanPrefixes) {
+      console.log(`- ${prefix}`);
+    }
+
+    if (!options.yes) {
+      console.log("\nNo changes made. Rerun with --yes to delete.");
+      return;
+    }
+
+    let totalDeletedObjects = 0;
+    for (const prefix of orphanPrefixes) {
+      const deletedObjects = await deletePrefix({ s3, bucket, prefix });
+      totalDeletedObjects += deletedObjects;
+      console.log(`Deleted ${prefix}: ${deletedObjects} object(s)`);
+    }
+
+    console.log(`Done. Deleted ${totalDeletedObjects} object(s).`);
+  } finally {
+    await prisma.$disconnect();
+  }
+}
+
+main().catch((error) => {
+  console.error(error instanceof Error ? error.message : error);
+  process.exit(1);
+});

--- a/scripts/purge-ready-sessions.mjs
+++ b/scripts/purge-ready-sessions.mjs
@@ -1,0 +1,227 @@
+#!/usr/bin/env node
+
+import fs from "node:fs";
+import { PrismaClient } from "@prisma/client";
+
+function loadEnvFile(path, { override = false } = {}) {
+  if (!fs.existsSync(path)) {
+    return;
+  }
+
+  const lines = fs.readFileSync(path, "utf8").split(/\r?\n/);
+  for (const line of lines) {
+    const trimmed = line.trim();
+    if (!trimmed || trimmed.startsWith("#")) {
+      continue;
+    }
+
+    const match = trimmed.match(/^([A-Za-z_][A-Za-z0-9_]*)=(.*)$/);
+    if (!match) {
+      continue;
+    }
+
+    const [, key, rawValue] = match;
+    if (!override && process.env[key] !== undefined) {
+      continue;
+    }
+
+    let value = rawValue.trim();
+    if (
+      (value.startsWith('"') && value.endsWith('"')) ||
+      (value.startsWith("'") && value.endsWith("'"))
+    ) {
+      value = value.slice(1, -1);
+    }
+
+    process.env[key] = value;
+  }
+}
+
+function loadEnv() {
+  loadEnvFile(".env");
+  loadEnvFile(".env.local", { override: true });
+  if (!process.env.DIRECT_DATABASE_URL && process.env.DATABASE_URL) {
+    process.env.DIRECT_DATABASE_URL = process.env.DATABASE_URL;
+  }
+}
+
+function usage() {
+  console.log(`Usage: node scripts/purge-ready-sessions.mjs [options]
+
+Purges DB-backed ready sessions by calling /api/ingest/sessions/:id/purge-files.
+Dry-run by default.
+
+Options:
+  --yes                 Actually call purge endpoints. Without this, only prints.
+  --base-url <url>      App base URL. Can also use COZYTRACK_PURGE_BASE_URL.
+  --api-key <key>       Ingest API key. Can also use COZYTRACK_API_KEY.
+  --session-id <id>     Limit to a specific session. Repeatable.
+  --limit <n>           Limit number of sessions processed.
+  --help                Show this help.
+`);
+}
+
+function parseArgs(argv) {
+  const options = {
+    yes: false,
+    baseUrl: process.env.COZYTRACK_PURGE_BASE_URL,
+    apiKey: process.env.COZYTRACK_API_KEY,
+    sessionIds: [],
+    limit: undefined,
+  };
+
+  for (let i = 0; i < argv.length; i += 1) {
+    const arg = argv[i];
+    if (arg === "--yes") {
+      options.yes = true;
+    } else if (arg === "--base-url") {
+      options.baseUrl = argv[++i];
+    } else if (arg === "--api-key") {
+      options.apiKey = argv[++i];
+    } else if (arg === "--session-id") {
+      options.sessionIds.push(argv[++i]);
+    } else if (arg === "--limit") {
+      const limit = Number(argv[++i]);
+      if (!Number.isInteger(limit) || limit < 1) {
+        throw new Error("--limit must be a positive integer");
+      }
+      options.limit = limit;
+    } else if (arg === "--help" || arg === "-h") {
+      options.help = true;
+    } else {
+      throw new Error(`Unknown option: ${arg}`);
+    }
+  }
+
+  return options;
+}
+
+function normalizeBaseUrl(value) {
+  if (!value) {
+    return undefined;
+  }
+  return value.replace(/\/+$/, "");
+}
+
+function trackSummary(tracks) {
+  const unpurged = tracks.filter((track) => !track.s3PurgedAt).length;
+  return `${tracks.length} tracks (${unpurged} unpurged)`;
+}
+
+async function purgeSession({ baseUrl, apiKey, sessionId }) {
+  const response = await fetch(
+    `${baseUrl}/api/ingest/sessions/${encodeURIComponent(
+      sessionId,
+    )}/purge-files`,
+    {
+      method: "POST",
+      headers: {
+        "x-api-key": apiKey,
+      },
+    },
+  );
+
+  const body = await response.json().catch(() => ({}));
+  if (!response.ok) {
+    throw new Error(
+      `HTTP ${response.status}: ${
+        typeof body.error === "string" ? body.error : response.statusText
+      }`,
+    );
+  }
+
+  return body;
+}
+
+async function main() {
+  loadEnv();
+  const options = parseArgs(process.argv.slice(2));
+  if (options.help) {
+    usage();
+    return;
+  }
+
+  const prisma = new PrismaClient();
+  try {
+    const where = {
+      status: "ready",
+      tracks: { some: { s3PurgedAt: null } },
+    };
+
+    if (options.sessionIds.length > 0) {
+      where.id = { in: options.sessionIds };
+    }
+
+    const sessions = await prisma.session.findMany({
+      where,
+      include: {
+        tracks: {
+          select: {
+            id: true,
+            participantName: true,
+            s3PurgedAt: true,
+          },
+          orderBy: { createdAt: "asc" },
+        },
+      },
+      orderBy: { createdAt: "asc" },
+      take: options.limit,
+    });
+
+    if (sessions.length === 0) {
+      console.log("No ready sessions with unpurged tracks found.");
+      return;
+    }
+
+    console.log(
+      `${options.yes ? "Purging" : "Dry run:"} ${sessions.length} ready session(s).`,
+    );
+    for (const session of sessions) {
+      console.log(`- ${session.id}: ${session.name} — ${trackSummary(session.tracks)}`);
+    }
+
+    if (!options.yes) {
+      console.log("\nNo changes made. Rerun with --yes to purge.");
+      return;
+    }
+
+    const baseUrl = normalizeBaseUrl(options.baseUrl);
+    if (!baseUrl) {
+      throw new Error(
+        "--base-url or COZYTRACK_PURGE_BASE_URL is required with --yes",
+      );
+    }
+    if (!options.apiKey) {
+      throw new Error("--api-key or COZYTRACK_API_KEY is required with --yes");
+    }
+
+    let totalDeletedObjects = 0;
+    let totalPurgedTracks = 0;
+
+    for (const session of sessions) {
+      const result = await purgeSession({
+        baseUrl,
+        apiKey: options.apiKey,
+        sessionId: session.id,
+      });
+      totalDeletedObjects += result.deletedObjects ?? 0;
+      totalPurgedTracks += result.purgedTracks ?? 0;
+      console.log(
+        `Purged ${session.id}: ${result.deletedObjects ?? 0} objects, ${
+          result.purgedTracks ?? 0
+        } tracks stamped`,
+      );
+    }
+
+    console.log(
+      `Done. Deleted ${totalDeletedObjects} object(s), stamped ${totalPurgedTracks} track(s).`,
+    );
+  } finally {
+    await prisma.$disconnect();
+  }
+}
+
+main().catch((error) => {
+  console.error(error instanceof Error ? error.message : error);
+  process.exit(1);
+});

--- a/scripts/purge-ready-sessions.mjs
+++ b/scripts/purge-ready-sessions.mjs
@@ -1,49 +1,11 @@
 #!/usr/bin/env node
 
-import fs from "node:fs";
 import { PrismaClient } from "@prisma/client";
-
-function loadEnvFile(path, { override = false } = {}) {
-  if (!fs.existsSync(path)) {
-    return;
-  }
-
-  const lines = fs.readFileSync(path, "utf8").split(/\r?\n/);
-  for (const line of lines) {
-    const trimmed = line.trim();
-    if (!trimmed || trimmed.startsWith("#")) {
-      continue;
-    }
-
-    const match = trimmed.match(/^([A-Za-z_][A-Za-z0-9_]*)=(.*)$/);
-    if (!match) {
-      continue;
-    }
-
-    const [, key, rawValue] = match;
-    if (!override && process.env[key] !== undefined) {
-      continue;
-    }
-
-    let value = rawValue.trim();
-    if (
-      (value.startsWith('"') && value.endsWith('"')) ||
-      (value.startsWith("'") && value.endsWith("'"))
-    ) {
-      value = value.slice(1, -1);
-    }
-
-    process.env[key] = value;
-  }
-}
-
-function loadEnv() {
-  loadEnvFile(".env");
-  loadEnvFile(".env.local", { override: true });
-  if (!process.env.DIRECT_DATABASE_URL && process.env.DATABASE_URL) {
-    process.env.DIRECT_DATABASE_URL = process.env.DATABASE_URL;
-  }
-}
+import {
+  loadEnv,
+  parsePositiveInteger,
+  readOptionValue,
+} from "./script-utils.mjs";
 
 function usage() {
   console.log(`Usage: node scripts/purge-ready-sessions.mjs [options]
@@ -75,17 +37,17 @@ function parseArgs(argv) {
     if (arg === "--yes") {
       options.yes = true;
     } else if (arg === "--base-url") {
-      options.baseUrl = argv[++i];
+      options.baseUrl = readOptionValue(argv, i, arg);
+      i += 1;
     } else if (arg === "--api-key") {
-      options.apiKey = argv[++i];
+      options.apiKey = readOptionValue(argv, i, arg);
+      i += 1;
     } else if (arg === "--session-id") {
-      options.sessionIds.push(argv[++i]);
+      options.sessionIds.push(readOptionValue(argv, i, arg));
+      i += 1;
     } else if (arg === "--limit") {
-      const limit = Number(argv[++i]);
-      if (!Number.isInteger(limit) || limit < 1) {
-        throw new Error("--limit must be a positive integer");
-      }
-      options.limit = limit;
+      options.limit = parsePositiveInteger(readOptionValue(argv, i, arg), arg);
+      i += 1;
     } else if (arg === "--help" || arg === "-h") {
       options.help = true;
     } else {
@@ -157,11 +119,8 @@ async function main() {
       include: {
         tracks: {
           select: {
-            id: true,
-            participantName: true,
             s3PurgedAt: true,
           },
-          orderBy: { createdAt: "asc" },
         },
       },
       orderBy: { createdAt: "asc" },
@@ -177,7 +136,9 @@ async function main() {
       `${options.yes ? "Purging" : "Dry run:"} ${sessions.length} ready session(s).`,
     );
     for (const session of sessions) {
-      console.log(`- ${session.id}: ${session.name} — ${trackSummary(session.tracks)}`);
+      console.log(
+        `- ${session.id}: ${session.name} — ${trackSummary(session.tracks)}`,
+      );
     }
 
     if (!options.yes) {

--- a/scripts/script-utils.mjs
+++ b/scripts/script-utils.mjs
@@ -1,0 +1,59 @@
+import fs from "node:fs";
+
+export function loadEnvFile(path, { override = false } = {}) {
+  if (!fs.existsSync(path)) {
+    return;
+  }
+
+  const lines = fs.readFileSync(path, "utf8").split(/\r?\n/);
+  for (const line of lines) {
+    const trimmed = line.trim();
+    if (!trimmed || trimmed.startsWith("#")) {
+      continue;
+    }
+
+    const match = trimmed.match(/^([A-Za-z_][A-Za-z0-9_]*)=(.*)$/);
+    if (!match) {
+      continue;
+    }
+
+    const [, key, rawValue] = match;
+    if (!override && process.env[key] !== undefined) {
+      continue;
+    }
+
+    let value = rawValue.trim();
+    if (
+      (value.startsWith('"') && value.endsWith('"')) ||
+      (value.startsWith("'") && value.endsWith("'"))
+    ) {
+      value = value.slice(1, -1);
+    }
+
+    process.env[key] = value;
+  }
+}
+
+export function loadEnv() {
+  loadEnvFile(".env");
+  loadEnvFile(".env.local", { override: true });
+  if (!process.env.DIRECT_DATABASE_URL && process.env.DATABASE_URL) {
+    process.env.DIRECT_DATABASE_URL = process.env.DATABASE_URL;
+  }
+}
+
+export function readOptionValue(argv, index, optionName) {
+  const value = argv[index + 1];
+  if (value === undefined || value === "" || value.startsWith("--")) {
+    throw new Error(`Missing value for ${optionName}`);
+  }
+  return value;
+}
+
+export function parsePositiveInteger(value, optionName) {
+  const parsed = Number(value);
+  if (!Number.isInteger(parsed) || parsed < 1) {
+    throw new Error(`${optionName} must be a positive integer`);
+  }
+  return parsed;
+}


### PR DESCRIPTION
## Summary
- add `purge:ready` for DB-backed ready sessions that calls the ingest purge endpoint
- add `purge:orphans` for S3-only `sessions/<id>/` prefixes with no matching DB session
- keep both cleanup paths dry-run by default and require explicit flags before deletion
- document historical cleanup usage and required env vars

## Validation
- `node --check scripts/purge-ready-sessions.mjs`
- `node --check scripts/purge-orphan-s3-sessions.mjs`
- `npm run purge:ready -- --help`
- `npm run purge:orphans -- --help`
- `npm test`
- `npm run build`