### PR TITLE
Add upload failure integration coverage

### DIFF
--- a/tests/integration/upload-flow.test.ts
+++ b/tests/integration/upload-flow.test.ts
@@ -13,7 +13,9 @@ type Modules = {
   auth: typeof import("@/lib/auth");
   completeUpload: typeof import("@/app/api/upload/complete/route").POST;
   db: typeof import("@/lib/db").db;
+  finalizeSession: typeof import("@/app/api/sessions/[id]/finalize/route").POST;
   presignUpload: typeof import("@/app/api/upload/presign/route").POST;
+  recoverTrack: typeof import("@/lib/recovery").recoverTrack;
   s3: typeof import("@/lib/s3");
 };
 
@@ -45,11 +47,21 @@ function assertSafeIntegrationEnv() {
 }
 
 async function loadModules(): Promise<Modules> {
-  const [auth, completeRoute, dbModule, presignRoute, s3] = await Promise.all([
+  const [
+    auth,
+    completeRoute,
+    dbModule,
+    finalizeRoute,
+    presignRoute,
+    recovery,
+    s3,
+  ] = await Promise.all([
     import("@/lib/auth"),
     import("@/app/api/upload/complete/route"),
     import("@/lib/db"),
+    import("@/app/api/sessions/[id]/finalize/route"),
     import("@/app/api/upload/presign/route"),
+    import("@/lib/recovery"),
     import("@/lib/s3"),
   ]);
 
@@ -57,7 +69,9 @@ async function loadModules(): Promise<Modules> {
     auth,
     completeUpload: completeRoute.POST,
     db: dbModule.db,
+    finalizeSession: finalizeRoute.POST,
     presignUpload: presignRoute.POST,
+    recoverTrack: recovery.recoverTrack,
     s3,
   };
 }
@@ -134,6 +148,52 @@ async function putPresignedBytes(url: string, bytes: Uint8Array) {
   expect(response.ok).toBe(true);
 }
 
+async function createSession(name = "Integration test session"): Promise<string> {
+  const sessionId = `it-${randomUUID()}`;
+  cleanupSessions.add(sessionId);
+  await modules.db.session.create({
+    data: { id: sessionId, name },
+  });
+  return sessionId;
+}
+
+async function hostHeaders(): Promise<Record<string, string>> {
+  const hostToken = await modules.auth.issueHostSessionCookie();
+  return {
+    cookie: `${modules.auth.AUTH_COOKIES.host}=${hostToken}`,
+  };
+}
+
+async function startUpload(
+  sessionId: string,
+  trackId = `track-${randomUUID()}`,
+): Promise<{ recordingToken: string; trackId: string; url: string }> {
+  const start = await modules.presignUpload(
+    postJson(
+      "/api/upload/presign",
+      {
+        sessionId,
+        trackId,
+        partNumber: 0,
+        participantName: "Integration Host",
+        deviceLabel: "USB Integration Mic",
+        deviceId: "integration-device",
+        isBuiltInMic: false,
+        sessionStartedAt: new Date("2026-01-01T00:00:00.000Z").toISOString(),
+      },
+      await hostHeaders(),
+    ),
+  );
+
+  expect(start.status).toBe(200);
+  const body = (await start.json()) as {
+    recordingToken: string;
+    url: string;
+  };
+
+  return { recordingToken: body.recordingToken, trackId, url: body.url };
+}
+
 beforeAll(async () => {
   assertSafeIntegrationEnv();
   modules = await loadModules();
@@ -155,19 +215,9 @@ afterEach(async () => {
 
 describe("recording upload service integration", () => {
   it("creates, stores, completes, and cleans up a recording through real Postgres and S3-compatible storage", async () => {
-    const sessionId = `it-${randomUUID()}`;
+    const sessionId = await createSession();
     const trackId = `track-${randomUUID()}`;
     const sessionStartedAt = new Date("2026-01-01T00:00:00.000Z").toISOString();
-    cleanupSessions.add(sessionId);
-
-    await modules.db.session.create({
-      data: { id: sessionId, name: "Integration test session" },
-    });
-
-    const hostToken = await modules.auth.issueHostSessionCookie();
-    const hostHeaders = {
-      cookie: `${modules.auth.AUTH_COOKIES.host}=${hostToken}`,
-    };
 
     const start = await modules.presignUpload(
       postJson(
@@ -182,7 +232,7 @@ describe("recording upload service integration", () => {
           isBuiltInMic: false,
           sessionStartedAt,
         },
-        hostHeaders,
+        await hostHeaders(),
       ),
     );
 
@@ -256,5 +306,146 @@ describe("recording upload service integration", () => {
     ).resolves.toEqual(new Uint8Array([7, 8, 9, 10]));
     await expect(modules.s3.listTrackChunkParts(sessionId, trackId)).resolves
       .toHaveLength(0);
+  });
+
+  it("rejects a recording token when presigning or completing a different track", async () => {
+    const sessionId = await createSession();
+    const { recordingToken } = await startUpload(sessionId);
+    const otherTrackId = `track-${randomUUID()}`;
+
+    const presign = await modules.presignUpload(
+      postJson(
+        "/api/upload/presign",
+        { sessionId, trackId: otherTrackId, partNumber: 1 },
+        { "x-cozytrack-recording-token": recordingToken },
+      ),
+    );
+    expect(presign.status).toBe(401);
+
+    const complete = await modules.completeUpload(
+      postJson(
+        "/api/upload/complete",
+        { sessionId, trackId: otherTrackId, durationMs: 1000 },
+        { "x-cozytrack-recording-token": recordingToken },
+      ),
+    );
+    expect(complete.status).toBe(401);
+  });
+
+  it("rejects completion when the track belongs to a different session", async () => {
+    const owningSessionId = await createSession("Owning session");
+    const otherSessionId = await createSession("Other session");
+    const { trackId } = await startUpload(owningSessionId);
+
+    const complete = await modules.completeUpload(
+      postJson(
+        "/api/upload/complete",
+        { sessionId: otherSessionId, trackId, durationMs: 1000 },
+        await hostHeaders(),
+      ),
+    );
+    expect(complete.status).toBe(403);
+
+    const track = await modules.db.track.findUnique({ where: { id: trackId } });
+    expect(track?.status).toBe("recording");
+  });
+
+  it("keeps finalize blocked while a track is still actively uploading", async () => {
+    const sessionId = await createSession();
+    const { recordingToken, trackId, url } = await startUpload(sessionId);
+    await putPresignedBytes(url, new Uint8Array([1, 2, 3]));
+
+    const nextChunk = await modules.presignUpload(
+      postJson(
+        "/api/upload/presign",
+        { sessionId, trackId, partNumber: 1 },
+        { "x-cozytrack-recording-token": recordingToken },
+      ),
+    );
+    expect(nextChunk.status).toBe(200);
+    const nextChunkBody = (await nextChunk.json()) as { url: string };
+    await putPresignedBytes(nextChunkBody.url, new Uint8Array([4, 5, 6]));
+
+    const finalized = await modules.finalizeSession(
+      postJson(`/api/sessions/${sessionId}/finalize`, {}),
+      { params: Promise.resolve({ id: sessionId }) },
+    );
+
+    expect(finalized.status).toBe(409);
+    const body = (await finalized.json()) as {
+      pending: Array<{ trackId: string; participantName: string; status: string }>;
+    };
+    expect(body.pending).toEqual([
+      {
+        trackId,
+        participantName: "Integration Host",
+        status: "recording",
+      },
+    ]);
+  });
+
+  it("recovers a recording by stitching real contiguous chunks from S3-compatible storage", async () => {
+    const sessionId = await createSession();
+    const { recordingToken, trackId, url } = await startUpload(sessionId);
+    await putPresignedBytes(url, new Uint8Array([1, 2]));
+
+    const secondChunk = await modules.presignUpload(
+      postJson(
+        "/api/upload/presign",
+        { sessionId, trackId, partNumber: 1 },
+        { "x-cozytrack-recording-token": recordingToken },
+      ),
+    );
+    expect(secondChunk.status).toBe(200);
+    const secondChunkBody = (await secondChunk.json()) as { url: string };
+    await putPresignedBytes(secondChunkBody.url, new Uint8Array([3, 4]));
+
+    const recovered = await modules.recoverTrack(trackId);
+
+    expect(recovered).toMatchObject({
+      outcome: "recovered_from_chunks",
+      partial: false,
+      status: "complete",
+      chunkCount: 2,
+      missingPartNumbers: [],
+    });
+    await expect(
+      modules.s3.getObjectBytes(modules.s3.trackRecordingKey(sessionId, trackId)),
+    ).resolves.toEqual(new Uint8Array([1, 2, 3, 4]));
+    await expect(modules.s3.listTrackChunkParts(sessionId, trackId)).resolves
+      .toHaveLength(2);
+  });
+
+  it("marks recovered recordings partial when uploaded chunks have gaps", async () => {
+    const sessionId = await createSession();
+    const { recordingToken, trackId, url } = await startUpload(sessionId);
+    await putPresignedBytes(url, new Uint8Array([1, 2]));
+
+    const thirdChunk = await modules.presignUpload(
+      postJson(
+        "/api/upload/presign",
+        { sessionId, trackId, partNumber: 2 },
+        { "x-cozytrack-recording-token": recordingToken },
+      ),
+    );
+    expect(thirdChunk.status).toBe(200);
+    const thirdChunkBody = (await thirdChunk.json()) as { url: string };
+    await putPresignedBytes(thirdChunkBody.url, new Uint8Array([5, 6]));
+
+    const recovered = await modules.recoverTrack(trackId);
+
+    expect(recovered).toMatchObject({
+      outcome: "recovered_partial",
+      partial: true,
+      status: "complete",
+      chunkCount: 2,
+      missingPartNumbers: [1],
+    });
+
+    const track = await modules.db.track.findUnique({ where: { id: trackId } });
+    expect(track?.partial).toBe(true);
+    await expect(
+      modules.s3.getObjectBytes(modules.s3.trackRecordingKey(sessionId, trackId)),
+    ).resolves.toEqual(new Uint8Array([1, 2, 5, 6]));
   });
 });


### PR DESCRIPTION
## Summary

Adds the next Tier 1 integration coverage from #95.

- expands the service-backed upload integration suite from 1 happy-path test to 6 tests
- covers recording-token mismatch failures for presign and complete
- covers wrong-session completion rejection
- covers finalize staying blocked while chunks are still active
- covers real MinIO chunk recovery for contiguous and partial/gapped chunks

Closes #95

## Verification

- `npm run typecheck` - passed
- `npm test` - 17 files passed, 123 tests passed
- `COZYTRACK_INTEGRATION_TEST=1 ... npm run test:integration` - 1 file passed, 6 tests passed against local Docker Postgres and MinIO
- `npm run lint` - passed, no ESLint warnings or errors
- `npm run build` - passed