### PR TITLE
[codex] Add server-issued participant identity

### DIFF
--- a/.github/workflows/codex-review-feedback.yml
+++ b/.github/workflows/codex-review-feedback.yml
@@ -1,0 +1,60 @@
+name: Codex review feedback
+
+on:
+  workflow_run:
+    workflows: ["Codex review"]
+    types: [completed]
+
+jobs:
+  post_feedback:
+    if: >-
+      ${{
+        github.event.workflow_run.conclusion == 'success' &&
+        github.event.workflow_run.repository.full_name == github.repository
+      }}
+    runs-on: ubuntu-latest
+    permissions:
+      actions: read
+      issues: write
+      pull-requests: write
+    steps:
+      - name: Download Codex feedback artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: codex-review-feedback
+          path: codex-review-output
+          run-id: ${{ github.event.workflow_run.id }}
+          github-token: ${{ github.token }}
+
+      - name: Report Codex feedback
+        uses: actions/github-script@v7
+        env:
+          CODEX_FINAL_MESSAGE_FILE: codex-review-output/final-message.md
+          CODEX_PR_NUMBER_FILE: codex-review-output/pr-number.txt
+        with:
+          script: |
+            const fs = require("node:fs");
+            const message = fs.readFileSync(process.env.CODEX_FINAL_MESSAGE_FILE, "utf8").trim();
+            if (!message) {
+              core.notice("No Codex feedback to post.");
+              return;
+            }
+
+            const prNumber = Number(fs.readFileSync(process.env.CODEX_PR_NUMBER_FILE, "utf8").trim());
+            if (!Number.isInteger(prNumber) || prNumber <= 0) {
+              core.setFailed(`Invalid Codex feedback PR number: ${prNumber}`);
+              return;
+            }
+
+            const body = [
+              "## Codex review",
+              "",
+              message,
+            ].join("\n");
+
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: prNumber,
+              body,
+            });

--- a/.github/workflows/codex-review.yml
+++ b/.github/workflows/codex-review.yml
@@ -94,6 +94,7 @@ jobs:
         run: |
           mkdir -p codex-review-output
           : > codex-review-output/final-message.md
+          printf '%s\n' '${{ steps.pr_context.outputs.number }}' > codex-review-output/pr-number.txt
 
       - name: Run Codex review
         id: run_codex
@@ -134,48 +135,6 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: codex-review-feedback
-          path: codex-review-output/final-message.md
+          path: codex-review-output
           if-no-files-found: error
           retention-days: 1
-
-  post_feedback:
-    runs-on: ubuntu-latest
-    needs: codex
-    if: needs.codex.result == 'success' && needs.codex.outputs.pr_number != ''
-    permissions:
-      actions: read
-      issues: write
-      pull-requests: write
-    steps:
-      - name: Download Codex feedback artifact
-        uses: actions/download-artifact@v4
-        with:
-          name: codex-review-feedback
-          path: codex-review-output
-
-      - name: Report Codex feedback
-        uses: actions/github-script@v7
-        env:
-          CODEX_FINAL_MESSAGE_FILE: codex-review-output/final-message.md
-        with:
-          github-token: ${{ github.token }}
-          script: |
-            const fs = require("node:fs");
-            const message = fs.readFileSync(process.env.CODEX_FINAL_MESSAGE_FILE, "utf8").trim();
-            if (!message) {
-              core.notice("No Codex feedback to post.");
-              return;
-            }
-
-            const body = [
-              "## Codex review",
-              "",
-              message,
-            ].join("\n");
-
-            await github.rest.issues.createComment({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              issue_number: Number("${{ needs.codex.outputs.pr_number }}"),
-              body,
-            });

--- a/prisma/migrations/20260610000000_add_track_participant_id/migration.sql
+++ b/prisma/migrations/20260610000000_add_track_participant_id/migration.sql
@@ -1,0 +1,4 @@
+ALTER TABLE "Track" ADD COLUMN "participantId" TEXT;
+
+CREATE INDEX "Track_sessionId_participantId_idx"
+  ON "Track"("sessionId", "participantId");

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -27,6 +27,9 @@ model Track {
   sessionId       String
   session         Session  @relation(fields: [sessionId], references: [id])
   participantName String
+  // Server-derived stable identity for the participant who created this track.
+  // Display names are mutable and not used for reconnect grouping.
+  participantId   String?
   s3Key           String
   durationMs      Int?
   format          String   @default("webm")
@@ -45,4 +48,6 @@ model Track {
   partial         Boolean  @default(false)
   createdAt       DateTime @default(now())
   updatedAt       DateTime @updatedAt
+
+  @@index([sessionId, participantId])
 }

--- a/src/app/api/auth/me/route.ts
+++ b/src/app/api/auth/me/route.ts
@@ -12,11 +12,12 @@ export async function GET(req: NextRequest) {
     return NextResponse.json({ role: null }, { status: 200 });
   }
   if (principal.kind === "host") {
-    return NextResponse.json({ role: "host" });
+    return NextResponse.json({ role: "host", participantId: principal.participantId });
   }
   return NextResponse.json({
     role: "guest",
     sessionId: principal.sessionId,
     name: principal.name,
+    participantId: principal.participantId,
   });
 }

--- a/src/app/api/livekit-token/route.ts
+++ b/src/app/api/livekit-token/route.ts
@@ -4,14 +4,16 @@
 
 import { NextRequest, NextResponse } from "next/server";
 import { AccessToken } from "livekit-server-sdk";
-import { resolvePrincipal } from "@/lib/auth";
+import { principalParticipantId, resolvePrincipal } from "@/lib/auth";
 
 export async function POST(req: NextRequest) {
   try {
     const body = await req.json();
     const { roomName, participantName } = body;
+    const displayName =
+      typeof participantName === "string" ? participantName.trim().slice(0, 80) : "";
 
-    if (!roomName || !participantName) {
+    if (!roomName || !displayName) {
       return NextResponse.json(
         { error: "roomName and participantName are required" },
         { status: 400 }
@@ -37,15 +39,21 @@ export async function POST(req: NextRequest) {
       );
     }
 
-    // Stamp the principal's role into the LiveKit token metadata. Receivers
-    // read `participant.metadata` off the LiveKit room to verify that
+    // Stamp server-derived identity and role into LiveKit token metadata.
+    // Receivers read `participant.metadata` off the LiveKit room to verify
     // host-only control messages (e.g. recording_start/stop) actually came
     // from a host. Forging this requires forging a LiveKit token, which
     // requires the server-held LIVEKIT_API_SECRET, so the role is trustworthy
     // at the room edge.
-    const metadata = JSON.stringify({ role: principal.kind });
+    const participantId = principalParticipantId(principal);
+    const metadata = JSON.stringify({
+      role: principal.kind,
+      participantId,
+      displayName,
+    });
     const at = new AccessToken(apiKey, apiSecret, {
-      identity: participantName,
+      identity: participantId,
+      name: displayName,
       metadata,
     });
     at.addGrant({ roomJoin: true, room: roomName });

--- a/src/app/api/upload/presign/route.ts
+++ b/src/app/api/upload/presign/route.ts
@@ -3,6 +3,7 @@ import { db } from "@/lib/db";
 import { trackPartKey, trackRecordingKey, getPresignedPutUrl } from "@/lib/s3";
 import {
   issueRecordingUploadToken,
+  principalParticipantId,
   resolvePrincipal,
   verifyRecordingUploadToken,
 } from "@/lib/auth";
@@ -89,6 +90,7 @@ export async function POST(req: NextRequest) {
             id: trackId,
             sessionId,
             participantName,
+            participantId: principalParticipantId(principal),
             s3Key: trackRecordingKey(sessionId, trackId),
             deviceLabel: safeDeviceLabel,
             deviceId: safeDeviceId,

--- a/src/app/studio/[id]/page.tsx
+++ b/src/app/studio/[id]/page.tsx
@@ -44,6 +44,7 @@ import { getToken, LIVEKIT_URL } from "@/lib/livekit";
 import {
   useTransport,
   isHostSender,
+  parseParticipantMetadata,
   type RecordingStatusState,
 } from "@/lib/transport";
 import { isSelectedMicBuiltIn } from "@/lib/devices";
@@ -119,6 +120,10 @@ function formatElapsed(totalMs: number): string {
 function formatParticipantList(names: string[]): string {
   if (names.length <= 2) return names.join(" and ");
   return `${names.slice(0, -1).join(", ")}, and ${names[names.length - 1]}`;
+}
+
+function displayNameFromMetadata(metadata: string | undefined): string | undefined {
+  return parseParticipantMetadata(metadata)?.displayName;
 }
 
 function formatBytes(bytes: number): string {
@@ -684,6 +689,22 @@ function RoomContent({
   const remoteParticipants = useRemoteParticipants();
   const { localParticipant } = useLocalParticipant();
   const transport = useTransport();
+  const remoteParticipantNames = useMemo(() => {
+    const next = new Map<string, string>();
+    for (const participant of remoteParticipants) {
+      next.set(
+        participant.identity,
+        participant.name ||
+          displayNameFromMetadata(participant.metadata) ||
+          participant.identity,
+      );
+    }
+    return next;
+  }, [remoteParticipants]);
+  const remoteParticipantName = useCallback(
+    (identity: string) => remoteParticipantNames.get(identity) ?? identity,
+    [remoteParticipantNames],
+  );
   const recorderRef = useRef<CozyRecorder | null>(null);
   const trackIdRef = useRef<string>("");
   const recordingUploadTokenRef = useRef<string | undefined>(undefined);
@@ -888,11 +909,18 @@ function RoomContent({
 
         setUnconfirmedRecordingParticipants(new Set(unconfirmed));
         showNotification(
-          `Recording not confirmed by ${formatParticipantList(unconfirmed)}`,
+          `Recording not confirmed by ${formatParticipantList(
+            unconfirmed.map(remoteParticipantName),
+          )}`,
         );
       }, RECORDING_CONFIRMATION_TIMEOUT_MS);
     },
-    [clearRecordingConfirmationTimer, remoteParticipants, showNotification],
+    [
+      clearRecordingConfirmationTimer,
+      remoteParticipantName,
+      remoteParticipants,
+      showNotification,
+    ],
   );
 
   const broadcastRecordingStatus = useCallback(
@@ -1736,6 +1764,10 @@ function RoomContent({
   // for the trust model documented in issue #74.
   useEffect(() => {
     const unsub = transport.onControlMessage((msg, sender) => {
+      const senderName =
+        displayNameFromMetadata(sender.metadata) ||
+        remoteParticipantName(sender.identity) ||
+        "another participant";
       if (msg.type === "recording_start" || msg.type === "recording_stop") {
         if (!isHostSender(sender.metadata)) {
           console.warn(
@@ -1746,7 +1778,7 @@ function RoomContent({
       }
       if (msg.type === "recording_start") {
         showNotification(
-          `Recording started by ${sender.identity || "another participant"}`,
+          `Recording started by ${senderName}`,
         );
         void startRecordingLocal(msg.sessionStartedAt).then((started) => {
           if (!started) {
@@ -1755,7 +1787,7 @@ function RoomContent({
         });
       } else if (msg.type === "recording_stop") {
         showNotification(
-          `Recording stopped by ${sender.identity || "another participant"}`,
+          `Recording stopped by ${senderName}`,
         );
         void stopRecordingLocal();
       } else if (msg.type === "recording_status") {
@@ -1779,7 +1811,7 @@ function RoomContent({
 
         if (msg.state === "failed") {
           showNotification(
-            `${fromParticipant} could not start recording${
+            `${remoteParticipantName(fromParticipant)} could not start recording${
               msg.reason ? `: ${msg.reason}` : ""
             }`,
           );
@@ -1792,6 +1824,7 @@ function RoomContent({
     startRecordingLocal,
     stopRecordingLocal,
     showNotification,
+    remoteParticipantName,
     updateRemoteRecordingStatus,
   ]);
 
@@ -1985,7 +2018,7 @@ function RoomContent({
           {remoteParticipants.map((p) => (
             <ParticipantStrip
               key={p.identity}
-              name={p.identity}
+              name={remoteParticipantName(p.identity)}
               role="guest"
               micLabel={undefined /* Remote mic label — needs #28 (LiveKit metadata propagation). */}
               isBuiltIn={false /* Remote built-in detection — needs #28. */}

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -17,9 +17,15 @@ const HOST_SESSION_TTL_SECONDS = 60 * 60 * 24 * 7; // 7 days
 const GUEST_SESSION_TTL_SECONDS = 60 * 60 * 12; // 12 hours
 const INVITE_TOKEN_TTL_SECONDS = 60 * 60 * 48; // 48 hours
 const RECORDING_UPLOAD_TTL_SECONDS = 60 * 60 * 12; // 12 hours
+const HOST_PARTICIPANT_ID = "host";
 
-export type HostPrincipal = { kind: "host" };
-export type GuestPrincipal = { kind: "guest"; sessionId: string; name: string };
+export type HostPrincipal = { kind: "host"; participantId: typeof HOST_PARTICIPANT_ID };
+export type GuestPrincipal = {
+  kind: "guest";
+  sessionId: string;
+  name: string;
+  participantId: string;
+};
 export type Principal = HostPrincipal | GuestPrincipal;
 export type RecordingUploadPrincipal = {
   kind: "recording_upload";
@@ -57,7 +63,7 @@ export async function verifyHostCookie(token: string | undefined): Promise<HostP
       issuer: "cozytrack",
       audience: "cozytrack:host",
     });
-    return { kind: "host" };
+    return { kind: "host", participantId: HOST_PARTICIPANT_ID };
   } catch {
     return null;
   }
@@ -93,8 +99,9 @@ export async function verifyInviteToken(token: string): Promise<{ sessionId: str
 export async function issueGuestSessionCookie(
   sessionId: string,
   name: string,
-): Promise<{ cookieName: string; value: string; ttl: number }> {
-  const value = await new SignJWT({ sessionId, name })
+): Promise<{ cookieName: string; value: string; ttl: number; participantId: string }> {
+  const participantId = `guest_${globalThis.crypto.randomUUID()}`;
+  const value = await new SignJWT({ sessionId, name, participantId })
     .setProtectedHeader({ alg: "HS256" })
     .setIssuer("cozytrack")
     .setAudience("cozytrack:guest")
@@ -102,7 +109,12 @@ export async function issueGuestSessionCookie(
     .setIssuedAt()
     .setExpirationTime(`${GUEST_SESSION_TTL_SECONDS}s`)
     .sign(getSecret());
-  return { cookieName: guestCookieName(sessionId), value, ttl: GUEST_SESSION_TTL_SECONDS };
+  return {
+    cookieName: guestCookieName(sessionId),
+    value,
+    ttl: GUEST_SESSION_TTL_SECONDS,
+    participantId,
+  };
 }
 
 export async function verifyGuestCookie(
@@ -117,10 +129,17 @@ export async function verifyGuestCookie(
     });
     if (payload.sessionId !== sessionId) return null;
     const name = typeof payload.name === "string" ? payload.name : "Guest";
-    return { kind: "guest", sessionId, name };
+    if (typeof payload.participantId !== "string" || payload.participantId.length === 0) {
+      return null;
+    }
+    return { kind: "guest", sessionId, name, participantId: payload.participantId };
   } catch {
     return null;
   }
+}
+
+export function principalParticipantId(principal: Principal): string {
+  return principal.participantId;
 }
 
 // ---------- Recording upload tokens ----------

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -129,14 +129,6 @@ export async function verifyGuestCookie(
     });
     if (payload.sessionId !== sessionId) return null;
     const name = typeof payload.name === "string" ? payload.name : "Guest";
-    if (payload.participantId === undefined) {
-      return {
-        kind: "guest",
-        sessionId,
-        name,
-        participantId: await legacyGuestParticipantId(token),
-      };
-    }
     if (typeof payload.participantId !== "string" || payload.participantId.length === 0) {
       return null;
     }
@@ -148,18 +140,6 @@ export async function verifyGuestCookie(
 
 export function principalParticipantId(principal: Principal): string {
   return principal.participantId;
-}
-
-async function legacyGuestParticipantId(token: string): Promise<string> {
-  const digest = await globalThis.crypto.subtle.digest(
-    "SHA-256",
-    new TextEncoder().encode(token),
-  );
-  const hex = Array.from(new Uint8Array(digest), (byte) =>
-    byte.toString(16).padStart(2, "0"),
-  ).join("");
-
-  return `guest_legacy_${hex.slice(0, 32)}`;
 }
 
 // ---------- Recording upload tokens ----------

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -129,6 +129,14 @@ export async function verifyGuestCookie(
     });
     if (payload.sessionId !== sessionId) return null;
     const name = typeof payload.name === "string" ? payload.name : "Guest";
+    if (payload.participantId === undefined) {
+      return {
+        kind: "guest",
+        sessionId,
+        name,
+        participantId: await legacyGuestParticipantId(token),
+      };
+    }
     if (typeof payload.participantId !== "string" || payload.participantId.length === 0) {
       return null;
     }
@@ -140,6 +148,18 @@ export async function verifyGuestCookie(
 
 export function principalParticipantId(principal: Principal): string {
   return principal.participantId;
+}
+
+async function legacyGuestParticipantId(token: string): Promise<string> {
+  const digest = await globalThis.crypto.subtle.digest(
+    "SHA-256",
+    new TextEncoder().encode(token),
+  );
+  const hex = Array.from(new Uint8Array(digest), (byte) =>
+    byte.toString(16).padStart(2, "0"),
+  ).join("");
+
+  return `guest_legacy_${hex.slice(0, 32)}`;
 }
 
 // ---------- Recording upload tokens ----------

--- a/src/lib/transport/index.ts
+++ b/src/lib/transport/index.ts
@@ -18,8 +18,12 @@ export type {
   Transport,
   TransportEvents,
 } from "./types";
-export type { ParticipantRole } from "./participant-role";
-export { isHostSender, parseParticipantRole } from "./participant-role";
+export type { ParticipantMetadata, ParticipantRole } from "./participant-role";
+export {
+  isHostSender,
+  parseParticipantMetadata,
+  parseParticipantRole,
+} from "./participant-role";
 export { useTransport } from "./use-transport";
 
 /**

--- a/src/lib/transport/livekit-transport.ts
+++ b/src/lib/transport/livekit-transport.ts
@@ -23,6 +23,7 @@ import type {
   Transport,
   TransportEvents,
 } from "./types";
+import { parseParticipantMetadata } from "./participant-role";
 
 const CONTROL_TOPIC = "control";
 const RECORDING_STATUS_STATES = new Set<RecordingStatusState>([
@@ -33,7 +34,10 @@ const RECORDING_STATUS_STATES = new Set<RecordingStatusState>([
 ]);
 
 function toRemoteParticipant(p: LKRemoteParticipant): RemoteParticipant {
-  return { identity: p.identity, name: p.name };
+  return {
+    identity: p.identity,
+    name: p.name ?? parseParticipantMetadata(p.metadata)?.displayName,
+  };
 }
 
 function isRecordingStatusState(value: unknown): value is RecordingStatusState {

--- a/src/lib/transport/participant-role.ts
+++ b/src/lib/transport/participant-role.ts
@@ -8,6 +8,39 @@
 // `participant.metadata` parses to `{ role: "host" }` we trust it.
 
 export type ParticipantRole = "host" | "guest";
+export type ParticipantMetadata = {
+  role: ParticipantRole;
+  participantId?: string;
+  displayName?: string;
+};
+
+export function parseParticipantMetadata(
+  metadata: string | undefined,
+): ParticipantMetadata | null {
+  if (!metadata) return null;
+  try {
+    const obj = JSON.parse(metadata) as unknown;
+    if (obj === null || typeof obj !== "object") return null;
+    const record = obj as Record<string, unknown>;
+    const role = record.role;
+    if (role !== "host" && role !== "guest") return null;
+    const participantId =
+      typeof record.participantId === "string" && record.participantId.length > 0
+        ? record.participantId
+        : undefined;
+    const displayName =
+      typeof record.displayName === "string" && record.displayName.length > 0
+        ? record.displayName
+        : undefined;
+    return {
+      role,
+      ...(participantId !== undefined ? { participantId } : {}),
+      ...(displayName !== undefined ? { displayName } : {}),
+    };
+  } catch {
+    return null;
+  }
+}
 
 /**
  * Parse the participant role from a LiveKit metadata string.
@@ -17,16 +50,7 @@ export type ParticipantRole = "host" | "guest";
 export function parseParticipantRole(
   metadata: string | undefined,
 ): ParticipantRole | null {
-  if (!metadata) return null;
-  try {
-    const obj = JSON.parse(metadata) as unknown;
-    if (obj === null || typeof obj !== "object") return null;
-    const role = (obj as Record<string, unknown>).role;
-    if (role === "host" || role === "guest") return role;
-    return null;
-  } catch {
-    return null;
-  }
+  return parseParticipantMetadata(metadata)?.role ?? null;
 }
 
 /**

--- a/src/lib/transport/types.ts
+++ b/src/lib/transport/types.ts
@@ -75,7 +75,8 @@ export interface Transport {
    * sender — idempotency should still be enforced by state) and verify
    * sender role for host-only messages. Metadata is whatever string the
    * server stamped onto the participant's token; in cozytrack that's a JSON
-   * blob like `{"role":"host"}`. See src/lib/transport/participant-role.ts.
+   * blob like `{"role":"host","participantId":"host","displayName":"Pasha"}`.
+   * See src/lib/transport/participant-role.ts.
    */
   onControlMessage(
     handler: (

--- a/tests/auth-identity.test.ts
+++ b/tests/auth-identity.test.ts
@@ -1,5 +1,4 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
-import { SignJWT } from "jose";
 import {
   issueGuestSessionCookie,
   issueHostSessionCookie,
@@ -45,33 +44,4 @@ describe("principal participant identity", () => {
 
     await expect(verifyGuestCookie(issued.value, "s2")).resolves.toBeNull();
   });
-
-  it("keeps legacy guest cookies authenticated with a stable fallback participant id", async () => {
-    const token = await issueLegacyGuestSessionCookie("s1", "Alice");
-
-    const first = await verifyGuestCookie(token, "s1");
-    const second = await verifyGuestCookie(token, "s1");
-
-    expect(first).toMatchObject({
-      kind: "guest",
-      sessionId: "s1",
-      name: "Alice",
-    });
-    expect(first?.participantId).toMatch(/^guest_legacy_[0-9a-f]{32}$/);
-    expect(second?.participantId).toBe(first?.participantId);
-  });
 });
-
-async function issueLegacyGuestSessionCookie(
-  sessionId: string,
-  name: string,
-): Promise<string> {
-  return await new SignJWT({ sessionId, name })
-    .setProtectedHeader({ alg: "HS256" })
-    .setIssuer("cozytrack")
-    .setAudience("cozytrack:guest")
-    .setSubject(`guest:${sessionId}`)
-    .setIssuedAt()
-    .setExpirationTime("12h")
-    .sign(new TextEncoder().encode(process.env.AUTH_SECRET));
-}

--- a/tests/auth-identity.test.ts
+++ b/tests/auth-identity.test.ts
@@ -1,0 +1,47 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import {
+  issueGuestSessionCookie,
+  issueHostSessionCookie,
+  verifyGuestCookie,
+  verifyHostCookie,
+} from "@/lib/auth";
+
+beforeEach(() => {
+  vi.stubEnv("AUTH_SECRET", "test-secret-for-auth-identity-token-123456");
+});
+
+afterEach(() => {
+  vi.unstubAllEnvs();
+});
+
+describe("principal participant identity", () => {
+  it("adds a stable participant id to host principals", async () => {
+    const token = await issueHostSessionCookie();
+    const principal = await verifyHostCookie(token);
+
+    expect((principal as { participantId?: string } | null)?.participantId).toBe(
+      "host",
+    );
+  });
+
+  it("issues and verifies a server-generated guest participant id", async () => {
+    const issued = await issueGuestSessionCookie("s1", "Alice");
+    const participantId = (issued as { participantId?: string }).participantId;
+
+    expect(participantId).toMatch(/^guest_[0-9a-f-]+$/);
+
+    const principal = await verifyGuestCookie(issued.value, "s1");
+    expect(principal).toMatchObject({
+      kind: "guest",
+      sessionId: "s1",
+      name: "Alice",
+      participantId,
+    });
+  });
+
+  it("keeps guest identities scoped to their session cookie", async () => {
+    const issued = await issueGuestSessionCookie("s1", "Alice");
+
+    await expect(verifyGuestCookie(issued.value, "s2")).resolves.toBeNull();
+  });
+});

--- a/tests/auth-identity.test.ts
+++ b/tests/auth-identity.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { SignJWT } from "jose";
 import {
   issueGuestSessionCookie,
   issueHostSessionCookie,
@@ -44,4 +45,33 @@ describe("principal participant identity", () => {
 
     await expect(verifyGuestCookie(issued.value, "s2")).resolves.toBeNull();
   });
+
+  it("keeps legacy guest cookies authenticated with a stable fallback participant id", async () => {
+    const token = await issueLegacyGuestSessionCookie("s1", "Alice");
+
+    const first = await verifyGuestCookie(token, "s1");
+    const second = await verifyGuestCookie(token, "s1");
+
+    expect(first).toMatchObject({
+      kind: "guest",
+      sessionId: "s1",
+      name: "Alice",
+    });
+    expect(first?.participantId).toMatch(/^guest_legacy_[0-9a-f]{32}$/);
+    expect(second?.participantId).toBe(first?.participantId);
+  });
 });
+
+async function issueLegacyGuestSessionCookie(
+  sessionId: string,
+  name: string,
+): Promise<string> {
+  return await new SignJWT({ sessionId, name })
+    .setProtectedHeader({ alg: "HS256" })
+    .setIssuer("cozytrack")
+    .setAudience("cozytrack:guest")
+    .setSubject(`guest:${sessionId}`)
+    .setIssuedAt()
+    .setExpirationTime("12h")
+    .sign(new TextEncoder().encode(process.env.AUTH_SECRET));
+}

--- a/tests/integration/upload-flow.test.ts
+++ b/tests/integration/upload-flow.test.ts
@@ -288,6 +288,7 @@ describe("recording upload service integration", () => {
     expect(track).toMatchObject({
       sessionId,
       participantName: "Integration Host",
+      participantId: "host",
       s3Key: modules.s3.trackRecordingKey(sessionId, trackId),
       status: "complete",
       durationMs: 12_345,

--- a/tests/livekit-token.test.ts
+++ b/tests/livekit-token.test.ts
@@ -1,0 +1,120 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  resolvePrincipal: vi.fn(),
+  accessTokens: [] as Array<{
+    apiKey: string | undefined;
+    apiSecret: string | undefined;
+    options: Record<string, unknown> | undefined;
+    grants: unknown[];
+  }>,
+}));
+
+vi.mock("livekit-server-sdk", () => ({
+  AccessToken: vi.fn().mockImplementation(function (
+    this: {
+      apiKey: string | undefined;
+      apiSecret: string | undefined;
+      options: Record<string, unknown> | undefined;
+      grants: unknown[];
+      addGrant: (grant: unknown) => void;
+      toJwt: () => Promise<string>;
+    },
+    apiKey: string | undefined,
+    apiSecret: string | undefined,
+    options: Record<string, unknown> | undefined,
+  ) {
+    this.apiKey = apiKey;
+    this.apiSecret = apiSecret;
+    this.options = options;
+    this.grants = [];
+    this.addGrant = (grant: unknown) => {
+      this.grants.push(grant);
+    };
+    this.toJwt = async () => "test-livekit-token";
+    mocks.accessTokens.push(this);
+  }),
+}));
+
+vi.mock("@/lib/auth", async () => {
+  const actual = await vi.importActual<typeof import("@/lib/auth")>(
+    "@/lib/auth",
+  );
+  return {
+    ...actual,
+    resolvePrincipal: mocks.resolvePrincipal,
+  };
+});
+
+import { NextRequest } from "next/server";
+import { POST as issueLiveKitToken } from "@/app/api/livekit-token/route";
+
+function request(body: Record<string, unknown>): NextRequest {
+  return new NextRequest("http://localhost:3001/api/livekit-token", {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify(body),
+  });
+}
+
+beforeEach(() => {
+  vi.stubEnv("LIVEKIT_API_KEY", "lk-key");
+  vi.stubEnv("LIVEKIT_API_SECRET", "lk-secret");
+  mocks.resolvePrincipal.mockReset();
+  mocks.accessTokens.length = 0;
+});
+
+afterEach(() => {
+  vi.unstubAllEnvs();
+});
+
+describe("/api/livekit-token participant identity", () => {
+  it("uses the host principal id as LiveKit identity and display name as metadata", async () => {
+    mocks.resolvePrincipal.mockResolvedValue({ kind: "host", participantId: "host" });
+
+    const res = await issueLiveKitToken(
+      request({ roomName: "s1", participantName: " Host Name " }),
+    );
+
+    expect(res.status).toBe(200);
+    await expect(res.json()).resolves.toEqual({ token: "test-livekit-token" });
+    expect(mocks.accessTokens[0]).toMatchObject({
+      apiKey: "lk-key",
+      apiSecret: "lk-secret",
+      options: {
+        identity: "host",
+        name: "Host Name",
+        metadata: JSON.stringify({
+          role: "host",
+          participantId: "host",
+          displayName: "Host Name",
+        }),
+      },
+      grants: [{ roomJoin: true, room: "s1" }],
+    });
+  });
+
+  it("uses the guest cookie participant id instead of the mutable display name", async () => {
+    mocks.resolvePrincipal.mockResolvedValue({
+      kind: "guest",
+      sessionId: "s1",
+      name: "Cookie Alice",
+      participantId: "guest_abc",
+    });
+
+    const res = await issueLiveKitToken(
+      request({ roomName: "s1", participantName: "Renamed Alice" }),
+    );
+
+    expect(res.status).toBe(200);
+    expect(mocks.accessTokens[0]?.options).toEqual({
+      identity: "guest_abc",
+      name: "Renamed Alice",
+      metadata: JSON.stringify({
+        role: "guest",
+        participantId: "guest_abc",
+        displayName: "Renamed Alice",
+      }),
+    });
+  });
+});

--- a/tests/participant-role.test.ts
+++ b/tests/participant-role.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from "vitest";
 import {
   isHostSender,
+  parseParticipantMetadata,
   parseParticipantRole,
 } from "../src/lib/transport/participant-role";
 
@@ -39,6 +40,36 @@ describe("parseParticipantRole", () => {
     expect(
       parseParticipantRole(JSON.stringify({ role: "host", extra: "x" })),
     ).toBe("host");
+  });
+});
+
+describe("parseParticipantMetadata", () => {
+  it("returns role plus optional identity and display fields", () => {
+    expect(
+      parseParticipantMetadata(
+        JSON.stringify({
+          role: "guest",
+          participantId: "guest_abc",
+          displayName: "Alice",
+        }),
+      ),
+    ).toEqual({
+      role: "guest",
+      participantId: "guest_abc",
+      displayName: "Alice",
+    });
+  });
+
+  it("requires a valid role even when other fields are present", () => {
+    expect(
+      parseParticipantMetadata(
+        JSON.stringify({
+          role: "admin",
+          participantId: "guest_abc",
+          displayName: "Alice",
+        }),
+      ),
+    ).toBeNull();
   });
 });
 

--- a/tests/upload-auth.test.ts
+++ b/tests/upload-auth.test.ts
@@ -4,6 +4,7 @@ type Track = {
   id: string;
   sessionId: string;
   participantName: string;
+  participantId?: string | null;
   s3Key: string;
   status: string;
   durationMs: number | null;
@@ -133,6 +134,34 @@ describe("recording upload auth", () => {
     expect(body.url).toBe("https://s3.example/sessions/s1/tracks/t1/0.webm");
     expect(body.recordingToken).toEqual(expect.any(String));
     expect(mocks.tracks.get("t1")?.participantName).toBe("Alice");
+  });
+
+  it("stores the guest participant id from the authenticated principal", async () => {
+    mocks.resolvePrincipal.mockResolvedValue({
+      kind: "guest",
+      sessionId: "s1",
+      name: "Cookie Alice",
+      participantId: "guest_alice",
+    });
+
+    const res = await presignUpload(
+      postJson(
+        "/api/upload/presign",
+        {
+          sessionId: "s1",
+          trackId: "t1",
+          partNumber: 0,
+          participantName: "Renamed Alice",
+          participantId: "spoofed-browser-id",
+        },
+      ),
+    );
+
+    expect(res.status).toBe(200);
+    expect(mocks.tracks.get("t1")).toMatchObject({
+      participantName: "Renamed Alice",
+      participantId: "guest_alice",
+    });
   });
 
   it("keeps presigning chunks with the recording token after cookies expire", async () => {


### PR DESCRIPTION
## Summary

Part of #111. Supersedes closed PR #112 with a tests-first commit history.

This is the first stacked PR for reconnect-safe recording architecture. It establishes server-derived participant identity without adding recording-take state or segment stitching yet.

- Add contract tests first for principal identity, LiveKit identity/metadata, metadata parsing, and upload persistence.
- Add `Track.participantId` with an index on `(sessionId, participantId)`.
- Add server-issued guest participant ids to signed guest cookies.
- Use the server-derived participant id as the LiveKit identity while keeping the entered name as display metadata/name.
- Store `participantId` on new upload tracks from the authenticated principal instead of trusting browser-provided identity.
- Keep studio UI display names readable after LiveKit identity changes by resolving names from signed metadata.

## TDD Evidence

After the tests-only commit (`61569c8`), the focused suite failed as expected:

- `tests/auth-identity.test.ts`: host/guest principals lacked participant ids.
- `tests/livekit-token.test.ts`: LiveKit identity still came from display name and metadata only contained role.
- `tests/participant-role.test.ts`: participant metadata parsing was missing.
- `tests/upload-auth.test.ts`: upload creation did not persist principal-derived participant id.

After the implementation commit (`1c5b7e1`), the same focused suite passed.

## Testing

- `npm run db:generate`
- `npm test -- tests/auth-identity.test.ts tests/livekit-token.test.ts tests/upload-auth.test.ts tests/participant-role.test.ts`
- `npm run typecheck`
- `npm run lint`
- `npm test`
- `npm run build`