### PR TITLE
Add service-backed upload integration CI

### DIFF
--- a/.github/workflows/service-integration.yml
+++ b/.github/workflows/service-integration.yml
@@ -1,0 +1,81 @@
+name: Service integration
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: read
+
+jobs:
+  service-integration:
+    name: Prisma and storage integration
+    runs-on: ubuntu-latest
+    services:
+      postgres:
+        image: postgres:16
+        env:
+          POSTGRES_USER: cozytrack
+          POSTGRES_PASSWORD: cozytrack
+          POSTGRES_DB: cozytrack
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd "pg_isready -U cozytrack -d cozytrack"
+          --health-interval 5s
+          --health-timeout 5s
+          --health-retries 10
+
+    env:
+      COZYTRACK_INTEGRATION_TEST: "1"
+      AUTH_SECRET: cozytrack-ci-auth-secret-32-characters
+      DATABASE_URL: postgresql://cozytrack:cozytrack@localhost:5432/cozytrack
+      DIRECT_DATABASE_URL: postgresql://cozytrack:cozytrack@localhost:5432/cozytrack
+      AWS_REGION: us-east-1
+      AWS_ACCESS_KEY_ID: minioadmin
+      AWS_SECRET_ACCESS_KEY: minioadmin
+      S3_BUCKET_NAME: cozytrack-ci-test
+      S3_ENDPOINT: http://127.0.0.1:9000
+      S3_FORCE_PATH_STYLE: "true"
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v5
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Start MinIO
+        run: |
+          docker run --rm -d \
+            --name cozytrack-minio \
+            -p 9000:9000 \
+            -e MINIO_ROOT_USER=minioadmin \
+            -e MINIO_ROOT_PASSWORD=minioadmin \
+            quay.io/minio/minio:latest server /data
+
+      - name: Wait for MinIO
+        run: |
+          for attempt in $(seq 1 60); do
+            if curl -fsS http://127.0.0.1:9000/minio/health/live >/dev/null; then
+              exit 0
+            fi
+            echo "Waiting for MinIO ($attempt/60)"
+            sleep 1
+          done
+          echo "Timed out waiting for MinIO" >&2
+          exit 1
+
+      - name: Apply Prisma migrations
+        run: npx prisma migrate deploy
+
+      - name: Run service integration tests
+        run: npm run test:integration

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "postinstall": "prisma generate",
     "lint": "next lint",
     "typecheck": "tsc --noEmit --incremental false",
+    "test:integration": "vitest run --config vitest.integration.config.ts",
     "db:migrate": "prisma migrate dev",
     "db:generate": "prisma generate",
     "db:push": "prisma db push",

--- a/tests/integration/upload-flow.test.ts
+++ b/tests/integration/upload-flow.test.ts
@@ -1,0 +1,260 @@
+import {
+  CreateBucketCommand,
+  DeleteObjectsCommand,
+  HeadBucketCommand,
+  ListObjectsV2Command,
+  type S3Client,
+} from "@aws-sdk/client-s3";
+import { randomUUID } from "node:crypto";
+import { afterEach, beforeAll, describe, expect, it } from "vitest";
+import { NextRequest } from "next/server";
+
+type Modules = {
+  auth: typeof import("@/lib/auth");
+  completeUpload: typeof import("@/app/api/upload/complete/route").POST;
+  db: typeof import("@/lib/db").db;
+  presignUpload: typeof import("@/app/api/upload/presign/route").POST;
+  s3: typeof import("@/lib/s3");
+};
+
+let modules: Modules;
+const cleanupSessions = new Set<string>();
+
+function requiredEnv(name: string): string {
+  const value = process.env[name];
+  if (!value) {
+    throw new Error(`${name} is required for integration tests`);
+  }
+  return value;
+}
+
+function assertSafeIntegrationEnv() {
+  if (process.env.COZYTRACK_INTEGRATION_TEST !== "1") {
+    throw new Error("Set COZYTRACK_INTEGRATION_TEST=1 to run integration tests");
+  }
+
+  const bucket = requiredEnv("S3_BUCKET_NAME");
+  if (!/(ci|test|local)/i.test(bucket)) {
+    throw new Error(`Refusing to use non-test bucket: ${bucket}`);
+  }
+
+  const databaseUrl = requiredEnv("DATABASE_URL");
+  if (!/(localhost|127\.0\.0\.1)/.test(databaseUrl)) {
+    throw new Error("Integration tests require a local throwaway DATABASE_URL");
+  }
+}
+
+async function loadModules(): Promise<Modules> {
+  const [auth, completeRoute, dbModule, presignRoute, s3] = await Promise.all([
+    import("@/lib/auth"),
+    import("@/app/api/upload/complete/route"),
+    import("@/lib/db"),
+    import("@/app/api/upload/presign/route"),
+    import("@/lib/s3"),
+  ]);
+
+  return {
+    auth,
+    completeUpload: completeRoute.POST,
+    db: dbModule.db,
+    presignUpload: presignRoute.POST,
+    s3,
+  };
+}
+
+async function ensureBucket(s3: S3Client, bucket: string) {
+  try {
+    await s3.send(new HeadBucketCommand({ Bucket: bucket }));
+    return;
+  } catch (error) {
+    const status = (error as { $metadata?: { httpStatusCode?: number } })
+      .$metadata?.httpStatusCode;
+    if (status !== 404) throw error;
+  }
+
+  await s3.send(new CreateBucketCommand({ Bucket: bucket }));
+}
+
+async function deletePrefix(s3: S3Client, bucket: string, prefix: string) {
+  let continuationToken: string | undefined;
+
+  do {
+    const listed = await s3.send(
+      new ListObjectsV2Command({
+        Bucket: bucket,
+        Prefix: prefix,
+        ContinuationToken: continuationToken,
+      }),
+    );
+
+    const objects = (listed.Contents ?? [])
+      .map((object) => object.Key)
+      .filter((key): key is string => Boolean(key))
+      .map((Key) => ({ Key }));
+
+    if (objects.length > 0) {
+      await s3.send(
+        new DeleteObjectsCommand({
+          Bucket: bucket,
+          Delete: { Objects: objects, Quiet: true },
+        }),
+      );
+    }
+
+    continuationToken = listed.IsTruncated
+      ? listed.NextContinuationToken
+      : undefined;
+  } while (continuationToken);
+}
+
+function postJson(
+  path: string,
+  body: Record<string, unknown>,
+  headers: Record<string, string> = {},
+): NextRequest {
+  return new NextRequest(`http://localhost:3001${path}`, {
+    method: "POST",
+    headers: {
+      "content-type": "application/json",
+      ...headers,
+    },
+    body: JSON.stringify(body),
+  });
+}
+
+async function putPresignedBytes(url: string, bytes: Uint8Array) {
+  const body = new ArrayBuffer(bytes.byteLength);
+  new Uint8Array(body).set(bytes);
+  const response = await fetch(url, {
+    method: "PUT",
+    headers: { "content-type": "audio/webm" },
+    body: new Blob([body], { type: "audio/webm" }),
+  });
+
+  expect(response.ok).toBe(true);
+}
+
+beforeAll(async () => {
+  assertSafeIntegrationEnv();
+  modules = await loadModules();
+  await ensureBucket(modules.s3.s3, requiredEnv("S3_BUCKET_NAME"));
+});
+
+afterEach(async () => {
+  for (const sessionId of cleanupSessions) {
+    await modules.db.track.deleteMany({ where: { sessionId } });
+    await modules.db.session.deleteMany({ where: { id: sessionId } });
+    await deletePrefix(
+      modules.s3.s3,
+      requiredEnv("S3_BUCKET_NAME"),
+      modules.s3.sessionPrefix(sessionId),
+    );
+  }
+  cleanupSessions.clear();
+});
+
+describe("recording upload service integration", () => {
+  it("creates, stores, completes, and cleans up a recording through real Postgres and S3-compatible storage", async () => {
+    const sessionId = `it-${randomUUID()}`;
+    const trackId = `track-${randomUUID()}`;
+    const sessionStartedAt = new Date("2026-01-01T00:00:00.000Z").toISOString();
+    cleanupSessions.add(sessionId);
+
+    await modules.db.session.create({
+      data: { id: sessionId, name: "Integration test session" },
+    });
+
+    const hostToken = await modules.auth.issueHostSessionCookie();
+    const hostHeaders = {
+      cookie: `${modules.auth.AUTH_COOKIES.host}=${hostToken}`,
+    };
+
+    const start = await modules.presignUpload(
+      postJson(
+        "/api/upload/presign",
+        {
+          sessionId,
+          trackId,
+          partNumber: 0,
+          participantName: "Integration Host",
+          deviceLabel: "USB Integration Mic",
+          deviceId: "integration-device",
+          isBuiltInMic: false,
+          sessionStartedAt,
+        },
+        hostHeaders,
+      ),
+    );
+
+    expect(start.status).toBe(200);
+    const startBody = (await start.json()) as {
+      key: string;
+      recordingToken: string;
+      url: string;
+    };
+    expect(startBody.key).toBe(modules.s3.trackPartKey(sessionId, trackId, 0));
+    expect(startBody.recordingToken).toEqual(expect.any(String));
+    await putPresignedBytes(startBody.url, new Uint8Array([1, 2, 3]));
+
+    const secondChunk = await modules.presignUpload(
+      postJson(
+        "/api/upload/presign",
+        { sessionId, trackId, partNumber: 1 },
+        { "x-cozytrack-recording-token": startBody.recordingToken },
+      ),
+    );
+    expect(secondChunk.status).toBe(200);
+    const secondChunkBody = (await secondChunk.json()) as {
+      key: string;
+      url: string;
+    };
+    expect(secondChunkBody.key).toBe(
+      modules.s3.trackPartKey(sessionId, trackId, 1),
+    );
+    await putPresignedBytes(secondChunkBody.url, new Uint8Array([4, 5, 6]));
+
+    const finalUpload = await modules.presignUpload(
+      postJson(
+        "/api/upload/presign",
+        { sessionId, trackId, partNumber: 9999 },
+        { "x-cozytrack-recording-token": startBody.recordingToken },
+      ),
+    );
+    expect(finalUpload.status).toBe(200);
+    const finalBody = (await finalUpload.json()) as { key: string; url: string };
+    expect(finalBody.key).toBe(modules.s3.trackRecordingKey(sessionId, trackId));
+    await putPresignedBytes(finalBody.url, new Uint8Array([7, 8, 9, 10]));
+
+    const complete = await modules.completeUpload(
+      postJson(
+        "/api/upload/complete",
+        { sessionId, trackId, durationMs: 12_345 },
+        { "x-cozytrack-recording-token": startBody.recordingToken },
+      ),
+    );
+    expect(complete.status).toBe(200);
+
+    const track = await modules.db.track.findUnique({ where: { id: trackId } });
+    expect(track).toMatchObject({
+      sessionId,
+      participantName: "Integration Host",
+      s3Key: modules.s3.trackRecordingKey(sessionId, trackId),
+      status: "complete",
+      durationMs: 12_345,
+      deviceLabel: "USB Integration Mic",
+      deviceId: "integration-device",
+      isBuiltInMic: false,
+      partial: false,
+    });
+    expect(track?.sessionStartedAt?.toISOString()).toBe(sessionStartedAt);
+
+    await expect(
+      modules.s3.trackRecordingExists(sessionId, trackId),
+    ).resolves.toBe(true);
+    await expect(
+      modules.s3.getObjectBytes(modules.s3.trackRecordingKey(sessionId, trackId)),
+    ).resolves.toEqual(new Uint8Array([7, 8, 9, 10]));
+    await expect(modules.s3.listTrackChunkParts(sessionId, trackId)).resolves
+      .toHaveLength(0);
+  });
+});

--- a/vitest.integration.config.ts
+++ b/vitest.integration.config.ts
@@ -8,8 +8,12 @@ export default defineConfig({
     },
   },
   test: {
-    environment: "happy-dom",
-    include: ["tests/**/*.test.ts"],
-    exclude: ["tests/integration/**/*.test.ts"],
+    environment: "node",
+    include: ["tests/integration/**/*.test.ts"],
+    hookTimeout: 30_000,
+    testTimeout: 30_000,
+    sequence: {
+      concurrent: false,
+    },
   },
 });


### PR DESCRIPTION
## Summary

Adds the Tier 1 service-backed integration layer from #88.

- adds a separate service integration workflow for Postgres + MinIO-backed checks
- adds `npm run test:integration` with a dedicated Vitest config
- exercises the recording upload API path against real Prisma/Postgres and S3-compatible storage
- keeps browser and multi-participant Playwright E2E deferred to #63

Closes #88

## Verification

- `npm run lint` - passed, no ESLint warnings or errors
- `npm run typecheck` - passed
- `npm test` - 17 files passed, 123 tests passed
- `DATABASE_URL=postgresql://cozytrack:cozytrack@127.0.0.1:5433/cozytrack DIRECT_DATABASE_URL=postgresql://cozytrack:cozytrack@127.0.0.1:5433/cozytrack npx prisma migrate deploy` - 5 migrations found, all applied/confirmed
- `COZYTRACK_INTEGRATION_TEST=1 ... npm run test:integration` - 1 file passed, 1 test passed against local Docker Postgres and MinIO
- `npm run build` - passed

## Notes

This PR builds on the baseline validation workflow merged in #93. Full browser/multi-participant E2E remains tracked separately in #63.