### PR TITLE
Add local recording backup recovery

### DIFF
--- a/.github/workflows/browser-smoke.yml
+++ b/.github/workflows/browser-smoke.yml
@@ -1,0 +1,34 @@
+name: Browser smoke
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: read
+
+jobs:
+  browser-smoke:
+    name: Browser recording smoke
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v5
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Install Playwright browser
+        run: npx playwright install --with-deps chromium
+
+      - name: Run browser smoke tests
+        run: npm run test:browser

--- a/src/app/studio/[id]/page.tsx
+++ b/src/app/studio/[id]/page.tsx
@@ -1514,9 +1514,6 @@ function RoomContent({
       setHasRecorded(true);
       if (backupId) {
         try {
-          const uploadedBackup =
-            await browserRecordingBackupStore.markBackupUploaded(backupId);
-          setRecoveryBackupSync(uploadedBackup);
           await browserRecordingBackupStore.clearBackup(backupId, "verified-upload");
           setRecoveryBackupSync(null);
           setBackupError(null);
@@ -1588,9 +1585,9 @@ function RoomContent({
     try {
       const latest =
         (await browserRecordingBackupStore.getBackup(current.id)) ?? current;
-      const uploaded = await retryLocalRecordingBackupUpload(latest);
-      setRecoveryBackupSync(uploaded);
-      await browserRecordingBackupStore.clearBackup(uploaded.id, "verified-upload");
+      const recovered = await retryLocalRecordingBackupUpload(latest);
+      setRecoveryBackupSync(recovered);
+      await browserRecordingBackupStore.clearBackup(recovered.id, "verified-upload");
       setRecoveryBackupSync(null);
       setHasRecorded(true);
       showNotification("Local backup uploaded");

--- a/src/app/studio/[id]/page.tsx
+++ b/src/app/studio/[id]/page.tsx
@@ -1579,6 +1579,7 @@ function RoomContent({
 
   const handleRetryLocalBackupUpload = useCallback(async () => {
     if (backupAction !== "idle") return;
+    if (studioStateRef.current !== "connected") return;
     const current = recoveryBackupRef.current;
     if (!isRecoverableBackup(current)) return;
 
@@ -1610,6 +1611,7 @@ function RoomContent({
 
   const handleDownloadLocalBackup = useCallback(async () => {
     if (backupAction !== "idle") return;
+    if (studioStateRef.current !== "connected") return;
     const current = recoveryBackupRef.current;
     if (!isRecoverableBackup(current)) return;
 
@@ -1636,6 +1638,7 @@ function RoomContent({
 
   const handleClearLocalBackup = useCallback(async () => {
     if (backupAction !== "idle") return;
+    if (studioStateRef.current !== "connected") return;
     const current = recoveryBackupRef.current;
     if (!isRecoverableBackup(current)) return;
     if (!window.confirm("Clear this local recording backup?")) return;
@@ -1895,8 +1898,8 @@ function RoomContent({
   );
 
   const showBackupPanel =
-    Boolean(backupError) ||
-    (studioState !== "recording" && isRecoverableBackup(recoveryBackup));
+    studioState === "connected" &&
+    (Boolean(backupError) || isRecoverableBackup(recoveryBackup));
 
   return (
     <div className="flex flex-col flex-1 min-h-0">

--- a/src/app/studio/[id]/page.tsx
+++ b/src/app/studio/[id]/page.tsx
@@ -34,6 +34,12 @@ import {
   uploadChunk,
   completeUpload,
 } from "@/lib/upload";
+import {
+  browserRecordingBackupStore,
+  recordingBackupId,
+  type RecordingBackupManifest,
+} from "@/lib/recording-backup";
+import { retryLocalRecordingBackupUpload } from "@/lib/recording-backup-upload";
 import { getToken, LIVEKIT_URL } from "@/lib/livekit";
 import {
   useTransport,
@@ -60,14 +66,18 @@ import { useUploadProgress } from "@/hooks/useUploadProgress";
 import { useNavigationGuard } from "@/hooks/useNavigationGuard";
 import { UploadProgressBar } from "@/components/UploadProgressBar";
 
+import { Button } from "@/components/ui/Button";
 import { Topbar } from "@/components/ui/Topbar";
 import { VUMeter, DbScale } from "@/components/ui/VUMeter";
 import { StatusDot, type Status } from "@/components/ui/StatusDot";
 import {
   IcoAlert,
+  IcoDownload,
   IcoLink,
   IcoMic,
   IcoPlus,
+  IcoTrash,
+  IcoUpload,
   IcoX,
 } from "@/components/ui/Icon";
 
@@ -109,6 +119,29 @@ function formatElapsed(totalMs: number): string {
 function formatParticipantList(names: string[]): string {
   if (names.length <= 2) return names.join(" and ");
   return `${names.slice(0, -1).join(", ")}, and ${names[names.length - 1]}`;
+}
+
+function formatBytes(bytes: number): string {
+  if (bytes < 1024) return `${bytes} B`;
+  const kb = bytes / 1024;
+  if (kb < 1024) return `${kb.toFixed(1)} KB`;
+  return `${(kb / 1024).toFixed(1)} MB`;
+}
+
+function backupByteCount(manifest: RecordingBackupManifest): number {
+  return manifest.chunks.reduce((sum, chunk) => sum + chunk.byteSize, 0);
+}
+
+function isRecoverableBackup(
+  manifest: RecordingBackupManifest | null,
+): manifest is RecordingBackupManifest {
+  return Boolean(
+    manifest && manifest.state !== "uploaded" && manifest.chunks.length > 0,
+  );
+}
+
+function backupErrorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : "Local recording backup failed";
 }
 
 function isMobileBrowser(navigatorInfo: Navigator): boolean {
@@ -496,6 +529,109 @@ function InviteLinkModal({
   );
 }
 
+function LocalRecordingBackupPanel({
+  manifest,
+  error,
+  action,
+  onRetry,
+  onDownload,
+  onClear,
+}: {
+  manifest: RecordingBackupManifest | null;
+  error: string | null;
+  action: "idle" | "retrying" | "downloading" | "clearing";
+  onRetry: () => void;
+  onDownload: () => void;
+  onClear: () => void;
+}) {
+  const hasChunks = Boolean(manifest && manifest.chunks.length > 0);
+  const isBusy = action !== "idle";
+  const totalBytes = manifest ? backupByteCount(manifest) : 0;
+  const statusText =
+    action === "retrying"
+      ? "Retrying upload from local backup..."
+      : manifest?.state === "failed"
+      ? "Remote upload failed. Local backup is available in this browser."
+      : manifest?.state === "uploading"
+      ? "Uploading local backup..."
+      : manifest
+      ? "Local recording backup found in this browser."
+      : "Local recording backup is unavailable.";
+
+  return (
+    <div
+      role="alert"
+      className="rounded-lg border px-4 py-3.5 flex flex-col gap-3"
+      style={{
+        background: "rgba(232,168,48,0.08)",
+        borderColor: "rgba(232,168,48,0.28)",
+      }}
+    >
+      <div className="flex items-start gap-3">
+        <span className="mt-0.5 flex-shrink-0">
+          <IcoAlert size={15} color="var(--warn)" />
+        </span>
+        <div className="min-w-0 flex-1">
+          <h2 className="text-[13px] font-semibold text-warn">
+            Local recording backup
+          </h2>
+          <p className="mt-1 text-[12px] leading-5 text-text-2">
+            {statusText}
+          </p>
+          {manifest && (
+            <p className="mt-1 font-mono text-[10px] text-text-3">
+              {manifest.participantName} - {manifest.chunks.length} chunk
+              {manifest.chunks.length === 1 ? "" : "s"} - {formatBytes(totalBytes)}
+            </p>
+          )}
+          {manifest?.persistentStorage === false && (
+            <p className="mt-1 text-[11px] leading-4 text-text-3">
+              Browser persistence was not granted, so keep this tab open until
+              the backup is handled.
+            </p>
+          )}
+          {error && (
+            <p className="mt-1 text-[11px] leading-4 text-rec">{error}</p>
+          )}
+        </div>
+      </div>
+
+      <div className="flex flex-wrap items-center gap-2">
+        <Button
+          type="button"
+          size="sm"
+          variant="primary"
+          onClick={onRetry}
+          disabled={!hasChunks || isBusy}
+        >
+          <IcoUpload size={13} />
+          {action === "retrying" ? "Retrying" : "Retry upload"}
+        </Button>
+        <Button
+          type="button"
+          size="sm"
+          variant="subtle"
+          onClick={onDownload}
+          disabled={!hasChunks || isBusy}
+        >
+          <IcoDownload size={13} />
+          {action === "downloading" ? "Preparing" : "Download"}
+        </Button>
+        <Button
+          type="button"
+          size="sm"
+          variant="danger"
+          onClick={onClear}
+          disabled={!hasChunks || isBusy}
+        >
+          <IcoTrash size={13} />
+          {action === "clearing" ? "Clearing" : "Clear"}
+        </Button>
+      </div>
+    </div>
+  );
+}
+
 // ---------- Room Content (inside LiveKitRoom) ----------
 
 /**
@@ -612,6 +748,20 @@ function RoomContent({
   const [notification, setNotification] = useState<string | null>(null);
   const notificationTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const [hasRecorded, setHasRecorded] = useState(false);
+  const [recoveryBackup, setRecoveryBackup] =
+    useState<RecordingBackupManifest | null>(null);
+  const recoveryBackupRef = useRef<RecordingBackupManifest | null>(null);
+  const [backupError, setBackupError] = useState<string | null>(null);
+  const [backupAction, setBackupAction] = useState<
+    "idle" | "retrying" | "downloading" | "clearing"
+  >("idle");
+  const setRecoveryBackupSync = useCallback(
+    (manifest: RecordingBackupManifest | null) => {
+      recoveryBackupRef.current = manifest;
+      setRecoveryBackup(manifest);
+    },
+    [],
+  );
 
   // Elapsed recording timer
   const [elapsedMs, setElapsedMs] = useState(0);
@@ -673,6 +823,27 @@ function RoomContent({
       if (notificationTimerRef.current) clearTimeout(notificationTimerRef.current);
     };
   }, []);
+
+  useEffect(() => {
+    let cancelled = false;
+    async function loadLocalBackups() {
+      try {
+        const backups = await browserRecordingBackupStore.listBackups(sessionId);
+        if (cancelled) return;
+        const backup = backups.find((item) => isRecoverableBackup(item)) ?? null;
+        if (backup) {
+          setRecoveryBackupSync(backup);
+          setBackupError(null);
+        }
+      } catch (error) {
+        if (!cancelled) setBackupError(backupErrorMessage(error));
+      }
+    }
+    void loadLocalBackups();
+    return () => {
+      cancelled = true;
+    };
+  }, [sessionId, setRecoveryBackupSync]);
 
   useEffect(() => clearRecordingConfirmationTimer, [
     clearRecordingConfirmationTimer,
@@ -1076,6 +1247,21 @@ function RoomContent({
           },
         );
         recordingUploadTokenRef.current = initialUpload.recordingToken;
+        try {
+          const backup = await browserRecordingBackupStore.startBackup({
+            sessionId,
+            trackId,
+            participantName,
+            recordingToken: initialUpload.recordingToken,
+          });
+          setRecoveryBackupSync(backup);
+          setBackupError(null);
+        } catch (backupErr) {
+          console.error("Failed to initialize local recording backup:", backupErr);
+          setRecoveryBackupSync(null);
+          setBackupError(backupErrorMessage(backupErr));
+          showNotification("Local backup unavailable - remote upload only");
+        }
       } catch (err) {
         console.error("Failed to initialize upload:", err);
         clearRecordingConfirmationState();
@@ -1109,16 +1295,67 @@ function RoomContent({
           );
         }
 
-        const uploadPromise = (async () => {
-          const url = await getPresignedUploadUrl(
+        const capturedAt = new Date();
+        const backupSave = browserRecordingBackupStore
+          .saveChunk({
             sessionId,
             trackId,
-            index,
-            undefined,
-            undefined,
-            recordingUploadTokenRef.current,
-          );
-          await uploadChunk(url, chunk);
+            chunkIndex: index,
+            chunk,
+            capturedAt,
+          })
+          .then((backup) => {
+            setRecoveryBackupSync(backup);
+            setBackupError(null);
+            return backup;
+          })
+          .catch((backupErr) => {
+            console.error("Failed to write local recording backup:", backupErr);
+            setBackupError(backupErrorMessage(backupErr));
+            return null;
+          });
+
+        const uploadPromise = (async () => {
+          const savedBackup = await backupSave;
+          try {
+            const url = await getPresignedUploadUrl(
+              sessionId,
+              trackId,
+              index,
+              undefined,
+              undefined,
+              recordingUploadTokenRef.current,
+            );
+            await uploadChunk(url, chunk);
+          } catch (uploadErr) {
+            if (savedBackup) {
+              try {
+                const backup = await browserRecordingBackupStore.markChunkFailed(
+                  sessionId,
+                  trackId,
+                  index,
+                  uploadErr,
+                );
+                setRecoveryBackupSync(backup);
+              } catch (backupErr) {
+                console.error("Failed to mark local backup chunk failed:", backupErr);
+              }
+            }
+            throw uploadErr;
+          }
+          if (savedBackup) {
+            try {
+              const backup = await browserRecordingBackupStore.markChunkUploaded(
+                sessionId,
+                trackId,
+                index,
+              );
+              setRecoveryBackupSync(backup);
+            } catch (backupErr) {
+              console.error("Failed to mark local backup chunk uploaded:", backupErr);
+              setBackupError(backupErrorMessage(backupErr));
+            }
+          }
         })();
 
         void trackerTrackUpload(byteLength, uploadPromise);
@@ -1179,6 +1416,7 @@ function RoomContent({
       selectedMicLabel,
       sessionId,
       setRecordingSessionStartedAtSync,
+      setRecoveryBackupSync,
       setStudioStateSync,
       showNotification,
       switchAudioQuality,
@@ -1210,6 +1448,7 @@ function RoomContent({
     // tears down immediately — even if the upload pipeline below hangs.
     const recorder = recorderRef.current;
     const trackId = trackIdRef.current;
+    const backupId = trackId ? recordingBackupId(sessionId, trackId) : null;
     const recordingUploadToken = recordingUploadTokenRef.current;
     const startedAt = recordingStartRef.current;
     setStudioStateSync("finalizing");
@@ -1236,6 +1475,17 @@ function RoomContent({
 
       // Freeze denominator — recording is done, no more chunks will arrive.
       trackerFreezeRecorded();
+      if (backupId) {
+        try {
+          const backup = await browserRecordingBackupStore.markBackupAvailable(
+            backupId,
+            durationMs,
+          );
+          setRecoveryBackupSync(backup);
+        } catch (backupErr) {
+          console.error("Failed to mark local backup available:", backupErr);
+        }
+      }
 
       // The final recording.webm upload is critical: if it fails, we must
       // NOT call completeUpload (which marks the track complete and lets
@@ -1262,10 +1512,36 @@ function RoomContent({
       await completeUpload(sessionId, trackId, durationMs, recordingUploadToken);
 
       setHasRecorded(true);
+      if (backupId) {
+        try {
+          const uploadedBackup =
+            await browserRecordingBackupStore.markBackupUploaded(backupId);
+          setRecoveryBackupSync(uploadedBackup);
+          await browserRecordingBackupStore.clearBackup(backupId, "verified-upload");
+          setRecoveryBackupSync(null);
+          setBackupError(null);
+        } catch (backupErr) {
+          console.error("Failed to clear uploaded local backup:", backupErr);
+          setBackupError(backupErrorMessage(backupErr));
+        }
+      }
     } catch (err) {
       // Final upload (or stop()) failed. lastError is already populated by
       // trackUpload's rethrow path; the recording stays incomplete.
       console.error("Failed to stop recording:", err);
+      if (backupId) {
+        try {
+          const backup = await browserRecordingBackupStore.markBackupFailed(
+            backupId,
+            err,
+          );
+          setRecoveryBackupSync(backup);
+          setBackupError(null);
+        } catch (backupErr) {
+          console.error("Failed to mark local backup failed:", backupErr);
+          setBackupError(backupErrorMessage(backupErr));
+        }
+      }
     } finally {
       recorderRef.current = null;
       recordingUploadTokenRef.current = undefined;
@@ -1291,6 +1567,7 @@ function RoomContent({
     clearRecordingConfirmationState,
     sessionId,
     setRecordingSessionStartedAtSync,
+    setRecoveryBackupSync,
     setStudioStateSync,
     switchAudioQuality,
     trackerFreezeRecorded,
@@ -1299,6 +1576,81 @@ function RoomContent({
     trackerWaitForUploads,
     timingDebug,
   ]);
+
+  const handleRetryLocalBackupUpload = useCallback(async () => {
+    if (backupAction !== "idle") return;
+    const current = recoveryBackupRef.current;
+    if (!isRecoverableBackup(current)) return;
+
+    setBackupAction("retrying");
+    setBackupError(null);
+    try {
+      const latest =
+        (await browserRecordingBackupStore.getBackup(current.id)) ?? current;
+      const uploaded = await retryLocalRecordingBackupUpload(latest);
+      setRecoveryBackupSync(uploaded);
+      await browserRecordingBackupStore.clearBackup(uploaded.id, "verified-upload");
+      setRecoveryBackupSync(null);
+      setHasRecorded(true);
+      showNotification("Local backup uploaded");
+    } catch (error) {
+      const message = backupErrorMessage(error);
+      setBackupError(message);
+      try {
+        const latest = await browserRecordingBackupStore.getBackup(current.id);
+        if (latest) setRecoveryBackupSync(latest);
+      } catch (backupErr) {
+        console.error("Failed to refresh local backup after retry:", backupErr);
+      }
+      showNotification("Retry failed - local backup kept");
+    } finally {
+      setBackupAction("idle");
+    }
+  }, [backupAction, setRecoveryBackupSync, showNotification]);
+
+  const handleDownloadLocalBackup = useCallback(async () => {
+    if (backupAction !== "idle") return;
+    const current = recoveryBackupRef.current;
+    if (!isRecoverableBackup(current)) return;
+
+    setBackupAction("downloading");
+    setBackupError(null);
+    try {
+      const recording = await browserRecordingBackupStore.buildRecordingBlob(
+        current.id,
+      );
+      const url = URL.createObjectURL(recording);
+      const link = document.createElement("a");
+      link.href = url;
+      link.download = `cozytrack-${current.sessionId.slice(0, 8)}-${current.trackId.slice(0, 8)}.webm`;
+      document.body.appendChild(link);
+      link.click();
+      link.remove();
+      window.setTimeout(() => URL.revokeObjectURL(url), 0);
+    } catch (error) {
+      setBackupError(backupErrorMessage(error));
+    } finally {
+      setBackupAction("idle");
+    }
+  }, [backupAction]);
+
+  const handleClearLocalBackup = useCallback(async () => {
+    if (backupAction !== "idle") return;
+    const current = recoveryBackupRef.current;
+    if (!isRecoverableBackup(current)) return;
+    if (!window.confirm("Clear this local recording backup?")) return;
+
+    setBackupAction("clearing");
+    setBackupError(null);
+    try {
+      await browserRecordingBackupStore.clearBackup(current.id, "user-confirmed");
+      setRecoveryBackupSync(null);
+    } catch (error) {
+      setBackupError(backupErrorMessage(error));
+    } finally {
+      setBackupAction("idle");
+    }
+  }, [backupAction, setRecoveryBackupSync]);
 
   // Synchronous "request in flight" guards. Set true at the top of the click
   // handler before any await so a rapid second click is dropped immediately
@@ -1542,6 +1894,10 @@ function RoomContent({
     ],
   );
 
+  const showBackupPanel =
+    Boolean(backupError) ||
+    (studioState !== "recording" && isRecoverableBackup(recoveryBackup));
+
   return (
     <div className="flex flex-col flex-1 min-h-0">
       {/* Notification toast */}
@@ -1652,6 +2008,17 @@ function RoomContent({
               onVolumeChange={onMonitorVolumeChange}
             />
           </div>
+
+          {showBackupPanel && (
+            <LocalRecordingBackupPanel
+              manifest={recoveryBackup}
+              error={backupError}
+              action={backupAction}
+              onRetry={handleRetryLocalBackupUpload}
+              onDownload={handleDownloadLocalBackup}
+              onClear={handleClearLocalBackup}
+            />
+          )}
 
           {/* Finish recording (post-stop) — surfaces after the local recorder
               has produced at least one track and the studio is no longer in

--- a/src/components/ui/Icon.tsx
+++ b/src/components/ui/Icon.tsx
@@ -69,6 +69,30 @@ export const IcoDownload = (p: IconProps) => (
   />
 );
 
+export const IcoUpload = (p: IconProps) => (
+  <Paths
+    {...p}
+    d={[
+      "M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4",
+      "M17 8l-5-5-5 5",
+      "M12 3v12",
+    ]}
+  />
+);
+
+export const IcoTrash = (p: IconProps) => (
+  <Paths
+    {...p}
+    d={[
+      "M3 6h18",
+      "M8 6V4a2 2 0 0 1 2-2h4a2 2 0 0 1 2 2v2",
+      "M19 6l-1 14a2 2 0 0 1-2 2H8a2 2 0 0 1-2-2L5 6",
+      "M10 11v6",
+      "M14 11v6",
+    ]}
+  />
+);
+
 export const IcoPlay = (p: IconProps) => <Paths {...p} fill={p.fill ?? "currentColor"} d="M5 3l14 9-14 9V3z" />;
 export const IcoPause = (p: IconProps) => <Paths {...p} d={["M6 4h4v16H6z", "M14 4h4v16h-4z"]} />;
 export const IcoChevron = (p: IconProps) => <Paths {...p} d="M15 18l-6-6 6-6" />;

--- a/src/lib/recording-backup-upload.ts
+++ b/src/lib/recording-backup-upload.ts
@@ -51,5 +51,5 @@ export async function retryLocalRecordingBackupUpload(
     throw error;
   }
 
-  return await backupStore.markBackupUploaded(manifest.id);
+  return await backupStore.markBackupAvailable(manifest.id, manifest.durationMs);
 }

--- a/src/lib/recording-backup-upload.ts
+++ b/src/lib/recording-backup-upload.ts
@@ -1,0 +1,55 @@
+"use client";
+
+import {
+  browserRecordingBackupStore,
+  type RecordingBackupManifest,
+  type RecordingBackupStore,
+} from "@/lib/recording-backup";
+import {
+  completeUpload,
+  getPresignedUploadUrl,
+  uploadChunk,
+} from "@/lib/upload";
+
+export interface RetryLocalRecordingBackupDeps {
+  backupStore?: RecordingBackupStore;
+  getPresignedUploadUrl?: typeof getPresignedUploadUrl;
+  uploadChunk?: typeof uploadChunk;
+  completeUpload?: typeof completeUpload;
+}
+
+export async function retryLocalRecordingBackupUpload(
+  manifest: RecordingBackupManifest,
+  deps: RetryLocalRecordingBackupDeps = {},
+): Promise<RecordingBackupManifest> {
+  const backupStore = deps.backupStore ?? browserRecordingBackupStore;
+  const getUploadUrl = deps.getPresignedUploadUrl ?? getPresignedUploadUrl;
+  const putChunk = deps.uploadChunk ?? uploadChunk;
+  const finishUpload = deps.completeUpload ?? completeUpload;
+
+  await backupStore.markBackupUploading(manifest.id);
+
+  try {
+    const recording = await backupStore.buildRecordingBlob(manifest.id);
+    const url = await getUploadUrl(
+      manifest.sessionId,
+      manifest.trackId,
+      9999,
+      undefined,
+      undefined,
+      manifest.recordingToken,
+    );
+    await putChunk(url, recording);
+    await finishUpload(
+      manifest.sessionId,
+      manifest.trackId,
+      manifest.durationMs,
+      manifest.recordingToken,
+    );
+  } catch (error) {
+    await backupStore.markBackupFailed(manifest.id, error);
+    throw error;
+  }
+
+  return await backupStore.markBackupUploaded(manifest.id);
+}

--- a/src/lib/recording-backup.ts
+++ b/src/lib/recording-backup.ts
@@ -1,0 +1,678 @@
+"use client";
+
+export type RecordingBackupStorage = "opfs" | "indexeddb";
+export type RecordingBackupUploadStatus = "pending" | "uploaded" | "failed";
+export type RecordingBackupState =
+  | "recording"
+  | "available"
+  | "uploading"
+  | "uploaded"
+  | "failed";
+export type RecordingBackupClearReason = "user-confirmed" | "verified-upload";
+
+export interface RecordingBackupChunkManifest {
+  chunkIndex: number;
+  byteSize: number;
+  capturedAt: string;
+  uploadedAt?: string;
+  uploadStatus: RecordingBackupUploadStatus;
+  storage: RecordingBackupStorage;
+  storageKey: string;
+  error?: string;
+}
+
+export interface RecordingBackupManifest {
+  id: string;
+  sessionId: string;
+  trackId: string;
+  participantName: string;
+  createdAt: string;
+  updatedAt: string;
+  state: RecordingBackupState;
+  persistentStorage: boolean | null;
+  recordingToken?: string;
+  durationMs?: number;
+  lastError?: string;
+  chunks: RecordingBackupChunkManifest[];
+}
+
+export interface StartRecordingBackupInput {
+  sessionId: string;
+  trackId: string;
+  participantName: string;
+  recordingToken?: string;
+}
+
+export interface RecordingBackupChunkRef {
+  sessionId: string;
+  trackId: string;
+  chunkIndex: number;
+}
+
+export interface StoredRecordingBackupChunk {
+  storage: RecordingBackupStorage;
+  storageKey: string;
+}
+
+export interface RecordingBackupBackend {
+  requestPersistence(): Promise<boolean | null>;
+  writeChunk(
+    ref: RecordingBackupChunkRef,
+    chunk: Blob,
+  ): Promise<StoredRecordingBackupChunk>;
+  readChunk(
+    ref: RecordingBackupChunkRef,
+    stored: StoredRecordingBackupChunk,
+  ): Promise<Blob>;
+  deleteChunk(
+    ref: RecordingBackupChunkRef,
+    stored: StoredRecordingBackupChunk,
+  ): Promise<void>;
+  putManifest(manifest: RecordingBackupManifest): Promise<void>;
+  getManifest(id: string): Promise<RecordingBackupManifest | null>;
+  listManifests(sessionId?: string): Promise<RecordingBackupManifest[]>;
+  deleteManifest(id: string): Promise<void>;
+}
+
+const DB_NAME = "cozytrack-recording-backups";
+const DB_VERSION = 1;
+const MANIFEST_STORE = "manifests";
+const CHUNK_STORE = "chunks";
+const OPFS_ROOT = "cozytrack-recordings";
+const WEBM_MIME_TYPE = "audio/webm;codecs=opus";
+
+type ChunkRecord = {
+  key: string;
+  blob: Blob;
+};
+
+type WritableFileStreamLike = {
+  write(data: Blob): Promise<void>;
+  close(): Promise<void>;
+};
+
+type FileHandleLike = {
+  createWritable(): Promise<WritableFileStreamLike>;
+  getFile(): Promise<File>;
+};
+
+type DirectoryHandleLike = {
+  getDirectoryHandle(
+    name: string,
+    options?: { create?: boolean },
+  ): Promise<DirectoryHandleLike>;
+  getFileHandle(
+    name: string,
+    options?: { create?: boolean },
+  ): Promise<FileHandleLike>;
+  removeEntry?(name: string, options?: { recursive?: boolean }): Promise<void>;
+};
+
+type StorageManagerWithDirectory = StorageManager & {
+  getDirectory?: () => Promise<DirectoryHandleLike>;
+};
+
+export function recordingBackupId(sessionId: string, trackId: string): string {
+  return `${sessionId}:${trackId}`;
+}
+
+function nowIso(): string {
+  return new Date().toISOString();
+}
+
+function cloneManifest(manifest: RecordingBackupManifest): RecordingBackupManifest {
+  return JSON.parse(JSON.stringify(manifest)) as RecordingBackupManifest;
+}
+
+function normalizeError(error: unknown): string {
+  return error instanceof Error ? error.message : "Recording backup failed";
+}
+
+function chunkStorageKey(ref: RecordingBackupChunkRef): string {
+  return `${ref.sessionId}:${ref.trackId}:${ref.chunkIndex}`;
+}
+
+function opfsFilename(chunkIndex: number): string {
+  return `${chunkIndex}.webm`;
+}
+
+function safePathSegment(value: string): string {
+  return value.replace(/[^a-zA-Z0-9_-]/g, "_");
+}
+
+function idbRequest<T>(request: IDBRequest<T>): Promise<T> {
+  return new Promise<T>((resolve, reject) => {
+    request.onsuccess = () => resolve(request.result);
+    request.onerror = () => reject(request.error ?? new Error("IndexedDB error"));
+  });
+}
+
+async function idbTransaction(
+  db: IDBDatabase,
+  stores: string | string[],
+  mode: IDBTransactionMode,
+  work: (tx: IDBTransaction) => void,
+): Promise<void> {
+  await new Promise<void>((resolve, reject) => {
+    const tx = db.transaction(stores, mode);
+    tx.oncomplete = () => resolve();
+    tx.onerror = () => reject(tx.error ?? new Error("IndexedDB transaction error"));
+    tx.onabort = () => reject(tx.error ?? new Error("IndexedDB transaction aborted"));
+    work(tx);
+  });
+}
+
+export class BrowserRecordingBackupBackend implements RecordingBackupBackend {
+  private dbPromise: Promise<IDBDatabase> | null = null;
+
+  async requestPersistence(): Promise<boolean | null> {
+    if (typeof navigator === "undefined" || !navigator.storage?.persist) {
+      return null;
+    }
+    try {
+      return await navigator.storage.persist();
+    } catch {
+      return null;
+    }
+  }
+
+  async writeChunk(
+    ref: RecordingBackupChunkRef,
+    chunk: Blob,
+  ): Promise<StoredRecordingBackupChunk> {
+    try {
+      const opfsDir = await this.getOpfsTrackDirectory(
+        ref.sessionId,
+        ref.trackId,
+        true,
+      );
+      if (opfsDir) {
+        const filename = opfsFilename(ref.chunkIndex);
+        const fileHandle = await opfsDir.getFileHandle(filename, {
+          create: true,
+        });
+        const writable = await fileHandle.createWritable();
+        await writable.write(chunk);
+        await writable.close();
+        return {
+          storage: "opfs",
+          storageKey: `${OPFS_ROOT}/${safePathSegment(ref.sessionId)}/${safePathSegment(ref.trackId)}/${filename}`,
+        };
+      }
+    } catch (error) {
+      console.warn("Recording backup OPFS write failed; falling back to IndexedDB", error);
+    }
+
+    const storageKey = chunkStorageKey(ref);
+    const db = await this.openDb();
+    await idbTransaction(db, CHUNK_STORE, "readwrite", (tx) => {
+      tx.objectStore(CHUNK_STORE).put({ key: storageKey, blob: chunk });
+    });
+    return { storage: "indexeddb", storageKey };
+  }
+
+  async readChunk(
+    ref: RecordingBackupChunkRef,
+    stored: StoredRecordingBackupChunk,
+  ): Promise<Blob> {
+    if (stored.storage === "opfs") {
+      const opfsDir = await this.getOpfsTrackDirectory(
+        ref.sessionId,
+        ref.trackId,
+        false,
+      );
+      if (opfsDir) {
+        const fileHandle = await opfsDir.getFileHandle(opfsFilename(ref.chunkIndex));
+        return await fileHandle.getFile();
+      }
+    }
+
+    const db = await this.openDb();
+    const record = await idbRequest<ChunkRecord | undefined>(
+      db
+        .transaction(CHUNK_STORE, "readonly")
+        .objectStore(CHUNK_STORE)
+        .get(stored.storageKey),
+    );
+    if (!record) {
+      throw new Error(`Local recording chunk ${ref.chunkIndex} was not found`);
+    }
+    return record.blob;
+  }
+
+  async deleteChunk(
+    ref: RecordingBackupChunkRef,
+    stored: StoredRecordingBackupChunk,
+  ): Promise<void> {
+    if (stored.storage === "opfs") {
+      try {
+        const opfsDir = await this.getOpfsTrackDirectory(
+          ref.sessionId,
+          ref.trackId,
+          false,
+        );
+        await opfsDir?.removeEntry?.(opfsFilename(ref.chunkIndex));
+      } catch {
+        // Continue with the IndexedDB cleanup path below. Missing OPFS chunks
+        // should not make explicit backup cleanup fail.
+      }
+    }
+
+    const db = await this.openDb();
+    await idbTransaction(db, CHUNK_STORE, "readwrite", (tx) => {
+      tx.objectStore(CHUNK_STORE).delete(stored.storageKey);
+    });
+  }
+
+  async putManifest(manifest: RecordingBackupManifest): Promise<void> {
+    const db = await this.openDb();
+    await idbTransaction(db, MANIFEST_STORE, "readwrite", (tx) => {
+      tx.objectStore(MANIFEST_STORE).put(cloneManifest(manifest));
+    });
+  }
+
+  async getManifest(id: string): Promise<RecordingBackupManifest | null> {
+    const db = await this.openDb();
+    const manifest = await idbRequest<RecordingBackupManifest | undefined>(
+      db.transaction(MANIFEST_STORE, "readonly").objectStore(MANIFEST_STORE).get(id),
+    );
+    return manifest ? cloneManifest(manifest) : null;
+  }
+
+  async listManifests(sessionId?: string): Promise<RecordingBackupManifest[]> {
+    const db = await this.openDb();
+    const manifests = await idbRequest<RecordingBackupManifest[]>(
+      db
+        .transaction(MANIFEST_STORE, "readonly")
+        .objectStore(MANIFEST_STORE)
+        .getAll(),
+    );
+    return manifests
+      .filter((manifest) => (sessionId ? manifest.sessionId === sessionId : true))
+      .map(cloneManifest)
+      .sort((a, b) => b.updatedAt.localeCompare(a.updatedAt));
+  }
+
+  async deleteManifest(id: string): Promise<void> {
+    const db = await this.openDb();
+    await idbTransaction(db, MANIFEST_STORE, "readwrite", (tx) => {
+      tx.objectStore(MANIFEST_STORE).delete(id);
+    });
+  }
+
+  private async openDb(): Promise<IDBDatabase> {
+    if (this.dbPromise) return this.dbPromise;
+    if (typeof indexedDB === "undefined") {
+      throw new Error("IndexedDB is not available for recording backup");
+    }
+
+    this.dbPromise = new Promise<IDBDatabase>((resolve, reject) => {
+      const request = indexedDB.open(DB_NAME, DB_VERSION);
+      request.onupgradeneeded = () => {
+        const db = request.result;
+        if (!db.objectStoreNames.contains(MANIFEST_STORE)) {
+          db.createObjectStore(MANIFEST_STORE, { keyPath: "id" });
+        }
+        if (!db.objectStoreNames.contains(CHUNK_STORE)) {
+          db.createObjectStore(CHUNK_STORE, { keyPath: "key" });
+        }
+      };
+      request.onsuccess = () => resolve(request.result);
+      request.onerror = () => {
+        this.dbPromise = null;
+        reject(request.error ?? new Error("Failed to open IndexedDB"));
+      };
+      request.onblocked = () => {
+        this.dbPromise = null;
+        reject(new Error("Recording backup database upgrade is blocked"));
+      };
+    });
+
+    return this.dbPromise;
+  }
+
+  private async getOpfsTrackDirectory(
+    sessionId: string,
+    trackId: string,
+    create: boolean,
+  ): Promise<DirectoryHandleLike | null> {
+    if (typeof navigator === "undefined") return null;
+    const storage = navigator.storage as StorageManagerWithDirectory | undefined;
+    if (!storage?.getDirectory) return null;
+
+    const root = await storage.getDirectory();
+    const appDir = await root.getDirectoryHandle(OPFS_ROOT, { create });
+    const sessionDir = await appDir.getDirectoryHandle(safePathSegment(sessionId), {
+      create,
+    });
+    return await sessionDir.getDirectoryHandle(safePathSegment(trackId), {
+      create,
+    });
+  }
+}
+
+export class MemoryRecordingBackupBackend implements RecordingBackupBackend {
+  private manifests = new Map<string, RecordingBackupManifest>();
+  private chunks = new Map<string, Blob>();
+
+  constructor(private persistentStorage: boolean | null = true) {}
+
+  async requestPersistence(): Promise<boolean | null> {
+    return this.persistentStorage;
+  }
+
+  async writeChunk(
+    ref: RecordingBackupChunkRef,
+    chunk: Blob,
+  ): Promise<StoredRecordingBackupChunk> {
+    const storageKey = chunkStorageKey(ref);
+    this.chunks.set(storageKey, chunk);
+    return { storage: "indexeddb", storageKey };
+  }
+
+  async readChunk(
+    ref: RecordingBackupChunkRef,
+    stored: StoredRecordingBackupChunk,
+  ): Promise<Blob> {
+    const chunk = this.chunks.get(stored.storageKey);
+    if (!chunk) {
+      throw new Error(`Local recording chunk ${ref.chunkIndex} was not found`);
+    }
+    return chunk;
+  }
+
+  async deleteChunk(
+    _ref: RecordingBackupChunkRef,
+    stored: StoredRecordingBackupChunk,
+  ): Promise<void> {
+    this.chunks.delete(stored.storageKey);
+  }
+
+  async putManifest(manifest: RecordingBackupManifest): Promise<void> {
+    this.manifests.set(manifest.id, cloneManifest(manifest));
+  }
+
+  async getManifest(id: string): Promise<RecordingBackupManifest | null> {
+    const manifest = this.manifests.get(id);
+    return manifest ? cloneManifest(manifest) : null;
+  }
+
+  async listManifests(sessionId?: string): Promise<RecordingBackupManifest[]> {
+    return Array.from(this.manifests.values())
+      .filter((manifest) => (sessionId ? manifest.sessionId === sessionId : true))
+      .map(cloneManifest)
+      .sort((a, b) => b.updatedAt.localeCompare(a.updatedAt));
+  }
+
+  async deleteManifest(id: string): Promise<void> {
+    this.manifests.delete(id);
+  }
+}
+
+export class RecordingBackupStore {
+  private locks = new Map<string, Promise<void>>();
+
+  constructor(private backend: RecordingBackupBackend) {}
+
+  async startBackup(
+    input: StartRecordingBackupInput,
+  ): Promise<RecordingBackupManifest> {
+    const now = nowIso();
+    const manifest: RecordingBackupManifest = {
+      id: recordingBackupId(input.sessionId, input.trackId),
+      sessionId: input.sessionId,
+      trackId: input.trackId,
+      participantName: input.participantName,
+      createdAt: now,
+      updatedAt: now,
+      state: "recording",
+      persistentStorage: await this.backend.requestPersistence(),
+      recordingToken: input.recordingToken,
+      chunks: [],
+    };
+    await this.backend.putManifest(manifest);
+    return cloneManifest(manifest);
+  }
+
+  async listBackups(sessionId?: string): Promise<RecordingBackupManifest[]> {
+    return await this.backend.listManifests(sessionId);
+  }
+
+  async getBackup(id: string): Promise<RecordingBackupManifest | null> {
+    return await this.backend.getManifest(id);
+  }
+
+  async updateRecordingToken(
+    id: string,
+    recordingToken: string | undefined,
+  ): Promise<RecordingBackupManifest> {
+    return await this.mutateManifest(id, (manifest) => {
+      manifest.recordingToken = recordingToken;
+      return manifest;
+    });
+  }
+
+  async saveChunk(
+    input: {
+      sessionId: string;
+      trackId: string;
+      chunkIndex: number;
+      chunk: Blob;
+      capturedAt?: Date;
+    },
+  ): Promise<RecordingBackupManifest> {
+    const stored = await this.backend.writeChunk(
+      {
+        sessionId: input.sessionId,
+        trackId: input.trackId,
+        chunkIndex: input.chunkIndex,
+      },
+      input.chunk,
+    );
+
+    return await this.mutateManifest(
+      recordingBackupId(input.sessionId, input.trackId),
+      (manifest) => {
+        const chunkManifest: RecordingBackupChunkManifest = {
+          chunkIndex: input.chunkIndex,
+          byteSize: input.chunk.size,
+          capturedAt: (input.capturedAt ?? new Date()).toISOString(),
+          uploadStatus: "pending",
+          storage: stored.storage,
+          storageKey: stored.storageKey,
+        };
+        const existingIndex = manifest.chunks.findIndex(
+          (chunk) => chunk.chunkIndex === input.chunkIndex,
+        );
+        if (existingIndex >= 0) {
+          manifest.chunks[existingIndex] = chunkManifest;
+        } else {
+          manifest.chunks.push(chunkManifest);
+          manifest.chunks.sort((a, b) => a.chunkIndex - b.chunkIndex);
+        }
+        if (manifest.state === "uploaded") manifest.state = "available";
+        return manifest;
+      },
+    );
+  }
+
+  async markChunkUploaded(
+    sessionId: string,
+    trackId: string,
+    chunkIndex: number,
+  ): Promise<RecordingBackupManifest> {
+    return await this.updateChunkUploadState(
+      sessionId,
+      trackId,
+      chunkIndex,
+      "uploaded",
+    );
+  }
+
+  async markChunkFailed(
+    sessionId: string,
+    trackId: string,
+    chunkIndex: number,
+    error: unknown,
+  ): Promise<RecordingBackupManifest> {
+    return await this.updateChunkUploadState(
+      sessionId,
+      trackId,
+      chunkIndex,
+      "failed",
+      normalizeError(error),
+    );
+  }
+
+  async markBackupAvailable(
+    id: string,
+    durationMs?: number,
+  ): Promise<RecordingBackupManifest> {
+    return await this.mutateManifest(id, (manifest) => {
+      manifest.durationMs = durationMs;
+      if (manifest.state !== "failed") {
+        manifest.state = "available";
+      }
+      return manifest;
+    });
+  }
+
+  async markBackupUploading(id: string): Promise<RecordingBackupManifest> {
+    return await this.mutateManifest(id, (manifest) => {
+      manifest.state = "uploading";
+      manifest.lastError = undefined;
+      return manifest;
+    });
+  }
+
+  async markBackupUploaded(id: string): Promise<RecordingBackupManifest> {
+    return await this.mutateManifest(id, (manifest) => {
+      manifest.state = "uploaded";
+      manifest.lastError = undefined;
+      return manifest;
+    });
+  }
+
+  async markBackupFailed(
+    id: string,
+    error: unknown,
+  ): Promise<RecordingBackupManifest> {
+    return await this.mutateManifest(id, (manifest) => {
+      manifest.state = "failed";
+      manifest.lastError = normalizeError(error);
+      return manifest;
+    });
+  }
+
+  async buildRecordingBlob(id: string): Promise<Blob> {
+    const manifest = await this.backend.getManifest(id);
+    if (!manifest) throw new Error("Local recording backup was not found");
+    const chunks = [...manifest.chunks].sort((a, b) => a.chunkIndex - b.chunkIndex);
+    if (chunks.length === 0) {
+      throw new Error("Local recording backup has no chunks");
+    }
+
+    const blobs: Blob[] = [];
+    for (const chunk of chunks) {
+      blobs.push(
+        await this.backend.readChunk(
+          {
+            sessionId: manifest.sessionId,
+            trackId: manifest.trackId,
+            chunkIndex: chunk.chunkIndex,
+          },
+          { storage: chunk.storage, storageKey: chunk.storageKey },
+        ),
+      );
+    }
+    return new Blob(blobs, { type: WEBM_MIME_TYPE });
+  }
+
+  async clearBackup(
+    id: string,
+    reason: RecordingBackupClearReason,
+  ): Promise<void> {
+    if (reason !== "user-confirmed" && reason !== "verified-upload") {
+      throw new Error("Recording backup cleanup requires an explicit reason");
+    }
+
+    const manifest = await this.backend.getManifest(id);
+    if (!manifest) return;
+
+    for (const chunk of manifest.chunks) {
+      await this.backend.deleteChunk(
+        {
+          sessionId: manifest.sessionId,
+          trackId: manifest.trackId,
+          chunkIndex: chunk.chunkIndex,
+        },
+        { storage: chunk.storage, storageKey: chunk.storageKey },
+      );
+    }
+
+    await this.backend.deleteManifest(id);
+  }
+
+  private async updateChunkUploadState(
+    sessionId: string,
+    trackId: string,
+    chunkIndex: number,
+    uploadStatus: RecordingBackupUploadStatus,
+    error?: string,
+  ): Promise<RecordingBackupManifest> {
+    return await this.mutateManifest(
+      recordingBackupId(sessionId, trackId),
+      (manifest) => {
+        const chunk = manifest.chunks.find(
+          (item) => item.chunkIndex === chunkIndex,
+        );
+        if (!chunk) return manifest;
+        chunk.uploadStatus = uploadStatus;
+        chunk.error = error;
+        if (uploadStatus === "uploaded") {
+          chunk.uploadedAt = nowIso();
+        }
+        if (uploadStatus === "failed") {
+          manifest.state = "failed";
+          manifest.lastError = error;
+        }
+        return manifest;
+      },
+    );
+  }
+
+  private async mutateManifest(
+    id: string,
+    mutate: (manifest: RecordingBackupManifest) => RecordingBackupManifest,
+  ): Promise<RecordingBackupManifest> {
+    const prior = this.locks.get(id) ?? Promise.resolve();
+    let resolvedManifest: RecordingBackupManifest | null = null;
+    const next = prior.then(async () => {
+      const current = await this.backend.getManifest(id);
+      if (!current) {
+        throw new Error("Local recording backup was not found");
+      }
+      const updated = mutate(cloneManifest(current));
+      updated.updatedAt = nowIso();
+      await this.backend.putManifest(updated);
+      resolvedManifest = updated;
+    });
+
+    this.locks.set(
+      id,
+      next.catch(() => {
+        // Keep later mutations from being permanently blocked by a failed one.
+      }),
+    );
+
+    await next;
+    if (!resolvedManifest) {
+      throw new Error("Local recording backup update did not complete");
+    }
+    return cloneManifest(resolvedManifest);
+  }
+}
+
+export const browserRecordingBackupStore = new RecordingBackupStore(
+  new BrowserRecordingBackupBackend(),
+);

--- a/tests/browser/recording-smoke.spec.ts
+++ b/tests/browser/recording-smoke.spec.ts
@@ -1,4 +1,4 @@
-import { expect, test } from "@playwright/test";
+import { expect, test, type Page } from "@playwright/test";
 import {
   DeleteObjectsCommand,
   HeadObjectCommand,
@@ -98,12 +98,12 @@ test.afterAll(async () => {
   await db.$disconnect();
 });
 
-test("records a host track through the browser and stores a completed WebM", async ({
-  page,
-}) => {
+async function createAndJoinHostStudio(
+  page: Page,
+  sessionName: string,
+  participantName: string,
+): Promise<string> {
   const hostPassword = requiredEnv("HOST_PASSWORD");
-  const sessionName = `Browser smoke ${Date.now()}`;
-  const participantName = "Browser Smoke Host";
 
   await test.step("sign in and create a session", async () => {
     await page.goto("/signin?return_to=/");
@@ -137,6 +137,20 @@ test("records a host track through the browser and stores a completed WebM", asy
       page.getByRole("button", { name: "Start recording" }),
     ).toBeVisible();
   });
+
+  return sessionId;
+}
+
+test("records a host track through the browser and stores a completed WebM", async ({
+  page,
+}) => {
+  const sessionName = `Browser smoke ${Date.now()}`;
+  const participantName = "Browser Smoke Host";
+  const sessionId = await createAndJoinHostStudio(
+    page,
+    sessionName,
+    participantName,
+  );
 
   await test.step("start and stop a short recording", async () => {
     await page.waitForTimeout(1_000);
@@ -188,5 +202,106 @@ test("records a host track through the browser and stores a completed WebM", asy
   await test.step("finish the recording from the studio UI", async () => {
     await page.getByRole("button", { name: "Finish recording" }).click();
     await expect(page.getByText("Ready for ingest")).toBeVisible({ timeout: 45_000 });
+  });
+});
+
+test("recovers a failed final upload from the local browser backup", async ({
+  page,
+}) => {
+  const sessionName = `Browser recovery ${Date.now()}`;
+  const participantName = "Browser Recovery Host";
+  const sessionId = await createAndJoinHostStudio(
+    page,
+    sessionName,
+    participantName,
+  );
+  let failedFinalUpload = false;
+
+  await page.route("**/*", async (route) => {
+    const request = route.request();
+    const url = new URL(request.url());
+    if (
+      !failedFinalUpload &&
+      request.method() === "PUT" &&
+      url.pathname.endsWith("/recording.webm")
+    ) {
+      failedFinalUpload = true;
+      await route.fulfill({
+        status: 503,
+        contentType: "text/plain",
+        body: "forced final upload failure",
+      });
+      return;
+    }
+
+    await route.continue();
+  });
+
+  await test.step("record until a local backup chunk exists and force final upload failure", async () => {
+    await page.waitForTimeout(1_000);
+    await page.getByRole("button", { name: "Start recording" }).click();
+    await expect(
+      page.getByRole("button", { name: "Stop recording" }),
+    ).toBeVisible();
+
+    await page.waitForTimeout(6_000);
+    await page.getByRole("button", { name: "Stop recording" }).click();
+    await expect(page.getByText("FINALIZING").first()).toBeVisible();
+    await expect(
+      page.getByRole("button", { name: "Start recording" }),
+    ).toBeVisible({ timeout: 45_000 });
+    await expect(page.getByText("Local recording backup")).toBeVisible();
+    await expect(
+      page.getByText(
+        "Remote upload failed. Local backup is available in this browser.",
+      ),
+    ).toBeVisible();
+    expect(failedFinalUpload).toBe(true);
+  });
+
+  await test.step("retry upload from the local backup", async () => {
+    const retryUpload = page.getByRole("button", { name: "Retry upload" });
+    await expect(retryUpload).toBeEnabled();
+    await retryUpload.click();
+    await expect(page.getByText("Local backup uploaded")).toBeVisible();
+    await expect(page.getByText("Local recording backup")).toBeHidden({
+      timeout: 45_000,
+    });
+    await expect(
+      page.getByRole("button", { name: "Finish recording" }),
+    ).toBeVisible();
+  });
+
+  await test.step("assert recovered track metadata and stored recording", async () => {
+    await expect
+      .poll(
+        async () => {
+          const track = await db.track.findFirst({
+            where: { sessionId, participantName },
+            select: { status: true },
+          });
+          return track?.status ?? null;
+        },
+        { timeout: 30_000 },
+      )
+      .toBe("complete");
+
+    const track = await db.track.findFirstOrThrow({
+      where: { sessionId, participantName },
+      select: { durationMs: true, s3Key: true },
+    });
+
+    expect(track.durationMs).toBeGreaterThan(0);
+    expect(track.s3Key).toMatch(
+      new RegExp(`^sessions/${sessionId}/tracks/[^/]+/recording\\.webm$`),
+    );
+
+    const head = await createS3Client().send(
+      new HeadObjectCommand({
+        Bucket: requiredEnv("S3_BUCKET_NAME"),
+        Key: track.s3Key,
+      }),
+    );
+    expect(head.ContentLength).toBeGreaterThan(0);
   });
 });

--- a/tests/recording-backup.test.ts
+++ b/tests/recording-backup.test.ts
@@ -1,0 +1,176 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  MemoryRecordingBackupBackend,
+  RecordingBackupStore,
+  type RecordingBackupClearReason,
+} from "@/lib/recording-backup";
+import { retryLocalRecordingBackupUpload } from "@/lib/recording-backup-upload";
+
+function blob(value: string): Blob {
+  return new Blob([value], { type: "audio/webm" });
+}
+
+describe("recording backup store", () => {
+  it("persists a manifest with chunk upload state and recovery metadata", async () => {
+    const store = new RecordingBackupStore(
+      new MemoryRecordingBackupBackend(true),
+    );
+
+    const manifest = await store.startBackup({
+      sessionId: "session-1",
+      trackId: "track-1",
+      participantName: "Alice",
+      recordingToken: "recording-token",
+    });
+
+    expect(manifest).toMatchObject({
+      id: "session-1:track-1",
+      sessionId: "session-1",
+      trackId: "track-1",
+      participantName: "Alice",
+      recordingToken: "recording-token",
+      persistentStorage: true,
+      state: "recording",
+      chunks: [],
+    });
+
+    const withChunk = await store.saveChunk({
+      sessionId: "session-1",
+      trackId: "track-1",
+      chunkIndex: 0,
+      chunk: blob("first"),
+      capturedAt: new Date("2026-05-31T10:00:00.000Z"),
+    });
+
+    expect(withChunk.chunks).toEqual([
+      expect.objectContaining({
+        chunkIndex: 0,
+        byteSize: 5,
+        capturedAt: "2026-05-31T10:00:00.000Z",
+        uploadStatus: "pending",
+        storage: "indexeddb",
+      }),
+    ]);
+
+    const uploaded = await store.markChunkUploaded("session-1", "track-1", 0);
+    expect(uploaded.chunks[0]).toMatchObject({
+      uploadStatus: "uploaded",
+      uploadedAt: expect.any(String),
+    });
+
+    await store.saveChunk({
+      sessionId: "session-1",
+      trackId: "track-1",
+      chunkIndex: 1,
+      chunk: blob("second"),
+    });
+    const failed = await store.markChunkFailed(
+      "session-1",
+      "track-1",
+      1,
+      new Error("S3 rejected the chunk"),
+    );
+
+    expect(failed.state).toBe("failed");
+    expect(failed.lastError).toBe("S3 rejected the chunk");
+    expect(failed.chunks[1]).toMatchObject({
+      uploadStatus: "failed",
+      error: "S3 rejected the chunk",
+    });
+  });
+
+  it("retries a failed remote upload from local chunks", async () => {
+    const store = new RecordingBackupStore(
+      new MemoryRecordingBackupBackend(true),
+    );
+    const manifest = await store.startBackup({
+      sessionId: "session-1",
+      trackId: "track-1",
+      participantName: "Alice",
+      recordingToken: "recording-token",
+    });
+    await store.saveChunk({
+      sessionId: "session-1",
+      trackId: "track-1",
+      chunkIndex: 0,
+      chunk: blob("first"),
+    });
+    await store.saveChunk({
+      sessionId: "session-1",
+      trackId: "track-1",
+      chunkIndex: 1,
+      chunk: blob("second"),
+    });
+    const failed = await store.markBackupFailed(
+      manifest.id,
+      new Error("final upload failed"),
+    );
+
+    const getPresignedUploadUrl = vi
+      .fn()
+      .mockResolvedValue("https://s3.example/final");
+    const uploadChunk = vi.fn().mockResolvedValue(undefined);
+    const completeUpload = vi.fn().mockResolvedValue(undefined);
+
+    const retried = await retryLocalRecordingBackupUpload(failed, {
+      backupStore: store,
+      getPresignedUploadUrl,
+      uploadChunk,
+      completeUpload,
+    });
+
+    expect(getPresignedUploadUrl).toHaveBeenCalledWith(
+      "session-1",
+      "track-1",
+      9999,
+      undefined,
+      undefined,
+      "recording-token",
+    );
+    expect(uploadChunk).toHaveBeenCalledWith(
+      "https://s3.example/final",
+      expect.any(Blob),
+    );
+    const uploadedBlob = uploadChunk.mock.calls[0][1] as Blob;
+    expect(await uploadedBlob.text()).toBe("firstsecond");
+    expect(completeUpload).toHaveBeenCalledWith(
+      "session-1",
+      "track-1",
+      undefined,
+      "recording-token",
+    );
+    expect(retried.state).toBe("uploaded");
+  });
+
+  it("clears local chunks only for explicit user or verified-upload cleanup", async () => {
+    const store = new RecordingBackupStore(
+      new MemoryRecordingBackupBackend(true),
+    );
+    const manifest = await store.startBackup({
+      sessionId: "session-1",
+      trackId: "track-1",
+      participantName: "Alice",
+    });
+    await store.saveChunk({
+      sessionId: "session-1",
+      trackId: "track-1",
+      chunkIndex: 0,
+      chunk: blob("first"),
+    });
+
+    await expect(
+      store.clearBackup(
+        manifest.id,
+        "implicit" as RecordingBackupClearReason,
+      ),
+    ).rejects.toThrow("explicit reason");
+    expect(await store.getBackup(manifest.id)).not.toBeNull();
+
+    await store.clearBackup(manifest.id, "user-confirmed");
+
+    expect(await store.getBackup(manifest.id)).toBeNull();
+    await expect(store.buildRecordingBlob(manifest.id)).rejects.toThrow(
+      "not found",
+    );
+  });
+});

--- a/tests/recording-backup.test.ts
+++ b/tests/recording-backup.test.ts
@@ -139,7 +139,10 @@ describe("recording backup store", () => {
       undefined,
       "recording-token",
     );
-    expect(retried.state).toBe("uploaded");
+    expect(retried.state).toBe("available");
+    await expect(store.buildRecordingBlob(manifest.id)).resolves.toBeInstanceOf(
+      Blob,
+    );
   });
 
   it("clears local chunks only for explicit user or verified-upload cleanup", async () => {


### PR DESCRIPTION
Closes #90

## Summary

- Add browser-side recording backup storage with OPFS-first chunk writes and IndexedDB fallback manifests.
- Persist per-chunk metadata, upload status, timestamps, participant/session/track identity, recording token, and cleanup state.
- Surface local backup recovery in the studio with retry upload, download reconstructed WebM, and explicit clear actions.
- Clear local backups only after verified upload completion or explicit user confirmation.
- Add browser smoke coverage for failed final upload recovery from the local backup.
- Run the browser smoke suite in CI through a dedicated Browser smoke workflow.

## Verification

- `npm run test -- tests/recording-backup.test.ts tests/upload-client.test.ts tests/hooks/useUploadProgress.test.ts` - 3 files passed, 12 tests passed.
- `npm run typecheck` - passed.
- `npm run test` - 18 files passed, 126 tests passed.
- `npm run test:browser -- --grep "recovers a failed final upload"` - 1 browser test passed.
- `npm run test:browser` - 2 browser tests passed.
- `npm run build` - passed. Next.js reported the existing multiple-lockfile workspace-root warning.
- Playwright CLI opened `http://localhost:3001/studio/local-backup-check`; auth middleware redirected to `/signin`, and the sign-in page rendered.