### PR TITLE
Add manual Codex review trigger

### DIFF
--- a/.github/workflows/codex-review.yml
+++ b/.github/workflows/codex-review.yml
@@ -30,21 +30,8 @@ jobs:
       final_message: ${{ steps.run_codex.outputs.final-message }}
       pr_number: ${{ steps.pr_context.outputs.number }}
     steps:
-      - name: Check OpenAI API key
-        id: api_key
-        env:
-          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
-        run: |
-          if [ -z "$OPENAI_API_KEY" ]; then
-            echo "available=false" >> "$GITHUB_OUTPUT"
-            echo "OPENAI_API_KEY is not configured; skipping Codex review."
-          else
-            echo "available=true" >> "$GITHUB_OUTPUT"
-          fi
-
       - name: Resolve PR context
         id: pr_context
-        if: steps.api_key.outputs.available == 'true'
         uses: actions/github-script@v7
         with:
           script: |
@@ -66,15 +53,36 @@ jobs:
             core.setOutput("head_sha", pr.head.sha);
             core.setOutput("title", pr.title ?? "");
             core.setOutput("body", pr.body ?? "");
+            core.setOutput(
+              "same_repo",
+              pr.head.repo?.full_name === `${context.repo.owner}/${context.repo.repo}` ? "true" : "false",
+            );
+
+      - name: Skip fork PR
+        if: steps.pr_context.outputs.same_repo != 'true'
+        run: echo "Codex review is skipped for forked pull requests."
+
+      - name: Check OpenAI API key
+        id: api_key
+        if: steps.pr_context.outputs.same_repo == 'true'
+        env:
+          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+        run: |
+          if [ -z "$OPENAI_API_KEY" ]; then
+            echo "available=false" >> "$GITHUB_OUTPUT"
+            echo "OPENAI_API_KEY is not configured; skipping Codex review."
+          else
+            echo "available=true" >> "$GITHUB_OUTPUT"
+          fi
 
       - uses: actions/checkout@v5
-        if: steps.api_key.outputs.available == 'true'
+        if: steps.pr_context.outputs.same_repo == 'true' && steps.api_key.outputs.available == 'true'
         with:
           ref: refs/pull/${{ steps.pr_context.outputs.number }}/merge
           persist-credentials: false
 
       - name: Pre-fetch PR refs
-        if: steps.api_key.outputs.available == 'true'
+        if: steps.pr_context.outputs.same_repo == 'true' && steps.api_key.outputs.available == 'true'
         env:
           PR_BASE_REF: ${{ steps.pr_context.outputs.base_ref }}
           PR_NUMBER: ${{ steps.pr_context.outputs.number }}
@@ -85,7 +93,7 @@ jobs:
 
       - name: Run Codex review
         id: run_codex
-        if: steps.api_key.outputs.available == 'true'
+        if: steps.pr_context.outputs.same_repo == 'true' && steps.api_key.outputs.available == 'true'
         uses: openai/codex-action@v1
         with:
           openai-api-key: ${{ secrets.OPENAI_API_KEY }}

--- a/.github/workflows/codex-review.yml
+++ b/.github/workflows/codex-review.yml
@@ -3,15 +3,32 @@ name: Codex review
 on:
   pull_request:
     types: [opened, ready_for_review, reopened]
+  issue_comment:
+    types: [created]
 
 jobs:
   codex:
-    if: github.event.pull_request.draft == false && github.event.pull_request.user.type != 'Bot'
+    if: >-
+      ${{
+        (
+          github.event_name == 'pull_request' &&
+          github.event.pull_request.draft == false &&
+          github.event.pull_request.user.type != 'Bot'
+        ) ||
+        (
+          github.event_name == 'issue_comment' &&
+          github.event.issue.pull_request &&
+          startsWith(github.event.comment.body, '/codex review') &&
+          contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.comment.author_association)
+        )
+      }}
     runs-on: ubuntu-latest
     permissions:
       contents: read
+      pull-requests: read
     outputs:
       final_message: ${{ steps.run_codex.outputs.final-message }}
+      pr_number: ${{ steps.pr_context.outputs.number }}
     steps:
       - name: Check OpenAI API key
         id: api_key
@@ -25,17 +42,42 @@ jobs:
             echo "available=true" >> "$GITHUB_OUTPUT"
           fi
 
+      - name: Resolve PR context
+        id: pr_context
+        if: steps.api_key.outputs.available == 'true'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const prNumber = context.eventName === "pull_request"
+              ? context.payload.pull_request.number
+              : context.payload.issue.number;
+
+            const pr = context.eventName === "pull_request"
+              ? context.payload.pull_request
+              : (await github.rest.pulls.get({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  pull_number: prNumber,
+                })).data;
+
+            core.setOutput("number", String(pr.number));
+            core.setOutput("base_ref", pr.base.ref);
+            core.setOutput("base_sha", pr.base.sha);
+            core.setOutput("head_sha", pr.head.sha);
+            core.setOutput("title", pr.title ?? "");
+            core.setOutput("body", pr.body ?? "");
+
       - uses: actions/checkout@v5
         if: steps.api_key.outputs.available == 'true'
         with:
-          ref: refs/pull/${{ github.event.pull_request.number }}/merge
+          ref: refs/pull/${{ steps.pr_context.outputs.number }}/merge
           persist-credentials: false
 
       - name: Pre-fetch PR refs
         if: steps.api_key.outputs.available == 'true'
         env:
-          PR_BASE_REF: ${{ github.event.pull_request.base.ref }}
-          PR_NUMBER: ${{ github.event.pull_request.number }}
+          PR_BASE_REF: ${{ steps.pr_context.outputs.base_ref }}
+          PR_NUMBER: ${{ steps.pr_context.outputs.number }}
         run: |
           git fetch --no-tags origin \
             "$PR_BASE_REF" \
@@ -53,9 +95,10 @@ jobs:
 
             Scope:
             - Repository: ${{ github.repository }}
-            - PR: #${{ github.event.pull_request.number }}
-            - Base SHA: ${{ github.event.pull_request.base.sha }}
-            - Head SHA: ${{ github.event.pull_request.head.sha }}
+            - PR: #${{ steps.pr_context.outputs.number }}
+            - Base SHA: ${{ steps.pr_context.outputs.base_sha }}
+            - Head SHA: ${{ steps.pr_context.outputs.head_sha }}
+            - Trigger: ${{ github.event_name }}
 
             Review only the changes introduced by this PR. Do not suggest broad refactors or style-only changes.
             Prioritize actionable findings with file and line references. If there are no findings, say that clearly.
@@ -63,8 +106,8 @@ jobs:
 
             Pull request title and body:
             ----
-            ${{ github.event.pull_request.title }}
-            ${{ github.event.pull_request.body }}
+            ${{ steps.pr_context.outputs.title }}
+            ${{ steps.pr_context.outputs.body }}
 
   post_feedback:
     runs-on: ubuntu-latest
@@ -90,6 +133,6 @@ jobs:
             await github.rest.issues.createComment({
               owner: context.repo.owner,
               repo: context.repo.repo,
-              issue_number: context.payload.pull_request.number,
+              issue_number: Number("${{ needs.codex.outputs.pr_number }}"),
               body,
             });


### PR DESCRIPTION
## Summary

- Keep the existing first-pass Codex review on opened, ready-for-review, and reopened PRs.
- Add a trusted PR comment trigger for `/codex review`.
- Resolve PR metadata for both pull request and comment events before checkout.
- Skip forked PRs before any secret-bearing Codex step runs.

Closes #99

## Verification

- Ruby YAML parse check for `.github/workflows/codex-review.yml` - passed.
- `git diff --check` - passed.
- GitHub Baseline validation on `4be904b` - passed in 1m12s.
- GitHub Prisma and storage integration on `4be904b` - passed in 54s.
- Vercel preview on `4be904b` - passed.
- Initial Codex review on PR open passed and posted one finding; fixed in `4be904b`.

Note: GitHub only evaluates `issue_comment` workflows from the default branch, so the new `/codex review` trigger can be exercised after merge. The existing pull request path ran on PR open.