### PR TITLE
Add browser recording smoke test

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@
 
 # testing
 /coverage
+/output/playwright
 
 # next.js
 /.next/

--- a/README.md
+++ b/README.md
@@ -147,6 +147,33 @@ To reset everything and immediately start the app:
 npm run init:local
 ```
 
+## Testing
+
+Fast validation:
+
+```bash
+npm test
+npm run typecheck
+```
+
+`npm run test:integration` expects `COZYTRACK_INTEGRATION_TEST=1` plus local
+Postgres and S3-compatible storage environment variables. The GitHub Actions
+service integration workflow documents the exact CI values.
+
+Browser recording smoke test:
+
+```bash
+npx playwright install chromium
+npm run test:browser
+```
+
+`npm run test:browser` starts the local Docker services, provisions a local
+MinIO bucket, pushes the Prisma schema, starts Next.js on port 3101, signs in
+as the host with test-only credentials, records with Chromium's fake
+microphone, and verifies a complete track row plus a non-empty
+`recording.webm` object in MinIO. It is intentionally single-browser coverage;
+the multi-participant E2E harness remains separate.
+
 ## Project Structure
 
 ```

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -37,7 +37,7 @@ services:
     environment:
       MINIO_ROOT_USER: ${MINIO_ROOT_USER:-minioadmin}
       MINIO_ROOT_PASSWORD: ${MINIO_ROOT_PASSWORD:-minioadmin}
-      MINIO_API_CORS_ALLOW_ORIGIN: ${MINIO_API_CORS_ALLOW_ORIGIN:-http://localhost:3000,http://127.0.0.1:3000,http://localhost:3001,http://127.0.0.1:3001}
+      MINIO_API_CORS_ALLOW_ORIGIN: ${MINIO_API_CORS_ALLOW_ORIGIN:-http://localhost:3000,http://127.0.0.1:3000,http://localhost:3001,http://127.0.0.1:3001,http://localhost:3101,http://127.0.0.1:3101}
     volumes:
       - miniodata:/data
     command: server /data --console-address ":9001"

--- a/package-lock.json
+++ b/package-lock.json
@@ -23,6 +23,7 @@
         "uuid": "^10.0.0"
       },
       "devDependencies": {
+        "@playwright/test": "^1.60.0",
         "@testing-library/react": "^16.3.2",
         "@types/node": "22.19.17",
         "@types/react": "^19.0.0",
@@ -961,7 +962,7 @@
       "version": "7.27.1",
       "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz",
       "integrity": "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
@@ -971,7 +972,7 @@
       "version": "7.28.5",
       "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.28.5.tgz",
       "integrity": "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
@@ -981,7 +982,7 @@
       "version": "7.29.2",
       "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.2.tgz",
       "integrity": "sha512-4GgRzy/+fsBa72/RZVJmGKPmZu9Byn8o4MoLpmNe1m8ZfYnz5emHLQz3U4gLud6Zwl0RZIcgiLD7Uq7ySFuDLA==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/types": "^7.29.0"
@@ -1007,7 +1008,7 @@
       "version": "7.29.0",
       "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.0.tgz",
       "integrity": "sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-string-parser": "^7.27.1",
@@ -2066,6 +2067,22 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/Boshen"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.60.0.tgz",
+      "integrity": "sha512-O71yZIbAh/PxDMNGns37GHBIfrVkEVyn+AXyIa5dOTfb4/xNvRWV+Vv/NMbNCtODB/pO7vLlF2OTmMVLhmr7Ag==",
+      "devOptional": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.60.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@prisma/client": {
@@ -7953,6 +7970,52 @@
         "confbox": "^0.2.2",
         "exsolve": "^1.0.7",
         "pathe": "^2.0.3"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.60.0.tgz",
+      "integrity": "sha512-hheHdokM8cdqCb0lcE3s+zT4t4W+vvjpGxsZlDnikarzx8tSzMebh3UiFtgqwFwnTnjYQcsyMF8ei2mCO/tpeA==",
+      "devOptional": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.60.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.60.0.tgz",
+      "integrity": "sha512-9bW6zvX/m0lEbgTKJ6YppOKx8H3VOPBMOCFh2irXFOT4BbHgrx5hPjwJYLT40Lu+4qtD36qKc/Hn56StUW57IA==",
+      "devOptional": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/possible-typed-array-names": {

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "lint": "next lint",
     "typecheck": "tsc --noEmit --incremental false",
     "test:integration": "vitest run --config vitest.integration.config.ts",
+    "test:browser": "bash ./scripts/test-browser-smoke.sh",
     "db:migrate": "prisma migrate dev",
     "db:generate": "prisma generate",
     "db:push": "prisma db push",
@@ -39,6 +40,7 @@
     "uuid": "^10.0.0"
   },
   "devDependencies": {
+    "@playwright/test": "^1.60.0",
     "@testing-library/react": "^16.3.2",
     "@types/node": "22.19.17",
     "@types/react": "^19.0.0",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,0 +1,44 @@
+import { defineConfig, devices } from "@playwright/test";
+
+const port = Number(process.env.COZYTRACK_BROWSER_PORT ?? 3101);
+const baseURL = `http://127.0.0.1:${port}`;
+
+export default defineConfig({
+  testDir: "./tests/browser",
+  timeout: 120_000,
+  expect: {
+    timeout: 20_000,
+  },
+  outputDir: "output/playwright/test-results",
+  reporter: [
+    ["list"],
+    ["html", { outputFolder: "output/playwright/report", open: "never" }],
+  ],
+  use: {
+    baseURL,
+    trace: "retain-on-failure",
+    video: "retain-on-failure",
+    launchOptions: {
+      args: [
+        "--autoplay-policy=no-user-gesture-required",
+        "--use-fake-device-for-media-stream",
+        "--use-fake-ui-for-media-stream",
+      ],
+    },
+  },
+  projects: [
+    {
+      name: "chromium",
+      use: {
+        ...devices["Desktop Chrome"],
+        permissions: ["microphone"],
+      },
+    },
+  ],
+  webServer: {
+    command: `./node_modules/.bin/next dev -H 127.0.0.1 -p ${port}`,
+    url: baseURL,
+    reuseExistingServer: false,
+    timeout: 120_000,
+  },
+});

--- a/scripts/test-browser-smoke.sh
+++ b/scripts/test-browser-smoke.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$ROOT_DIR"
+
+export COZYTRACK_BROWSER_SMOKE_TEST=1
+export COZYTRACK_BROWSER_PORT="${COZYTRACK_BROWSER_PORT:-3101}"
+export NEXT_TELEMETRY_DISABLED=1
+
+export DATABASE_URL="${COZYTRACK_BROWSER_DATABASE_URL:-postgresql://cozytrack:cozytrack@127.0.0.1:5433/cozytrack}"
+export DIRECT_DATABASE_URL="${COZYTRACK_BROWSER_DIRECT_DATABASE_URL:-$DATABASE_URL}"
+
+export AUTH_SECRET="${COZYTRACK_BROWSER_AUTH_SECRET:-cozytrack-browser-smoke-auth-secret-32chars}"
+export HOST_PASSWORD="${COZYTRACK_BROWSER_HOST_PASSWORD:-cozytrack-browser-smoke-password}"
+
+export LIVEKIT_API_KEY="${COZYTRACK_BROWSER_LIVEKIT_API_KEY:-devkey}"
+export LIVEKIT_API_SECRET="${COZYTRACK_BROWSER_LIVEKIT_API_SECRET:-cozytrack-local-livekit-secret-32}"
+export LIVEKIT_URL="${COZYTRACK_BROWSER_LIVEKIT_URL:-ws://127.0.0.1:7880}"
+export NEXT_PUBLIC_LIVEKIT_URL="${COZYTRACK_BROWSER_PUBLIC_LIVEKIT_URL:-ws://127.0.0.1:7880}"
+
+export MINIO_ROOT_USER="${MINIO_ROOT_USER:-minioadmin}"
+export MINIO_ROOT_PASSWORD="${MINIO_ROOT_PASSWORD:-minioadmin}"
+export AWS_ACCESS_KEY_ID="$MINIO_ROOT_USER"
+export AWS_SECRET_ACCESS_KEY="$MINIO_ROOT_PASSWORD"
+export AWS_REGION="${COZYTRACK_BROWSER_AWS_REGION:-us-east-1}"
+export S3_BUCKET_NAME="${COZYTRACK_BROWSER_S3_BUCKET_NAME:-cozytrack-browser-test}"
+export S3_ENDPOINT="${COZYTRACK_BROWSER_S3_ENDPOINT:-http://127.0.0.1:9000}"
+export S3_FORCE_PATH_STYLE=true
+export MINIO_API_CORS_ALLOW_ORIGIN="${MINIO_API_CORS_ALLOW_ORIGIN:-http://127.0.0.1:${COZYTRACK_BROWSER_PORT},http://localhost:${COZYTRACK_BROWSER_PORT},http://127.0.0.1:3001,http://localhost:3001}"
+
+docker compose --profile local-storage up -d postgres redis livekit minio
+docker compose --profile local-storage --profile tools run --rm minio-mc /scripts/minio-bucket.sh provision
+
+npx prisma db push
+npx playwright test --config playwright.config.ts "$@"

--- a/scripts/test-browser-smoke.sh
+++ b/scripts/test-browser-smoke.sh
@@ -30,7 +30,77 @@ export S3_ENDPOINT="${COZYTRACK_BROWSER_S3_ENDPOINT:-http://127.0.0.1:9000}"
 export S3_FORCE_PATH_STYLE=true
 export MINIO_API_CORS_ALLOW_ORIGIN="${MINIO_API_CORS_ALLOW_ORIGIN:-http://127.0.0.1:${COZYTRACK_BROWSER_PORT},http://localhost:${COZYTRACK_BROWSER_PORT},http://127.0.0.1:3001,http://localhost:3001}"
 
+assert_local_database_url() {
+  node -e '
+    const value = process.argv[1];
+    let parsed;
+    try {
+      parsed = new URL(value);
+    } catch (error) {
+      console.error(`Invalid DATABASE_URL: ${error.message}`);
+      process.exit(1);
+    }
+
+    const hostname = parsed.hostname.replace(/^\[|\]$/g, "");
+    const allowed = new Set(["localhost", "127.0.0.1", "::1"]);
+    if (!allowed.has(hostname)) {
+      console.error(`Refusing to run browser smoke test against non-local database host: ${hostname}`);
+      process.exit(1);
+    }
+  ' "$1"
+}
+
+assert_test_bucket() {
+  bucket_lc="$(printf '%s' "$S3_BUCKET_NAME" | tr '[:upper:]' '[:lower:]')"
+  case "$bucket_lc" in
+    *ci*|*test*|*local*)
+      ;;
+    *)
+      echo "Refusing to run browser smoke test against non-test bucket: $S3_BUCKET_NAME" >&2
+      exit 1
+      ;;
+  esac
+}
+
+wait_for_postgres() {
+  for attempt in $(seq 1 60); do
+    if docker compose exec -T postgres pg_isready -U cozytrack -d cozytrack >/dev/null 2>&1; then
+      return 0
+    fi
+
+    echo "Waiting for Postgres ($attempt/60)"
+    sleep 1
+  done
+
+  echo "Timed out waiting for Postgres" >&2
+  exit 1
+}
+
+wait_for_tcp() {
+  host="$1"
+  port="$2"
+  name="$3"
+
+  for attempt in $(seq 1 60); do
+    if (echo >"/dev/tcp/$host/$port") >/dev/null 2>&1; then
+      return 0
+    fi
+
+    echo "Waiting for $name at $host:$port ($attempt/60)"
+    sleep 1
+  done
+
+  echo "Timed out waiting for $name at $host:$port" >&2
+  exit 1
+}
+
+assert_local_database_url "$DATABASE_URL"
+assert_local_database_url "$DIRECT_DATABASE_URL"
+assert_test_bucket
+
 docker compose --profile local-storage up -d postgres redis livekit minio
+wait_for_postgres
+wait_for_tcp 127.0.0.1 7880 LiveKit
 docker compose --profile local-storage --profile tools run --rm minio-mc /scripts/minio-bucket.sh provision
 
 npx prisma db push

--- a/tests/browser/recording-smoke.spec.ts
+++ b/tests/browser/recording-smoke.spec.ts
@@ -1,0 +1,192 @@
+import { expect, test } from "@playwright/test";
+import {
+  DeleteObjectsCommand,
+  HeadObjectCommand,
+  ListObjectsV2Command,
+  S3Client,
+} from "@aws-sdk/client-s3";
+import { PrismaClient } from "@prisma/client";
+
+const db = new PrismaClient();
+const cleanupSessions = new Set<string>();
+
+function requiredEnv(name: string): string {
+  const value = process.env[name];
+  if (!value) {
+    throw new Error(`${name} is required for browser smoke tests`);
+  }
+  return value;
+}
+
+function assertSafeBrowserSmokeEnv() {
+  if (process.env.COZYTRACK_BROWSER_SMOKE_TEST !== "1") {
+    throw new Error("Set COZYTRACK_BROWSER_SMOKE_TEST=1 to run browser smoke tests");
+  }
+
+  const bucket = requiredEnv("S3_BUCKET_NAME");
+  if (!/(ci|test|local)/i.test(bucket)) {
+    throw new Error(`Refusing to use non-test bucket: ${bucket}`);
+  }
+
+  const databaseUrl = requiredEnv("DATABASE_URL");
+  if (!/(localhost|127\.0\.0\.1)/.test(databaseUrl)) {
+    throw new Error("Browser smoke tests require a local throwaway DATABASE_URL");
+  }
+}
+
+function createS3Client(): S3Client {
+  return new S3Client({
+    region: requiredEnv("AWS_REGION"),
+    endpoint: process.env.S3_ENDPOINT,
+    forcePathStyle: process.env.S3_FORCE_PATH_STYLE === "true",
+    credentials: {
+      accessKeyId: requiredEnv("AWS_ACCESS_KEY_ID"),
+      secretAccessKey: requiredEnv("AWS_SECRET_ACCESS_KEY"),
+    },
+  });
+}
+
+async function deletePrefix(s3: S3Client, bucket: string, prefix: string) {
+  let continuationToken: string | undefined;
+
+  do {
+    const listed = await s3.send(
+      new ListObjectsV2Command({
+        Bucket: bucket,
+        Prefix: prefix,
+        ContinuationToken: continuationToken,
+      }),
+    );
+
+    const objects = (listed.Contents ?? [])
+      .map((object) => object.Key)
+      .filter((key): key is string => Boolean(key))
+      .map((Key) => ({ Key }));
+
+    if (objects.length > 0) {
+      await s3.send(
+        new DeleteObjectsCommand({
+          Bucket: bucket,
+          Delete: { Objects: objects, Quiet: true },
+        }),
+      );
+    }
+
+    continuationToken = listed.IsTruncated
+      ? listed.NextContinuationToken
+      : undefined;
+  } while (continuationToken);
+}
+
+test.beforeAll(() => {
+  assertSafeBrowserSmokeEnv();
+});
+
+test.afterEach(async () => {
+  const s3 = createS3Client();
+  const bucket = requiredEnv("S3_BUCKET_NAME");
+
+  for (const sessionId of cleanupSessions) {
+    await db.track.deleteMany({ where: { sessionId } });
+    await db.session.deleteMany({ where: { id: sessionId } });
+    await deletePrefix(s3, bucket, `sessions/${sessionId}/`);
+  }
+  cleanupSessions.clear();
+});
+
+test.afterAll(async () => {
+  await db.$disconnect();
+});
+
+test("records a host track through the browser and stores a completed WebM", async ({
+  page,
+}) => {
+  const hostPassword = requiredEnv("HOST_PASSWORD");
+  const sessionName = `Browser smoke ${Date.now()}`;
+  const participantName = "Browser Smoke Host";
+
+  await test.step("sign in and create a session", async () => {
+    await page.goto("/signin?return_to=/");
+    await page.getByLabel("Password").fill(hostPassword);
+    await page.getByRole("button", { name: "Sign in" }).click();
+
+    await expect(page).toHaveURL(/\/$/);
+    await page.getByPlaceholder(/Name this session/).fill(sessionName);
+    await page.getByRole("button", { name: /Record/ }).click();
+    await expect(page).toHaveURL(/\/studio\/[^/]+$/);
+  });
+
+  const sessionId = page.url().split("/studio/")[1];
+  if (!sessionId) {
+    throw new Error(`Could not extract session id from URL: ${page.url()}`);
+  }
+  cleanupSessions.add(sessionId);
+
+  await test.step("join the studio with a fake microphone", async () => {
+    await page.getByPlaceholder("Enter your name").fill(participantName);
+    await page.getByRole("button", { name: "Join Studio" }).click();
+
+    const continueWithBuiltInMic = page.getByRole("button", {
+      name: /continue with built-in mic/i,
+    });
+    if (await continueWithBuiltInMic.isVisible().catch(() => false)) {
+      await continueWithBuiltInMic.click();
+    }
+
+    await expect(
+      page.getByRole("button", { name: "Start recording" }),
+    ).toBeVisible();
+  });
+
+  await test.step("start and stop a short recording", async () => {
+    await page.waitForTimeout(1_000);
+    await page.getByRole("button", { name: "Start recording" }).click();
+    await expect(page.getByRole("button", { name: "Stop recording" })).toBeVisible();
+
+    await page.waitForTimeout(2_000);
+    await page.getByRole("button", { name: "Stop recording" }).click();
+    await expect(page.getByText("FINALIZING").first()).toBeVisible();
+    await expect(
+      page.getByRole("button", { name: "Start recording" }),
+    ).toBeVisible({ timeout: 45_000 });
+    await expect(page.getByRole("button", { name: "Finish recording" })).toBeVisible();
+  });
+
+  await test.step("assert complete track metadata and stored recording", async () => {
+    await expect
+      .poll(
+        async () => {
+          const track = await db.track.findFirst({
+            where: { sessionId, participantName },
+            select: { status: true },
+          });
+          return track?.status ?? null;
+        },
+        { timeout: 30_000 },
+      )
+      .toBe("complete");
+
+    const track = await db.track.findFirstOrThrow({
+      where: { sessionId, participantName },
+      select: { durationMs: true, s3Key: true },
+    });
+
+    expect(track.durationMs).toBeGreaterThan(0);
+    expect(track.s3Key).toMatch(
+      new RegExp(`^sessions/${sessionId}/tracks/[^/]+/recording\\.webm$`),
+    );
+
+    const head = await createS3Client().send(
+      new HeadObjectCommand({
+        Bucket: requiredEnv("S3_BUCKET_NAME"),
+        Key: track.s3Key,
+      }),
+    );
+    expect(head.ContentLength).toBeGreaterThan(0);
+  });
+
+  await test.step("finish the recording from the studio UI", async () => {
+    await page.getByRole("button", { name: "Finish recording" }).click();
+    await expect(page.getByText("Ready for ingest")).toBeVisible({ timeout: 45_000 });
+  });
+});


### PR DESCRIPTION
## Summary

- Add a single-browser Playwright smoke test for the host recording flow with Chromium fake audio.
- Add `npm run test:browser` to start local Postgres, MinIO, LiveKit/Redis, Prisma, Next.js, and the Playwright spec.
- Verify the browser flow reaches a complete track row and non-empty `recording.webm` object in MinIO.
- Document the browser smoke workflow and ignore Playwright artifacts.
- Harden the browser smoke wrapper with local DB/bucket guards plus Postgres and LiveKit readiness checks.

Closes #96

## Verification

- `git diff --check` - passed.
- `npx playwright test --config playwright.config.ts --list` - listed 1 test in 1 file.
- `npm run typecheck` - passed.
- `npm test` - 17 files / 123 tests passed.
- `npm run lint` - passed with 0 warnings or errors.
- `npm run build` - passed.
- `env COZYTRACK_INTEGRATION_TEST=1 AUTH_SECRET=cozytrack-ci-auth-secret-32-characters DATABASE_URL=postgresql://cozytrack:cozytrack@127.0.0.1:5433/cozytrack DIRECT_DATABASE_URL=postgresql://cozytrack:cozytrack@127.0.0.1:5433/cozytrack AWS_REGION=us-east-1 AWS_ACCESS_KEY_ID=minioadmin AWS_SECRET_ACCESS_KEY=minioadmin S3_BUCKET_NAME=cozytrack-browser-test S3_ENDPOINT=http://127.0.0.1:9000 S3_FORCE_PATH_STYLE=true npm run test:integration` - 1 file / 6 tests passed.
- `npm run test:browser` - 1 Playwright test passed before PR open.
- `npm run test:browser` - 1 Playwright test passed again after the harness hardening fix.
- GitHub Baseline validation on `9408aac` - passed in 1m14s.
- GitHub Prisma and storage integration on `9408aac` - passed in 43s.
- Vercel preview on `9408aac` - passed.

Notes:

- `npx playwright install chromium` was needed locally before the first smoke run because the Playwright browser bundle was not installed yet.
- The first service integration attempt hit sandbox `EPERM` connecting to local MinIO; rerunning outside the sandbox passed.
- Codex review findings on the browser smoke wrapper were fixed in `9408aac`.
- Manual `/codex review` on this PR did trigger but exposed a separate feedback-posting bug now tracked in #102 / PR #103.