### PR TITLE
Keep recording uploads authorized mid-session

### DIFF
--- a/src/app/api/upload/complete/route.ts
+++ b/src/app/api/upload/complete/route.ts
@@ -1,7 +1,7 @@
 import { NextRequest, NextResponse } from "next/server";
 import { db } from "@/lib/db";
 import { deleteTrackChunks, trackRecordingKey } from "@/lib/s3";
-import { resolvePrincipal } from "@/lib/auth";
+import { resolvePrincipal, verifyRecordingUploadToken } from "@/lib/auth";
 
 export async function POST(req: NextRequest) {
   try {
@@ -16,10 +16,29 @@ export async function POST(req: NextRequest) {
     }
 
     const principal = await resolvePrincipal(req, sessionId);
-    if (!principal) {
-      return NextResponse.json({ error: "unauthorized" }, { status: 401 });
+    if (principal?.kind === "guest" && principal.sessionId !== sessionId) {
+      return NextResponse.json({ error: "forbidden" }, { status: 403 });
     }
-    if (principal.kind === "guest" && principal.sessionId !== sessionId) {
+    if (!principal) {
+      const token = req.headers.get("x-cozytrack-recording-token") ?? undefined;
+      const uploadPrincipal = await verifyRecordingUploadToken(
+        token,
+        sessionId,
+        trackId,
+      );
+      if (!uploadPrincipal) {
+        return NextResponse.json({ error: "unauthorized" }, { status: 401 });
+      }
+    }
+
+    const existingTrack = await db.track.findUnique({
+      where: { id: trackId },
+      select: { sessionId: true },
+    });
+    if (!existingTrack) {
+      return NextResponse.json({ error: "Track not found" }, { status: 404 });
+    }
+    if (existingTrack.sessionId !== sessionId) {
       return NextResponse.json({ error: "forbidden" }, { status: 403 });
     }
 

--- a/src/app/api/upload/presign/route.ts
+++ b/src/app/api/upload/presign/route.ts
@@ -34,8 +34,12 @@ export async function POST(req: NextRequest) {
       );
     }
 
+    const requestRecordingToken =
+      req.headers.get("x-cozytrack-recording-token") ?? undefined;
+    const isRecordingStart = partNumber === 0 && !requestRecordingToken;
+
     let recordingToken: string | undefined;
-    if (partNumber === 0) {
+    if (isRecordingStart) {
       // Starting a recording still requires normal host/guest auth. The
       // returned recording token is scoped to this session+track so later
       // chunks can keep uploading if the login cookie expires mid-take.
@@ -103,10 +107,8 @@ export async function POST(req: NextRequest) {
         return NextResponse.json({ error: "forbidden" }, { status: 403 });
       }
       if (!principal) {
-        const token =
-          req.headers.get("x-cozytrack-recording-token") ?? undefined;
         const uploadPrincipal = await verifyRecordingUploadToken(
-          token,
+          requestRecordingToken,
           sessionId,
           trackId,
         );

--- a/src/app/api/upload/presign/route.ts
+++ b/src/app/api/upload/presign/route.ts
@@ -1,7 +1,11 @@
 import { NextRequest, NextResponse } from "next/server";
 import { db } from "@/lib/db";
 import { trackPartKey, trackRecordingKey, getPresignedPutUrl } from "@/lib/s3";
-import { resolvePrincipal } from "@/lib/auth";
+import {
+  issueRecordingUploadToken,
+  resolvePrincipal,
+  verifyRecordingUploadToken,
+} from "@/lib/auth";
 
 function getUploadErrorMessage(error: unknown): string {
   if (!(error instanceof Error)) {
@@ -30,17 +34,19 @@ export async function POST(req: NextRequest) {
       );
     }
 
-    // AuthZ: host can presign for any session; guest only for the session
-    // their cookie is scoped to. This is where we enforce the S3 blast radius.
-    const principal = await resolvePrincipal(req, sessionId);
-    if (!principal) {
-      return NextResponse.json({ error: "unauthorized" }, { status: 401 });
-    }
-    if (principal.kind === "guest" && principal.sessionId !== sessionId) {
-      return NextResponse.json({ error: "forbidden" }, { status: 403 });
-    }
-
+    let recordingToken: string | undefined;
     if (partNumber === 0) {
+      // Starting a recording still requires normal host/guest auth. The
+      // returned recording token is scoped to this session+track so later
+      // chunks can keep uploading if the login cookie expires mid-take.
+      const principal = await resolvePrincipal(req, sessionId);
+      if (!principal) {
+        return NextResponse.json({ error: "unauthorized" }, { status: 401 });
+      }
+      if (principal.kind === "guest" && principal.sessionId !== sessionId) {
+        return NextResponse.json({ error: "forbidden" }, { status: 403 });
+      }
+
       const existingSession = await db.session.findUnique({
         where: { id: sessionId },
         select: { id: true },
@@ -87,6 +93,27 @@ export async function POST(req: NextRequest) {
           },
         });
       }
+
+      recordingToken = await issueRecordingUploadToken(sessionId, trackId);
+    } else {
+      // Subsequent chunks and the final recording.webm upload accept either
+      // the original principal cookie or the recording-scoped upload token.
+      const principal = await resolvePrincipal(req, sessionId);
+      if (principal?.kind === "guest" && principal.sessionId !== sessionId) {
+        return NextResponse.json({ error: "forbidden" }, { status: 403 });
+      }
+      if (!principal) {
+        const token =
+          req.headers.get("x-cozytrack-recording-token") ?? undefined;
+        const uploadPrincipal = await verifyRecordingUploadToken(
+          token,
+          sessionId,
+          trackId,
+        );
+        if (!uploadPrincipal) {
+          return NextResponse.json({ error: "unauthorized" }, { status: 401 });
+        }
+      }
     }
 
     const key =
@@ -95,7 +122,7 @@ export async function POST(req: NextRequest) {
         : trackPartKey(sessionId, trackId, partNumber);
     const url = await getPresignedPutUrl(key);
 
-    return NextResponse.json({ url, key });
+    return NextResponse.json({ url, key, recordingToken });
   } catch (error) {
     console.error("Failed to generate presigned URL:", error);
     return NextResponse.json(

--- a/src/app/studio/[id]/page.tsx
+++ b/src/app/studio/[id]/page.tsx
@@ -28,7 +28,12 @@ import {
 import { v4 as uuidv4 } from "uuid";
 import { CozyRecorder } from "@/lib/recorder";
 import { forceMonoStream, getTrackChannelCount } from "@/lib/audio-downmix";
-import { getPresignedUploadUrl, uploadChunk, completeUpload } from "@/lib/upload";
+import {
+  getPresignedUploadTarget,
+  getPresignedUploadUrl,
+  uploadChunk,
+  completeUpload,
+} from "@/lib/upload";
 import { getToken, LIVEKIT_URL } from "@/lib/livekit";
 import {
   useTransport,
@@ -545,6 +550,7 @@ function RoomContent({
   const transport = useTransport();
   const recorderRef = useRef<CozyRecorder | null>(null);
   const trackIdRef = useRef<string>("");
+  const recordingUploadTokenRef = useRef<string | undefined>(undefined);
   // Raw stream straight from getUserMedia — retained so we can stop the
   // underlying device tracks on teardown.
   const rawStreamRef = useRef<MediaStream | null>(null);
@@ -1052,16 +1058,24 @@ function RoomContent({
 
       trackIdRef.current = uuidv4();
       const trackId = trackIdRef.current;
+      recordingUploadTokenRef.current = undefined;
 
       try {
-        await getPresignedUploadUrl(sessionId, trackId, 0, participantName, {
-          deviceInfo: {
-            deviceLabel: selectedMicLabel,
-            deviceId: selectedMic,
-            isBuiltInMic: selectedMicIsBuiltIn,
+        const initialUpload = await getPresignedUploadTarget(
+          sessionId,
+          trackId,
+          0,
+          participantName,
+          {
+            deviceInfo: {
+              deviceLabel: selectedMicLabel,
+              deviceId: selectedMic,
+              isBuiltInMic: selectedMicIsBuiltIn,
+            },
+            sessionStartedAt: sessionStartedAtIso,
           },
-          sessionStartedAt: sessionStartedAtIso,
-        });
+        );
+        recordingUploadTokenRef.current = initialUpload.recordingToken;
       } catch (err) {
         console.error("Failed to initialize upload:", err);
         clearRecordingConfirmationState();
@@ -1096,7 +1110,14 @@ function RoomContent({
         }
 
         const uploadPromise = (async () => {
-          const url = await getPresignedUploadUrl(sessionId, trackId, index);
+          const url = await getPresignedUploadUrl(
+            sessionId,
+            trackId,
+            index,
+            undefined,
+            undefined,
+            recordingUploadTokenRef.current,
+          );
           await uploadChunk(url, chunk);
         })();
 
@@ -1189,6 +1210,7 @@ function RoomContent({
     // tears down immediately — even if the upload pipeline below hangs.
     const recorder = recorderRef.current;
     const trackId = trackIdRef.current;
+    const recordingUploadToken = recordingUploadTokenRef.current;
     const startedAt = recordingStartRef.current;
     setStudioStateSync("finalizing");
     void broadcastRecordingStatus("finalizing", sessionStartedAtForStatus);
@@ -1223,14 +1245,21 @@ function RoomContent({
       const finalBytes = blob.size;
       trackerOnChunkRecorded(finalBytes);
       const finalUpload = (async () => {
-        const url = await getPresignedUploadUrl(sessionId, trackId, 9999);
+        const url = await getPresignedUploadUrl(
+          sessionId,
+          trackId,
+          9999,
+          undefined,
+          undefined,
+          recordingUploadToken,
+        );
         await uploadChunk(url, blob);
       })();
       await trackerTrackUpload(finalBytes, finalUpload, { rethrow: true });
 
       // Wait for any background chunk uploads still settling.
       await trackerWaitForUploads();
-      await completeUpload(sessionId, trackId, durationMs);
+      await completeUpload(sessionId, trackId, durationMs, recordingUploadToken);
 
       setHasRecorded(true);
     } catch (err) {
@@ -1239,6 +1268,7 @@ function RoomContent({
       console.error("Failed to stop recording:", err);
     } finally {
       recorderRef.current = null;
+      recordingUploadTokenRef.current = undefined;
       // Hard invariant from issue #61: do not leave `finalizing` until the
       // chunk-upload promise set is drained, regardless of error path. If the
       // happy path above already drained, this is effectively a no-op.

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -16,10 +16,16 @@ const GUEST_COOKIE_PREFIX = "cozytrack_guest_"; // + sessionId
 const HOST_SESSION_TTL_SECONDS = 60 * 60 * 24 * 7; // 7 days
 const GUEST_SESSION_TTL_SECONDS = 60 * 60 * 12; // 12 hours
 const INVITE_TOKEN_TTL_SECONDS = 60 * 60 * 48; // 48 hours
+const RECORDING_UPLOAD_TTL_SECONDS = 60 * 60 * 12; // 12 hours
 
 export type HostPrincipal = { kind: "host" };
 export type GuestPrincipal = { kind: "guest"; sessionId: string; name: string };
 export type Principal = HostPrincipal | GuestPrincipal;
+export type RecordingUploadPrincipal = {
+  kind: "recording_upload";
+  sessionId: string;
+  trackId: string;
+};
 
 function getSecret(): Uint8Array {
   const secret = process.env.AUTH_SECRET;
@@ -117,6 +123,42 @@ export async function verifyGuestCookie(
   }
 }
 
+// ---------- Recording upload tokens ----------
+
+export async function issueRecordingUploadToken(
+  sessionId: string,
+  trackId: string,
+): Promise<string> {
+  return await new SignJWT({ sessionId, trackId })
+    .setProtectedHeader({ alg: "HS256" })
+    .setIssuer("cozytrack")
+    .setAudience("cozytrack:recording-upload")
+    .setSubject(`recording-upload:${sessionId}:${trackId}`)
+    .setIssuedAt()
+    .setExpirationTime(`${RECORDING_UPLOAD_TTL_SECONDS}s`)
+    .sign(getSecret());
+}
+
+export async function verifyRecordingUploadToken(
+  token: string | undefined,
+  sessionId: string,
+  trackId: string,
+): Promise<RecordingUploadPrincipal | null> {
+  if (!token) return null;
+  try {
+    const { payload } = await jwtVerify(token, getSecret(), {
+      issuer: "cozytrack",
+      audience: "cozytrack:recording-upload",
+    });
+    if (payload.sessionId !== sessionId || payload.trackId !== trackId) {
+      return null;
+    }
+    return { kind: "recording_upload", sessionId, trackId };
+  } catch {
+    return null;
+  }
+}
+
 function guestCookieName(sessionId: string): string {
   // Cookie names are per-session so a guest invited to one session doesn't
   // accidentally carry credentials into another.
@@ -176,4 +218,5 @@ export const AUTH_TTLS = {
   hostSession: HOST_SESSION_TTL_SECONDS,
   guestSession: GUEST_SESSION_TTL_SECONDS,
   invite: INVITE_TOKEN_TTL_SECONDS,
+  recordingUpload: RECORDING_UPLOAD_TTL_SECONDS,
 } as const;

--- a/src/lib/upload.ts
+++ b/src/lib/upload.ts
@@ -13,16 +13,27 @@ export interface TrackInitInfo {
   sessionStartedAt?: string;
 }
 
-export async function getPresignedUploadUrl(
+export interface PresignedUploadTarget {
+  url: string;
+  recordingToken?: string;
+}
+
+export async function getPresignedUploadTarget(
   sessionId: string,
   trackId: string,
   partNumber: number,
   participantName?: string,
   trackInit?: TrackInitInfo,
-): Promise<string> {
+  recordingToken?: string,
+): Promise<PresignedUploadTarget> {
+  const headers: Record<string, string> = { "Content-Type": "application/json" };
+  if (recordingToken) {
+    headers["X-Cozytrack-Recording-Token"] = recordingToken;
+  }
+
   const res = await fetch("/api/upload/presign", {
     method: "POST",
-    headers: { "Content-Type": "application/json" },
+    headers,
     body: JSON.stringify({
       sessionId,
       trackId,
@@ -49,7 +60,30 @@ export async function getPresignedUploadUrl(
   }
 
   const data = await res.json();
-  return data.url;
+  return {
+    url: data.url,
+    recordingToken:
+      typeof data.recordingToken === "string" ? data.recordingToken : undefined,
+  };
+}
+
+export async function getPresignedUploadUrl(
+  sessionId: string,
+  trackId: string,
+  partNumber: number,
+  participantName?: string,
+  trackInit?: TrackInitInfo,
+  recordingToken?: string,
+): Promise<string> {
+  const target = await getPresignedUploadTarget(
+    sessionId,
+    trackId,
+    partNumber,
+    participantName,
+    trackInit,
+    recordingToken,
+  );
+  return target.url;
 }
 
 export async function uploadChunk(url: string, chunk: Blob): Promise<void> {
@@ -69,11 +103,17 @@ export async function uploadChunk(url: string, chunk: Blob): Promise<void> {
 export async function completeUpload(
   sessionId: string,
   trackId: string,
-  durationMs?: number
+  durationMs?: number,
+  recordingToken?: string,
 ): Promise<void> {
+  const headers: Record<string, string> = { "Content-Type": "application/json" };
+  if (recordingToken) {
+    headers["X-Cozytrack-Recording-Token"] = recordingToken;
+  }
+
   const res = await fetch("/api/upload/complete", {
     method: "POST",
-    headers: { "Content-Type": "application/json" },
+    headers,
     body: JSON.stringify({ sessionId, trackId, durationMs }),
   });
 

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -74,6 +74,13 @@ function isGuestAllowedForSessionEndpoint(pathname: string): boolean {
   );
 }
 
+function isRecordingUploadEndpoint(pathname: string): boolean {
+  return (
+    pathname === "/api/upload/presign" ||
+    pathname === "/api/upload/complete"
+  );
+}
+
 export async function middleware(req: NextRequest) {
   const { pathname } = req.nextUrl;
 
@@ -107,6 +114,17 @@ export async function middleware(req: NextRequest) {
     if (guestCookies.length > 0) {
       return NextResponse.next();
     }
+  }
+
+  // Active recordings carry a short-lived, track-scoped upload token. The
+  // route handler validates the token against the request body; middleware only
+  // lets the body-bearing upload request reach that handler after cookies age
+  // out mid-recording.
+  if (
+    isRecordingUploadEndpoint(pathname) &&
+    req.headers.has("x-cozytrack-recording-token")
+  ) {
+    return NextResponse.next();
   }
 
   // API routes return JSON 401; pages redirect to sign-in.

--- a/tests/middleware.test.ts
+++ b/tests/middleware.test.ts
@@ -54,6 +54,22 @@ describe("auth middleware", () => {
     );
     expect(res.status).toBe(200);
   });
+
+  it("lets recording-token upload requests reach the route handler without cookies", async () => {
+    const res = await middleware(
+      makeReq("http://localhost:3001/api/upload/presign", {
+        "x-cozytrack-recording-token": "recording-token",
+      })
+    );
+    expect(res.status).toBe(200);
+  });
+
+  it("keeps upload requests without cookies or recording token unauthorized", async () => {
+    const res = await middleware(
+      makeReq("http://localhost:3001/api/upload/presign")
+    );
+    expect(res.status).toBe(401);
+  });
 });
 
 describe("middleware matcher", () => {

--- a/tests/upload-auth.test.ts
+++ b/tests/upload-auth.test.ts
@@ -166,6 +166,42 @@ describe("recording upload auth", () => {
     expect(body.key).toBe("sessions/s1/tracks/t1/47.webm");
   });
 
+  it("keeps presigning the first recorded chunk with the recording token after cookies expire", async () => {
+    mocks.resolvePrincipal.mockResolvedValueOnce({ kind: "host" });
+
+    const start = await presignUpload(
+      postJson(
+        "/api/upload/presign",
+        {
+          sessionId: "s1",
+          trackId: "t1",
+          partNumber: 0,
+          participantName: "Alice",
+        },
+      ),
+    );
+    const { recordingToken } = (await start.json()) as {
+      recordingToken: string;
+    };
+
+    const res = await presignUpload(
+      postJson(
+        "/api/upload/presign",
+        { sessionId: "s1", trackId: "t1", partNumber: 0 },
+        { "x-cozytrack-recording-token": recordingToken },
+      ),
+    );
+
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as {
+      key: string;
+      recordingToken?: string;
+      url: string;
+    };
+    expect(body.key).toBe("sessions/s1/tracks/t1/0.webm");
+    expect(body.recordingToken).toBeUndefined();
+  });
+
   it("keeps presigning the final recording upload with the recording token after cookies expire", async () => {
     mocks.resolvePrincipal.mockResolvedValueOnce({ kind: "host" });
 

--- a/tests/upload-auth.test.ts
+++ b/tests/upload-auth.test.ts
@@ -1,0 +1,263 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+
+type Track = {
+  id: string;
+  sessionId: string;
+  participantName: string;
+  s3Key: string;
+  status: string;
+  durationMs: number | null;
+};
+
+const mocks = vi.hoisted(() => ({
+  sessions: new Set<string>(),
+  tracks: new Map<string, Track>(),
+  getPresignedPutUrl: vi.fn(async (key: string) => `https://s3.example/${key}`),
+  deleteTrackChunks: vi.fn(async () => undefined),
+  resolvePrincipal: vi.fn(),
+}));
+
+vi.mock("@/lib/db", () => ({
+  db: {
+    session: {
+      findUnique: vi.fn(async ({ where: { id } }: { where: { id: string } }) =>
+        mocks.sessions.has(id) ? { id } : null,
+      ),
+    },
+    track: {
+      findUnique: vi.fn(
+        async ({ where: { id } }: { where: { id: string } }) => {
+          const track = mocks.tracks.get(id);
+          return track ? { ...track } : null;
+        },
+      ),
+      create: vi.fn(async ({ data }: { data: Track }) => {
+        const track = { ...data, status: "recording", durationMs: null };
+        mocks.tracks.set(track.id, track);
+        return { ...track };
+      }),
+      update: vi.fn(
+        async ({
+          where: { id },
+          data,
+        }: {
+          where: { id: string };
+          data: Partial<Track>;
+        }) => {
+          const existing = mocks.tracks.get(id);
+          if (!existing) throw new Error("track not found");
+          const updated = { ...existing, ...data };
+          mocks.tracks.set(id, updated);
+          return { ...updated };
+        },
+      ),
+    },
+  },
+}));
+
+vi.mock("@/lib/s3", () => ({
+  getPresignedPutUrl: mocks.getPresignedPutUrl,
+  deleteTrackChunks: mocks.deleteTrackChunks,
+  trackPartKey: (sessionId: string, trackId: string, partNumber: number) =>
+    `sessions/${sessionId}/tracks/${trackId}/${partNumber}.webm`,
+  trackRecordingKey: (sessionId: string, trackId: string) =>
+    `sessions/${sessionId}/tracks/${trackId}/recording.webm`,
+}));
+
+vi.mock("@/lib/auth", async () => {
+  const actual = await vi.importActual<typeof import("@/lib/auth")>(
+    "@/lib/auth",
+  );
+  return {
+    ...actual,
+    resolvePrincipal: mocks.resolvePrincipal,
+  };
+});
+
+import { NextRequest } from "next/server";
+import { POST as presignUpload } from "@/app/api/upload/presign/route";
+import { POST as completeUpload } from "@/app/api/upload/complete/route";
+import { issueRecordingUploadToken } from "@/lib/auth";
+
+function postJson(
+  path: string,
+  body: Record<string, unknown>,
+  headers: Record<string, string> = {},
+): NextRequest {
+  return new NextRequest(`http://localhost:3001${path}`, {
+    method: "POST",
+    headers: {
+      "content-type": "application/json",
+      ...headers,
+    },
+    body: JSON.stringify(body),
+  });
+}
+
+beforeEach(() => {
+  vi.stubEnv("AUTH_SECRET", "test-secret-for-recording-upload-token-123456");
+  mocks.sessions.clear();
+  mocks.tracks.clear();
+  mocks.sessions.add("s1");
+  vi.clearAllMocks();
+  mocks.resolvePrincipal.mockResolvedValue(null);
+});
+
+afterEach(() => {
+  vi.unstubAllEnvs();
+});
+
+describe("recording upload auth", () => {
+  it("returns a track-scoped recording token when an authenticated recording starts", async () => {
+    mocks.resolvePrincipal.mockResolvedValue({ kind: "host" });
+
+    const res = await presignUpload(
+      postJson(
+        "/api/upload/presign",
+        {
+          sessionId: "s1",
+          trackId: "t1",
+          partNumber: 0,
+          participantName: "Alice",
+        },
+      ),
+    );
+
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as {
+      key: string;
+      url: string;
+      recordingToken?: string;
+    };
+    expect(body.key).toBe("sessions/s1/tracks/t1/0.webm");
+    expect(body.url).toBe("https://s3.example/sessions/s1/tracks/t1/0.webm");
+    expect(body.recordingToken).toEqual(expect.any(String));
+    expect(mocks.tracks.get("t1")?.participantName).toBe("Alice");
+  });
+
+  it("keeps presigning chunks with the recording token after cookies expire", async () => {
+    mocks.resolvePrincipal.mockResolvedValueOnce({ kind: "host" });
+
+    const start = await presignUpload(
+      postJson(
+        "/api/upload/presign",
+        {
+          sessionId: "s1",
+          trackId: "t1",
+          partNumber: 0,
+          participantName: "Alice",
+        },
+      ),
+    );
+    const { recordingToken } = (await start.json()) as {
+      recordingToken: string;
+    };
+
+    const res = await presignUpload(
+      postJson(
+        "/api/upload/presign",
+        { sessionId: "s1", trackId: "t1", partNumber: 47 },
+        { "x-cozytrack-recording-token": recordingToken },
+      ),
+    );
+
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { key: string; url: string };
+    expect(body.key).toBe("sessions/s1/tracks/t1/47.webm");
+  });
+
+  it("keeps presigning the final recording upload with the recording token after cookies expire", async () => {
+    mocks.resolvePrincipal.mockResolvedValueOnce({ kind: "host" });
+
+    const start = await presignUpload(
+      postJson(
+        "/api/upload/presign",
+        {
+          sessionId: "s1",
+          trackId: "t1",
+          partNumber: 0,
+          participantName: "Alice",
+        },
+      ),
+    );
+    const { recordingToken } = (await start.json()) as {
+      recordingToken: string;
+    };
+
+    const res = await presignUpload(
+      postJson(
+        "/api/upload/presign",
+        { sessionId: "s1", trackId: "t1", partNumber: 9999 },
+        { "x-cozytrack-recording-token": recordingToken },
+      ),
+    );
+
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { key: string; url: string };
+    expect(body.key).toBe("sessions/s1/tracks/t1/recording.webm");
+  });
+
+  it("rejects a recording token for a different track", async () => {
+    const wrongTrackToken = await issueRecordingUploadToken("s1", "other-track");
+
+    const res = await presignUpload(
+      postJson(
+        "/api/upload/presign",
+        { sessionId: "s1", trackId: "t1", partNumber: 47 },
+        { "x-cozytrack-recording-token": wrongTrackToken },
+      ),
+    );
+
+    expect(res.status).toBe(401);
+  });
+
+  it("completes an upload with the recording token after cookies expire", async () => {
+    mocks.tracks.set("t1", {
+      id: "t1",
+      sessionId: "s1",
+      participantName: "Alice",
+      s3Key: "sessions/s1/tracks/t1/recording.webm",
+      status: "recording",
+      durationMs: null,
+    });
+    const recordingToken = await issueRecordingUploadToken("s1", "t1");
+
+    const res = await completeUpload(
+      postJson(
+        "/api/upload/complete",
+        { sessionId: "s1", trackId: "t1", durationMs: 12345 },
+        { "x-cozytrack-recording-token": recordingToken },
+      ),
+    );
+
+    expect(res.status).toBe(200);
+    expect(mocks.tracks.get("t1")).toMatchObject({
+      status: "complete",
+      durationMs: 12345,
+    });
+    expect(mocks.deleteTrackChunks).toHaveBeenCalledWith("s1", "t1");
+  });
+
+  it("forbids completing a track outside the requested session", async () => {
+    mocks.tracks.set("t1", {
+      id: "t1",
+      sessionId: "other-session",
+      participantName: "Alice",
+      s3Key: "sessions/other-session/tracks/t1/recording.webm",
+      status: "recording",
+      durationMs: null,
+    });
+    const recordingToken = await issueRecordingUploadToken("s1", "t1");
+
+    const res = await completeUpload(
+      postJson(
+        "/api/upload/complete",
+        { sessionId: "s1", trackId: "t1", durationMs: 12345 },
+        { "x-cozytrack-recording-token": recordingToken },
+      ),
+    );
+
+    expect(res.status).toBe(403);
+    expect(mocks.tracks.get("t1")?.status).toBe("recording");
+  });
+});

--- a/tests/upload-client.test.ts
+++ b/tests/upload-client.test.ts
@@ -1,0 +1,88 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  completeUpload,
+  getPresignedUploadTarget,
+  getPresignedUploadUrl,
+} from "@/lib/upload";
+
+const fetchMock = vi.fn();
+
+beforeEach(() => {
+  vi.stubGlobal("fetch", fetchMock);
+  fetchMock.mockReset();
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+function jsonResponse(body: Record<string, unknown>, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "content-type": "application/json" },
+  });
+}
+
+describe("upload client auth", () => {
+  it("returns the recording token from the initial presign response", async () => {
+    fetchMock.mockResolvedValueOnce(
+      jsonResponse({
+        url: "https://s3.example/chunk-0",
+        recordingToken: "recording-token",
+      }),
+    );
+
+    const target = await getPresignedUploadTarget(
+      "session-1",
+      "track-1",
+      0,
+      "Alice",
+    );
+
+    expect(target).toEqual({
+      url: "https://s3.example/chunk-0",
+      recordingToken: "recording-token",
+    });
+  });
+
+  it("sends the recording token when requesting later chunk presigns", async () => {
+    fetchMock.mockResolvedValueOnce(
+      jsonResponse({ url: "https://s3.example/47" }),
+    );
+
+    await getPresignedUploadUrl(
+      "session-1",
+      "track-1",
+      47,
+      undefined,
+      undefined,
+      "recording-token",
+    );
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      "/api/upload/presign",
+      expect.objectContaining({
+        headers: {
+          "Content-Type": "application/json",
+          "X-Cozytrack-Recording-Token": "recording-token",
+        },
+      }),
+    );
+  });
+
+  it("sends the recording token when completing the upload", async () => {
+    fetchMock.mockResolvedValueOnce(jsonResponse({ status: "complete" }));
+
+    await completeUpload("session-1", "track-1", 12345, "recording-token");
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      "/api/upload/complete",
+      expect.objectContaining({
+        headers: {
+          "Content-Type": "application/json",
+          "X-Cozytrack-Recording-Token": "recording-token",
+        },
+      }),
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- Add 12-hour recording-scoped upload tokens minted when recording upload starts.
- Allow upload presign and complete routes to accept that token after normal auth cookies expire, including the first recorded chunk at `partNumber: 0`.
- Reuse the token in the studio upload flow for chunks, final recording.webm upload, and completion.
- Add regression coverage for route auth, middleware pass-through, and client upload headers.

## Verification
- `npm run test -- tests/upload-auth.test.ts tests/upload-client.test.ts tests/middleware.test.ts` (17 passed)
- `npm run test` (110 passed)
- `npm run build` (passed)

Closes #89