### PR TITLE
Fix Codex feedback artifact path

### DIFF
--- a/.github/workflows/codex-review.yml
+++ b/.github/workflows/codex-review.yml
@@ -145,6 +145,7 @@ jobs:
     permissions:
       actions: read
       issues: write
+      pull-requests: write
     steps:
       - name: Download Codex feedback artifact
         uses: actions/download-artifact@v4

--- a/.github/workflows/codex-review.yml
+++ b/.github/workflows/codex-review.yml
@@ -57,11 +57,6 @@ jobs:
               pr.head.repo?.full_name === `${context.repo.owner}/${context.repo.repo}` ? "true" : "false",
             );
 
-      - name: Initialize Codex feedback artifact
-        run: |
-          mkdir -p .codex-review
-          : > .codex-review/final-message.md
-
       - name: Skip fork PR
         if: steps.pr_context.outputs.same_repo != 'true'
         run: echo "Codex review is skipped for forked pull requests."
@@ -95,6 +90,11 @@ jobs:
             "$PR_BASE_REF" \
             "+refs/pull/$PR_NUMBER/head"
 
+      - name: Initialize Codex feedback artifact
+        run: |
+          mkdir -p codex-review-output
+          : > codex-review-output/final-message.md
+
       - name: Run Codex review
         id: run_codex
         if: steps.pr_context.outputs.same_repo == 'true' && steps.api_key.outputs.available == 'true'
@@ -125,14 +125,16 @@ jobs:
         if: steps.run_codex.outputs['final-message'] != ''
         env:
           CODEX_FINAL_MESSAGE: ${{ steps.run_codex.outputs['final-message'] }}
-        run: printf '%s\n' "$CODEX_FINAL_MESSAGE" > .codex-review/final-message.md
+        run: |
+          mkdir -p codex-review-output
+          printf '%s\n' "$CODEX_FINAL_MESSAGE" > codex-review-output/final-message.md
 
       - name: Upload Codex feedback artifact
         if: always()
         uses: actions/upload-artifact@v4
         with:
           name: codex-review-feedback
-          path: .codex-review/final-message.md
+          path: codex-review-output/final-message.md
           if-no-files-found: error
           retention-days: 1
 
@@ -148,12 +150,12 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: codex-review-feedback
-          path: .codex-review
+          path: codex-review-output
 
       - name: Report Codex feedback
         uses: actions/github-script@v7
         env:
-          CODEX_FINAL_MESSAGE_FILE: .codex-review/final-message.md
+          CODEX_FINAL_MESSAGE_FILE: codex-review-output/final-message.md
         with:
           github-token: ${{ github.token }}
           script: |


### PR DESCRIPTION
## Summary

- Move Codex feedback artifact initialization to after checkout so checkout cannot delete it.
- Use a non-hidden `codex-review-output/final-message.md` artifact path.
- Make the feedback write step create the output directory defensively.
- Add `pull-requests: write` to the separate feedback-posting job so GitHub allows PR comments.
- Preserve the read-only Codex job; only `post_feedback` can write comments.

Closes #104

## Verification

- Ruby YAML parse check for `.github/workflows/codex-review.yml` - passed.
- `git diff --check` - passed.
- Baseline validation - passed in 1m6s.
- Prisma and storage integration - passed in 52s.
- Vercel - passed.

Observed failures being fixed:

- Manual `/codex review` run `26578769833` downloaded and ran `openai/codex-action@v1` successfully.
- That run failed later in `Write Codex feedback artifact` with `.codex-review/final-message.md: No such file or directory`.
- Root cause: artifact initialization happened before `actions/checkout`, and checkout deleted the initialized directory.
- PR #105 run `26624929514` then downloaded the artifact successfully but failed posting feedback with `Resource not accessible by integration`.
- GitHub returned accepted permissions `issues=write; pull_requests=write`, so the feedback job now requests both.

Manual `/codex review` is intentionally not re-run on every PR push; the comment-triggered path should be rechecked after this workflow is on `main`.