### PR TITLE
Resume active recordings after participant reconnects

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,18 +12,18 @@
     "reset:local": "bash ./scripts/reset-local.sh",
     "purge:ready": "node scripts/purge-ready-sessions.mjs",
     "purge:orphans": "node scripts/purge-orphan-s3-sessions.mjs",
-    "build": "next build",
-    "vercel-build": "if [ \"$VERCEL_ENV\" = \"production\" ]; then prisma migrate deploy; fi && next build",
+    "build": "prisma generate && next build",
+    "vercel-build": "prisma generate && if [ \"$VERCEL_ENV\" = \"production\" ]; then prisma migrate deploy; fi && next build",
     "start": "next start",
     "postinstall": "prisma generate",
     "lint": "next lint",
-    "typecheck": "tsc --noEmit --incremental false",
-    "test:integration": "vitest run --config vitest.integration.config.ts",
+    "typecheck": "prisma generate && tsc --noEmit --incremental false",
+    "test:integration": "prisma generate && vitest run --config vitest.integration.config.ts",
     "test:browser": "bash ./scripts/test-browser-smoke.sh",
     "db:migrate": "prisma migrate dev",
     "db:generate": "prisma generate",
     "db:push": "prisma db push",
-    "test": "vitest run"
+    "test": "prisma generate && vitest run"
   },
   "dependencies": {
     "@aws-sdk/client-s3": "^3.600.0",

--- a/prisma/migrations/20260601000000_participant_reconnect_segments/migration.sql
+++ b/prisma/migrations/20260601000000_participant_reconnect_segments/migration.sql
@@ -1,0 +1,8 @@
+-- Support logical participant continuity across reconnects during an active take.
+ALTER TABLE "Session" ADD COLUMN "activeRecordingStartedAt" TIMESTAMP(3);
+
+ALTER TABLE "Track" ADD COLUMN "participantIdentity" TEXT;
+ALTER TABLE "Track" ADD COLUMN "segmentIndex" INTEGER NOT NULL DEFAULT 0;
+
+CREATE INDEX "Track_sessionId_participantIdentity_sessionStartedAt_idx"
+  ON "Track"("sessionId", "participantIdentity", "sessionStartedAt");

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -17,6 +17,10 @@ model Session {
   name        String
   status      String    @default("recording") // recording | ready
   finalizedAt DateTime?
+  // Non-null while the host-controlled room recording is actively rolling.
+  // Rejoining participants poll this field so a missed LiveKit data-channel
+  // start event can be resumed as a new segment under the same logical identity.
+  activeRecordingStartedAt DateTime?
   createdAt   DateTime  @default(now())
   updatedAt   DateTime  @updatedAt
   tracks      Track[]
@@ -27,6 +31,11 @@ model Track {
   sessionId       String
   session         Session  @relation(fields: [sessionId], references: [id])
   participantName String
+  // Stable browser/session identity used to group reconnect-created physical
+  // segments into one logical participant stream. Display names remain editable
+  // and are intentionally not used as the durable reconnect key.
+  participantIdentity String?
+  segmentIndex    Int      @default(0)
   s3Key           String
   durationMs      Int?
   format          String   @default("webm")
@@ -45,4 +54,6 @@ model Track {
   partial         Boolean  @default(false)
   createdAt       DateTime @default(now())
   updatedAt       DateTime @updatedAt
+
+  @@index([sessionId, participantIdentity, sessionStartedAt])
 }

--- a/scripts/test-browser-smoke.sh
+++ b/scripts/test-browser-smoke.sh
@@ -104,4 +104,5 @@ wait_for_tcp 127.0.0.1 7880 LiveKit
 docker compose --profile local-storage --profile tools run --rm minio-mc /scripts/minio-bucket.sh provision
 
 npx prisma db push
+npx prisma generate
 npx playwright test --config playwright.config.ts "$@"

--- a/src/app/api/sessions/[id]/recording-state/route.ts
+++ b/src/app/api/sessions/[id]/recording-state/route.ts
@@ -1,0 +1,94 @@
+import { NextRequest, NextResponse } from "next/server";
+import { db } from "@/lib/db";
+import { resolvePrincipal } from "@/lib/auth";
+
+function parseStartedAt(value: unknown): Date | null {
+  if (typeof value !== "string") return null;
+  const parsed = Date.parse(value);
+  if (Number.isNaN(parsed)) return null;
+  return new Date(parsed);
+}
+
+async function requirePrincipal(req: NextRequest, sessionId: string) {
+  const principal = await resolvePrincipal(req, sessionId);
+  if (!principal) return { error: "unauthorized", status: 401 } as const;
+  if (principal.kind === "guest" && principal.sessionId !== sessionId) {
+    return { error: "forbidden", status: 403 } as const;
+  }
+  return { principal } as const;
+}
+
+export async function GET(
+  req: NextRequest,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  try {
+    const { id } = await params;
+    const auth = await requirePrincipal(req, id);
+    if ("error" in auth) {
+      return NextResponse.json({ error: auth.error }, { status: auth.status });
+    }
+
+    const session = await db.session.findUnique({
+      where: { id },
+      select: { id: true, activeRecordingStartedAt: true },
+    });
+    if (!session) {
+      return NextResponse.json({ error: "Session not found" }, { status: 404 });
+    }
+
+    return NextResponse.json({
+      active: Boolean(session.activeRecordingStartedAt),
+      sessionStartedAt: session.activeRecordingStartedAt?.toISOString() ?? null,
+    });
+  } catch (error) {
+    console.error("Failed to read recording state:", error);
+    return NextResponse.json(
+      { error: "Failed to read recording state" },
+      { status: 500 },
+    );
+  }
+}
+
+export async function POST(
+  req: NextRequest,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  try {
+    const { id } = await params;
+    const auth = await requirePrincipal(req, id);
+    if ("error" in auth) {
+      return NextResponse.json({ error: auth.error }, { status: auth.status });
+    }
+    if (auth.principal.kind !== "host") {
+      return NextResponse.json({ error: "forbidden" }, { status: 403 });
+    }
+
+    const body = await req.json().catch(() => ({}));
+    const active = body?.active === true;
+    const startedAt = active ? parseStartedAt(body?.sessionStartedAt) : null;
+    if (active && !startedAt) {
+      return NextResponse.json(
+        { error: "sessionStartedAt is required when active is true" },
+        { status: 400 },
+      );
+    }
+
+    const updated = await db.session.update({
+      where: { id },
+      data: { activeRecordingStartedAt: startedAt },
+      select: { activeRecordingStartedAt: true },
+    });
+
+    return NextResponse.json({
+      active: Boolean(updated.activeRecordingStartedAt),
+      sessionStartedAt: updated.activeRecordingStartedAt?.toISOString() ?? null,
+    });
+  } catch (error) {
+    console.error("Failed to update recording state:", error);
+    return NextResponse.json(
+      { error: "Failed to update recording state" },
+      { status: 500 },
+    );
+  }
+}

--- a/src/app/api/upload/presign/route.ts
+++ b/src/app/api/upload/presign/route.ts
@@ -25,7 +25,17 @@ function getUploadErrorMessage(error: unknown): string {
 export async function POST(req: NextRequest) {
   try {
     const body = await req.json();
-    const { sessionId, trackId, partNumber, participantName, deviceLabel, deviceId, isBuiltInMic, sessionStartedAt } = body;
+    const {
+      sessionId,
+      trackId,
+      partNumber,
+      participantName,
+      participantIdentity,
+      deviceLabel,
+      deviceId,
+      isBuiltInMic,
+      sessionStartedAt,
+    } = body;
 
     if (!sessionId || !trackId || partNumber === undefined) {
       return NextResponse.json(
@@ -83,12 +93,27 @@ export async function POST(req: NextRequest) {
           typeof sessionStartedAt === "string" && !Number.isNaN(Date.parse(sessionStartedAt))
             ? new Date(sessionStartedAt)
             : null;
+        const safeParticipantIdentity =
+          typeof participantIdentity === "string" && participantIdentity.length > 0
+            ? participantIdentity
+            : null;
+        const segmentCount = safeParticipantIdentity
+          ? await db.track.count({
+              where: {
+                sessionId,
+                participantIdentity: safeParticipantIdentity,
+                sessionStartedAt: safeSessionStartedAt,
+              },
+            })
+          : 0;
 
         await db.track.create({
           data: {
             id: trackId,
             sessionId,
             participantName,
+            participantIdentity: safeParticipantIdentity,
+            segmentIndex: segmentCount,
             s3Key: trackRecordingKey(sessionId, trackId),
             deviceLabel: safeDeviceLabel,
             deviceId: safeDeviceId,

--- a/src/app/session/[id]/page.tsx
+++ b/src/app/session/[id]/page.tsx
@@ -21,6 +21,9 @@ interface Track {
   durationMs: number | null;
   format: string;
   status: string;
+  participantIdentity: string | null;
+  segmentIndex: number;
+  partial: boolean;
   createdAt: string;
   deviceLabel: string | null;
   isBuiltInMic: boolean;
@@ -249,6 +252,12 @@ export default function SessionDetailPage() {
                       </div>
                       <div className="font-mono text-[10px] text-text-3 mt-0.5">
                         {formatDuration(t.durationMs)}
+                        {t.segmentIndex > 0 && (
+                          <span className="ml-1 text-warn">seg {t.segmentIndex + 1}</span>
+                        )}
+                        {t.partial && (
+                          <span className="ml-1 text-warn">partial</span>
+                        )}
                       </div>
                     </div>
 
@@ -283,7 +292,7 @@ export default function SessionDetailPage() {
                     {/* Status + download */}
                     <div className="flex items-center gap-2.5 flex-shrink-0">
                       <span className="font-mono text-[10px] text-text-3 uppercase">
-                        {t.status}
+                        {t.segmentIndex > 0 ? `segment ${t.segmentIndex + 1}` : t.status}
                       </span>
                       {t.status === "complete" && (
                         <Button

--- a/src/app/studio/[id]/page.tsx
+++ b/src/app/studio/[id]/page.tsx
@@ -105,6 +105,7 @@ const BANDWIDTH_SAVING_PUBLISH = {
 } as const;
 
 const RECORDING_CONFIRMATION_TIMEOUT_MS = 4000;
+const PARTICIPANT_IDENTITY_STORAGE_PREFIX = "cozytrack:participant-identity:";
 
 // ---------- Helpers ----------
 
@@ -142,6 +143,21 @@ function isRecoverableBackup(
 
 function backupErrorMessage(error: unknown): string {
   return error instanceof Error ? error.message : "Local recording backup failed";
+}
+
+function getStoredParticipantIdentity(sessionId: string): string {
+  const storageKey = `${PARTICIPANT_IDENTITY_STORAGE_PREFIX}${sessionId}`;
+  try {
+    const existing = window.localStorage.getItem(storageKey);
+    if (existing) return existing;
+    const next = uuidv4();
+    window.localStorage.setItem(storageKey, next);
+    return next;
+  } catch {
+    // Storage can be blocked in private modes. A tab-scoped identity still
+    // avoids coupling logical reconnect identity to mutable display names.
+    return uuidv4();
+  }
 }
 
 function isMobileBrowser(navigatorInfo: Navigator): boolean {
@@ -667,6 +683,7 @@ function RoomContent({
   onMonitorEnabledChange,
   onMonitorVolumeChange,
   isHost,
+  participantIdentity,
 }: {
   sessionId: string;
   participantName: string;
@@ -680,6 +697,7 @@ function RoomContent({
   onMonitorEnabledChange: (enabled: boolean) => void;
   onMonitorVolumeChange: (volume: number) => void;
   isHost: boolean;
+  participantIdentity: string;
 }) {
   const remoteParticipants = useRemoteParticipants();
   const { localParticipant } = useLocalParticipant();
@@ -1244,6 +1262,7 @@ function RoomContent({
               isBuiltInMic: selectedMicIsBuiltIn,
             },
             sessionStartedAt: sessionStartedAtIso,
+            participantIdentity,
           },
         );
         recordingUploadTokenRef.current = initialUpload.recordingToken;
@@ -1409,6 +1428,7 @@ function RoomContent({
     [
       broadcastRecordingStatus,
       clearRecordingConfirmationState,
+      participantIdentity,
       participantName,
       scheduleRecordingConfirmationCheck,
       selectedMic,
@@ -1652,6 +1672,53 @@ function RoomContent({
     }
   }, [backupAction, setRecoveryBackupSync]);
 
+  const updateServerRecordingState = useCallback(
+    async (active: boolean, sessionStartedAt?: string): Promise<boolean> => {
+      try {
+        const res = await fetch(`/api/sessions/${sessionId}/recording-state`, {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ active, sessionStartedAt }),
+        });
+        if (!res.ok) {
+          const body = await res.json().catch(() => ({}));
+          throw new Error(body.error ?? res.statusText);
+        }
+        return true;
+      } catch (err) {
+        console.error("Failed to update server recording state:", err);
+        return false;
+      }
+    },
+    [sessionId],
+  );
+
+  useEffect(() => {
+    let cancelled = false;
+
+    async function resumeActiveRecording() {
+      if (studioStateRef.current !== "connected") return;
+      try {
+        const res = await fetch(`/api/sessions/${sessionId}/recording-state`);
+        if (!res.ok) return;
+        const body: { active?: boolean; sessionStartedAt?: string | null } =
+          await res.json();
+        if (cancelled || studioStateRef.current !== "connected") return;
+        if (!body.active || !body.sessionStartedAt) return;
+
+        showNotification("Active recording detected — resuming as a new segment");
+        void startRecordingLocal(body.sessionStartedAt);
+      } catch (err) {
+        console.error("Failed to check active recording state:", err);
+      }
+    }
+
+    void resumeActiveRecording();
+    return () => {
+      cancelled = true;
+    };
+  }, [sessionId, showNotification, startRecordingLocal]);
+
   // Synchronous "request in flight" guards. Set true at the top of the click
   // handler before any await so a rapid second click is dropped immediately
   // (issue #74). studioStateRef is only updated mid-way through
@@ -1686,16 +1753,24 @@ function RoomContent({
     startingRef.current = true;
     try {
       const sessionStartedAt = new Date().toISOString();
+      const serverMarkedActive = await updateServerRecordingState(true, sessionStartedAt);
+      if (!serverMarkedActive) {
+        showNotification("Couldn't mark the room recording active");
+        return;
+      }
+
       try {
         await transport.sendControlMessage({ type: "recording_start", sessionStartedAt });
       } catch (err) {
         console.error("Failed to broadcast recording_start:", err);
+        void updateServerRecordingState(false);
         showNotification("Couldn't tell the room to start recording");
         return;
       }
 
       const started = await startRecordingLocal(sessionStartedAt);
       if (!started) {
+        void updateServerRecordingState(false);
         showNotification("Couldn't start your recorder — stopping the room");
         try {
           await transport.sendControlMessage({ type: "recording_stop" });
@@ -1706,13 +1781,20 @@ function RoomContent({
     } finally {
       startingRef.current = false;
     }
-  }, [isHost, transport, startRecordingLocal, showNotification]);
+  }, [
+    isHost,
+    transport,
+    startRecordingLocal,
+    showNotification,
+    updateServerRecordingState,
+  ]);
 
   const handleStopRecording = useCallback(async () => {
     if (!isHost) return;
     if (stoppingRef.current) return;
     stoppingRef.current = true;
     try {
+      void updateServerRecordingState(false);
       try {
         await transport.sendControlMessage({ type: "recording_stop" });
       } catch (err) {
@@ -1723,7 +1805,7 @@ function RoomContent({
     } finally {
       stoppingRef.current = false;
     }
-  }, [isHost, transport, stopRecordingLocal, showNotification]);
+  }, [isHost, transport, stopRecordingLocal, showNotification, updateServerRecordingState]);
 
   // Subscribe to remote control messages. LiveKit does not echo the sender's
   // own messages back, but startRecordingLocal/stopRecordingLocal are
@@ -2169,6 +2251,7 @@ export default function StudioPage() {
 
   const [studioState, setStudioState] = useState<StudioState>("prejoin");
   const [participantName, setParticipantName] = useState("");
+  const [participantIdentity, setParticipantIdentity] = useState("");
   const [selectedMic, setSelectedMic] = useState("");
   const [mics, setMics] = useState<MediaDeviceInfo[]>([]);
   const [token, setToken] = useState("");
@@ -2181,6 +2264,10 @@ export default function StudioPage() {
   // arriving via /join have their display name recorded in the cookie; we
   // use it to prefill the prejoin form.
   const [isHost, setIsHost] = useState(false);
+
+  useEffect(() => {
+    setParticipantIdentity(getStoredParticipantIdentity(sessionId));
+  }, [sessionId]);
 
   useEffect(() => {
     setMonitorEnabled(getStoredMonitorEnabled());
@@ -2315,7 +2402,7 @@ export default function StudioPage() {
   }
 
   function handleJoin() {
-    if (!participantName.trim()) return;
+    if (!participantName.trim() || !participantIdentity) return;
 
     if (
       selectedMicDevice &&
@@ -2410,13 +2497,13 @@ export default function StudioPage() {
 
               <button
                 onClick={handleJoin}
-                disabled={!participantName.trim() || connecting}
+                disabled={!participantName.trim() || !participantIdentity || connecting}
                 className="w-full py-[11px] text-[15px] font-semibold font-sans rounded-md border disabled:cursor-not-allowed"
                 style={{
-                  background: !participantName.trim() || connecting ? "var(--card)" : "var(--amber)",
-                  color: !participantName.trim() || connecting ? "var(--text-3)" : "var(--bg)",
-                  borderColor: !participantName.trim() || connecting ? "var(--border)" : "var(--amber)",
-                  opacity: !participantName.trim() || connecting ? 0.8 : 1,
+                  background: !participantName.trim() || !participantIdentity || connecting ? "var(--card)" : "var(--amber)",
+                  color: !participantName.trim() || !participantIdentity || connecting ? "var(--text-3)" : "var(--bg)",
+                  borderColor: !participantName.trim() || !participantIdentity || connecting ? "var(--border)" : "var(--amber)",
+                  opacity: !participantName.trim() || !participantIdentity || connecting ? 0.8 : 1,
                 }}
               >
                 {connecting ? "Connecting…" : "Join Studio"}
@@ -2470,6 +2557,7 @@ export default function StudioPage() {
           onMonitorEnabledChange={setMonitorEnabled}
           onMonitorVolumeChange={setMonitorVolume}
           isHost={isHost}
+          participantIdentity={participantIdentity}
         />
       </LiveKitRoom>
     </StudioFrame>

--- a/src/lib/upload.ts
+++ b/src/lib/upload.ts
@@ -11,6 +11,7 @@ export interface TrackInitInfo {
   // ISO8601 — the originator's local clock at the moment recording started.
   // Shared across all tracks triggered by the same broadcast.
   sessionStartedAt?: string;
+  participantIdentity?: string;
 }
 
 export interface PresignedUploadTarget {
@@ -41,6 +42,7 @@ export async function getPresignedUploadTarget(
       participantName,
       ...(trackInit?.deviceInfo ?? {}),
       sessionStartedAt: trackInit?.sessionStartedAt,
+      participantIdentity: trackInit?.participantIdentity,
     }),
   });
 

--- a/tests/recording-state.test.ts
+++ b/tests/recording-state.test.ts
@@ -1,0 +1,115 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  session: {
+    id: "s1",
+    activeRecordingStartedAt: null as Date | null,
+  },
+  resolvePrincipal: vi.fn(),
+}));
+
+vi.mock("@/lib/db", () => ({
+  db: {
+    session: {
+      findUnique: vi.fn(async ({ where: { id } }: { where: { id: string } }) =>
+        id === mocks.session.id ? { ...mocks.session } : null,
+      ),
+      update: vi.fn(
+        async ({
+          where: { id },
+          data,
+        }: {
+          where: { id: string };
+          data: { activeRecordingStartedAt: Date | null };
+        }) => {
+          if (id !== mocks.session.id) throw new Error("not found");
+          mocks.session.activeRecordingStartedAt = data.activeRecordingStartedAt;
+          return { ...mocks.session };
+        },
+      ),
+    },
+  },
+}));
+
+vi.mock("@/lib/auth", () => ({
+  resolvePrincipal: mocks.resolvePrincipal,
+}));
+
+import { NextRequest } from "next/server";
+import {
+  GET as getRecordingState,
+  POST as setRecordingState,
+} from "@/app/api/sessions/[id]/recording-state/route";
+
+function params(id = "s1") {
+  return { params: Promise.resolve({ id }) };
+}
+
+function request(body?: Record<string, unknown>) {
+  return new NextRequest("http://localhost/api/sessions/s1/recording-state", {
+    method: body ? "POST" : "GET",
+    headers: body ? { "content-type": "application/json" } : undefined,
+    body: body ? JSON.stringify(body) : undefined,
+  });
+}
+
+beforeEach(() => {
+  mocks.session.activeRecordingStartedAt = null;
+  vi.clearAllMocks();
+  mocks.resolvePrincipal.mockResolvedValue({ kind: "host" });
+});
+
+describe("/api/sessions/[id]/recording-state", () => {
+  it("lets hosts mark and clear an active room recording", async () => {
+    const startedAt = "2026-06-01T12:00:00.000Z";
+
+    const mark = await setRecordingState(
+      request({ active: true, sessionStartedAt: startedAt }),
+      params(),
+    );
+    expect(mark.status).toBe(200);
+    await expect(mark.json()).resolves.toEqual({
+      active: true,
+      sessionStartedAt: startedAt,
+    });
+
+    const read = await getRecordingState(request(), params());
+    await expect(read.json()).resolves.toEqual({
+      active: true,
+      sessionStartedAt: startedAt,
+    });
+
+    const clear = await setRecordingState(request({ active: false }), params());
+    expect(clear.status).toBe(200);
+    await expect(clear.json()).resolves.toEqual({
+      active: false,
+      sessionStartedAt: null,
+    });
+  });
+
+  it("allows guests to read but not mutate recording state", async () => {
+    mocks.resolvePrincipal.mockResolvedValue({
+      kind: "guest",
+      sessionId: "s1",
+      name: "Alice",
+    });
+
+    const read = await getRecordingState(request(), params());
+    expect(read.status).toBe(200);
+
+    const write = await setRecordingState(
+      request({ active: true, sessionStartedAt: "2026-06-01T12:00:00.000Z" }),
+      params(),
+    );
+    expect(write.status).toBe(403);
+  });
+
+  it("rejects active updates without a valid start time", async () => {
+    const res = await setRecordingState(
+      request({ active: true, sessionStartedAt: "not-a-date" }),
+      params(),
+    );
+
+    expect(res.status).toBe(400);
+  });
+});

--- a/tests/upload-auth.test.ts
+++ b/tests/upload-auth.test.ts
@@ -7,6 +7,9 @@ type Track = {
   s3Key: string;
   status: string;
   durationMs: number | null;
+  participantIdentity?: string | null;
+  segmentIndex?: number;
+  sessionStartedAt?: Date | null;
 };
 
 const mocks = vi.hoisted(() => ({
@@ -31,6 +34,17 @@ vi.mock("@/lib/db", () => ({
           return track ? { ...track } : null;
         },
       ),
+      count: vi.fn(async ({ where }: { where: Partial<Track> }) => {
+        return Array.from(mocks.tracks.values()).filter((track) => {
+          return Object.entries(where).every(([key, value]) => {
+            const actual = track[key as keyof Track];
+            if (actual instanceof Date && value instanceof Date) {
+              return actual.getTime() === value.getTime();
+            }
+            return actual === value;
+          });
+        }).length;
+      }),
       create: vi.fn(async ({ data }: { data: Track }) => {
         const track = { ...data, status: "recording", durationMs: null };
         mocks.tracks.set(track.id, track);
@@ -133,6 +147,41 @@ describe("recording upload auth", () => {
     expect(body.url).toBe("https://s3.example/sessions/s1/tracks/t1/0.webm");
     expect(body.recordingToken).toEqual(expect.any(String));
     expect(mocks.tracks.get("t1")?.participantName).toBe("Alice");
+  });
+
+  it("groups reconnect segments by stable participant identity", async () => {
+    mocks.resolvePrincipal.mockResolvedValue({ kind: "host" });
+    const sessionStartedAt = "2026-06-01T12:00:00.000Z";
+
+    await presignUpload(
+      postJson("/api/upload/presign", {
+        sessionId: "s1",
+        trackId: "t1",
+        partNumber: 0,
+        participantName: "Alice",
+        participantIdentity: "browser-alice",
+        sessionStartedAt,
+      }),
+    );
+    await presignUpload(
+      postJson("/api/upload/presign", {
+        sessionId: "s1",
+        trackId: "t2",
+        partNumber: 0,
+        participantName: "Alice Renamed",
+        participantIdentity: "browser-alice",
+        sessionStartedAt,
+      }),
+    );
+
+    expect(mocks.tracks.get("t1")).toMatchObject({
+      participantIdentity: "browser-alice",
+      segmentIndex: 0,
+    });
+    expect(mocks.tracks.get("t2")).toMatchObject({
+      participantIdentity: "browser-alice",
+      segmentIndex: 1,
+    });
   });
 
   it("keeps presigning chunks with the recording token after cookies expire", async () => {


### PR DESCRIPTION
### Motivation
- Reconnects during an active take could create separate physical tracks with no way to link them or resume recording; this change lets clients detect an in-progress room take and treat reconnects as new segments of the same logical participant.

### Description
- Add DB fields and migration: `Session.activeRecordingStartedAt`, `Track.participantIdentity`, `Track.segmentIndex`, and an index on `(sessionId, participantIdentity, sessionStartedAt)` with a migration SQL file.
- New route `/api/sessions/[id]/recording-state` to let authenticated callers read whether a room recording is active and let hosts mark the room active/inactive (validation and auth enforced).
- Wire participant identities into the studio flow: persist a per-session `participantIdentity` in `localStorage`, pass it into presign calls, and include it when creating a new `Track` so reconnect-created segments are grouped and indexed.
- Server-side upload presign now accepts `participantIdentity` and computes `segmentIndex` when creating a new `Track` so reconnect segments are ordered consistently.
- Studio client marks the session recording state on the server before/after host `recording_start`/`recording_stop`, and auto-resumes an active room recording (detected on join) as a new segment when appropriate.
- Surface `segmentIndex` and `partial` markers on the session detail page so reviewers see segment/partial annotations.
- Add tests for recording-state authorization/validation and for reconnect segment indexing.

### Testing
- Ran `npm run db:generate` to refresh Prisma client (succeeded).
- Unit/integration tests: ran `npm test -- tests/upload-auth.test.ts tests/recording-state.test.ts` and `npm test` (all tests passed).
- Typecheck: ran `npm run typecheck` (succeeded).
- Lint: ran `npm run lint` (no ESLint errors).
- Build: ran `npm run build` in this environment; build failed due to `next/font` being unable to fetch Google Fonts from the network (environment limitation) but this is unrelated to the code changes affecting runtime logic or tests.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1d290c43ec8332be2c13f5f80e5da1)