### PR TITLE
Fix manual Codex review feedback posting

### DIFF
--- a/.github/workflows/codex-review.yml
+++ b/.github/workflows/codex-review.yml
@@ -25,10 +25,8 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
+      issues: write
       pull-requests: read
-    outputs:
-      final_message: ${{ steps.run_codex.outputs.final-message }}
-      pr_number: ${{ steps.pr_context.outputs.number }}
     steps:
       - name: Resolve PR context
         id: pr_context
@@ -117,18 +115,11 @@ jobs:
             ${{ steps.pr_context.outputs.title }}
             ${{ steps.pr_context.outputs.body }}
 
-  post_feedback:
-    runs-on: ubuntu-latest
-    needs: codex
-    if: needs.codex.outputs.final_message != ''
-    permissions:
-      issues: write
-      pull-requests: write
-    steps:
       - name: Report Codex feedback
+        if: steps.run_codex.outputs['final-message'] != ''
         uses: actions/github-script@v7
         env:
-          CODEX_FINAL_MESSAGE: ${{ needs.codex.outputs.final_message }}
+          CODEX_FINAL_MESSAGE: ${{ steps.run_codex.outputs['final-message'] }}
         with:
           github-token: ${{ github.token }}
           script: |
@@ -141,6 +132,6 @@ jobs:
             await github.rest.issues.createComment({
               owner: context.repo.owner,
               repo: context.repo.repo,
-              issue_number: Number("${{ needs.codex.outputs.pr_number }}"),
+              issue_number: Number("${{ steps.pr_context.outputs.number }}"),
               body,
             });

--- a/.github/workflows/codex-review.yml
+++ b/.github/workflows/codex-review.yml
@@ -25,8 +25,9 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      issues: write
       pull-requests: read
+    outputs:
+      pr_number: ${{ steps.pr_context.outputs.number }}
     steps:
       - name: Resolve PR context
         id: pr_context
@@ -55,6 +56,11 @@ jobs:
               "same_repo",
               pr.head.repo?.full_name === `${context.repo.owner}/${context.repo.repo}` ? "true" : "false",
             );
+
+      - name: Initialize Codex feedback artifact
+        run: |
+          mkdir -p .codex-review
+          : > .codex-review/final-message.md
 
       - name: Skip fork PR
         if: steps.pr_context.outputs.same_repo != 'true'
@@ -115,23 +121,58 @@ jobs:
             ${{ steps.pr_context.outputs.title }}
             ${{ steps.pr_context.outputs.body }}
 
-      - name: Report Codex feedback
+      - name: Write Codex feedback artifact
         if: steps.run_codex.outputs['final-message'] != ''
-        uses: actions/github-script@v7
         env:
           CODEX_FINAL_MESSAGE: ${{ steps.run_codex.outputs['final-message'] }}
+        run: printf '%s\n' "$CODEX_FINAL_MESSAGE" > .codex-review/final-message.md
+
+      - name: Upload Codex feedback artifact
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: codex-review-feedback
+          path: .codex-review/final-message.md
+          if-no-files-found: error
+          retention-days: 1
+
+  post_feedback:
+    runs-on: ubuntu-latest
+    needs: codex
+    if: needs.codex.result == 'success' && needs.codex.outputs.pr_number != ''
+    permissions:
+      actions: read
+      issues: write
+    steps:
+      - name: Download Codex feedback artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: codex-review-feedback
+          path: .codex-review
+
+      - name: Report Codex feedback
+        uses: actions/github-script@v7
+        env:
+          CODEX_FINAL_MESSAGE_FILE: .codex-review/final-message.md
         with:
           github-token: ${{ github.token }}
           script: |
+            const fs = require("node:fs");
+            const message = fs.readFileSync(process.env.CODEX_FINAL_MESSAGE_FILE, "utf8").trim();
+            if (!message) {
+              core.notice("No Codex feedback to post.");
+              return;
+            }
+
             const body = [
               "## Codex review",
               "",
-              process.env.CODEX_FINAL_MESSAGE,
+              message,
             ].join("\n");
 
             await github.rest.issues.createComment({
               owner: context.repo.owner,
               repo: context.repo.repo,
-              issue_number: Number("${{ steps.pr_context.outputs.number }}"),
+              issue_number: Number("${{ needs.codex.outputs.pr_number }}"),
               body,
             });


### PR DESCRIPTION
## Summary

- Keep the Codex review job read-only while still avoiding cross-job `final_message` output redaction.
- Store the Codex final message in a short-lived workflow artifact.
- Let the separate write-permission feedback job download that artifact and post the PR comment.
- Preserve existing pull request and `/codex review` triggers plus the same-repo fork guard.

Closes #102

## Verification

- Ruby YAML parse check for `.github/workflows/codex-review.yml` - passed.
- `git diff --check` - passed.
- `actionlint` is not installed locally.

Observed failure being fixed:

- Manual `/codex review` on PR #101 created workflow run `26563740089`, but GitHub skipped the `final_message` job output as possibly secret, so the downstream feedback job skipped and no PR comment was posted.

Review iteration:

- Initial PR #103 attempt posted feedback from the same job, but Codex correctly flagged that as granting a write-capable token to the review action. Commit `aaf4380` restores the read-only Codex job boundary and uses artifacts instead of job outputs.