### PR TITLE
Add baseline CI validation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,56 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: read
+
+jobs:
+  validation:
+    name: Baseline validation
+    runs-on: ubuntu-latest
+    env:
+      AUTH_SECRET: cozytrack-ci-auth-secret-32-characters
+      HOST_PASSWORD: cozytrack-ci-password
+      DATABASE_URL: postgresql://cozytrack:cozytrack@localhost:5432/cozytrack
+      DIRECT_DATABASE_URL: postgresql://cozytrack:cozytrack@localhost:5432/cozytrack
+      LIVEKIT_API_KEY: devkey
+      LIVEKIT_API_SECRET: cozytrack-local-livekit-secret-32
+      LIVEKIT_URL: ws://localhost:7880
+      NEXT_PUBLIC_LIVEKIT_URL: ws://localhost:7880
+      AWS_REGION: us-east-1
+      AWS_ACCESS_KEY_ID: cozytrack-ci
+      AWS_SECRET_ACCESS_KEY: cozytrack-ci
+      S3_BUCKET_NAME: cozytrack-ci-test
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v5
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Lint
+        run: npm run lint
+
+      - name: Typecheck
+        run: npm run typecheck
+
+      - name: Test
+        run: npm test
+
+      - name: Validate Prisma schema
+        run: npx prisma validate
+
+      - name: Build
+        run: npm run build

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "start": "next start",
     "postinstall": "prisma generate",
     "lint": "next lint",
+    "typecheck": "tsc --noEmit --incremental false",
     "db:migrate": "prisma migrate dev",
     "db:generate": "prisma generate",
     "db:push": "prisma db push",

--- a/src/lib/s3.ts
+++ b/src/lib/s3.ts
@@ -11,6 +11,12 @@ import {
 import { getSignedUrl } from "@aws-sdk/s3-request-presigner";
 
 type S3ClientConfig = NonNullable<ConstructorParameters<typeof S3Client>[0]>;
+type S3Env = {
+  AWS_REGION?: string;
+  S3_ENDPOINT?: string;
+  S3_FORCE_PATH_STYLE?: string;
+  [key: string]: string | undefined;
+};
 
 function cleanEnv(value: string | undefined): string | undefined {
   const trimmed = value?.trim();
@@ -34,7 +40,7 @@ function booleanEnv(value: string | undefined): boolean | undefined {
 }
 
 export function buildS3ClientConfig(
-  env: NodeJS.ProcessEnv = process.env,
+  env: S3Env = process.env,
 ): S3ClientConfig {
   const endpoint = cleanEnv(env.S3_ENDPOINT);
   const forcePathStyle = booleanEnv(env.S3_FORCE_PATH_STYLE) ?? Boolean(endpoint);


### PR DESCRIPTION
## Summary

Adds the baseline validation workflow requested in #86.

- adds a PR/main GitHub Actions workflow separate from Codex review automation
- adds an explicit TypeScript typecheck script
- keeps S3 config test inputs typecheckable by narrowing the env shape used by the helper

Closes #86

## Verification

- `npm run lint` - passed, no ESLint warnings or errors
- `npm run typecheck` - passed
- `npm test` - 17 files passed, 123 tests passed
- `npx prisma validate` - schema valid
- `npm run build` - passed