### PR TITLE
Add recording take lifecycle model

### DIFF
--- a/prisma/migrations/20260611000000_recording_take_lifecycle/migration.sql
+++ b/prisma/migrations/20260611000000_recording_take_lifecycle/migration.sql
@@ -1,0 +1,48 @@
+-- Represent host-controlled room recording state as a first-class take.
+CREATE TABLE "RecordingTake" (
+    "id" TEXT NOT NULL,
+    "sessionId" TEXT NOT NULL,
+    "startedAt" TIMESTAMP(3) NOT NULL,
+    "stoppedAt" TIMESTAMP(3),
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "RecordingTake_pkey" PRIMARY KEY ("id")
+);
+
+CREATE TABLE "RecordingTakeParticipantStatus" (
+    "id" TEXT NOT NULL,
+    "takeId" TEXT NOT NULL,
+    "participantId" TEXT NOT NULL,
+    "participantName" TEXT,
+    "readinessStatus" TEXT,
+    "recordingStatus" TEXT,
+    "statusReason" TEXT,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "RecordingTakeParticipantStatus_pkey" PRIMARY KEY ("id")
+);
+
+CREATE INDEX "RecordingTake_sessionId_stoppedAt_idx"
+    ON "RecordingTake"("sessionId", "stoppedAt");
+
+CREATE UNIQUE INDEX "RecordingTake_sessionId_active_unique"
+    ON "RecordingTake"("sessionId")
+    WHERE "stoppedAt" IS NULL;
+
+CREATE UNIQUE INDEX "RecordingTakeParticipantStatus_takeId_participantId_key"
+    ON "RecordingTakeParticipantStatus"("takeId", "participantId");
+
+CREATE INDEX "RecordingTakeParticipantStatus_participantId_idx"
+    ON "RecordingTakeParticipantStatus"("participantId");
+
+ALTER TABLE "RecordingTake"
+    ADD CONSTRAINT "RecordingTake_sessionId_fkey"
+    FOREIGN KEY ("sessionId") REFERENCES "Session"("id")
+    ON DELETE RESTRICT ON UPDATE CASCADE;
+
+ALTER TABLE "RecordingTakeParticipantStatus"
+    ADD CONSTRAINT "RecordingTakeParticipantStatus_takeId_fkey"
+    FOREIGN KEY ("takeId") REFERENCES "RecordingTake"("id")
+    ON DELETE RESTRICT ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -13,13 +13,43 @@ generator client {
 }
 
 model Session {
-  id          String    @id @default(uuid())
-  name        String
-  status      String    @default("recording") // recording | ready
-  finalizedAt DateTime?
-  createdAt   DateTime  @default(now())
-  updatedAt   DateTime  @updatedAt
-  tracks      Track[]
+  id             String          @id @default(uuid())
+  name           String
+  status         String          @default("recording") // recording | ready
+  finalizedAt    DateTime?
+  createdAt      DateTime        @default(now())
+  updatedAt      DateTime        @updatedAt
+  tracks         Track[]
+  recordingTakes RecordingTake[]
+}
+
+model RecordingTake {
+  id                  String                         @id @default(uuid())
+  sessionId           String
+  session             Session                        @relation(fields: [sessionId], references: [id])
+  startedAt           DateTime
+  stoppedAt           DateTime?
+  createdAt           DateTime                       @default(now())
+  updatedAt           DateTime                       @updatedAt
+  participantStatuses RecordingTakeParticipantStatus[]
+
+  @@index([sessionId, stoppedAt])
+}
+
+model RecordingTakeParticipantStatus {
+  id              String        @id @default(uuid())
+  takeId          String
+  take            RecordingTake @relation(fields: [takeId], references: [id])
+  participantId   String
+  participantName String?
+  readinessStatus String?
+  recordingStatus String?
+  statusReason    String?
+  createdAt       DateTime      @default(now())
+  updatedAt       DateTime      @updatedAt
+
+  @@unique([takeId, participantId])
+  @@index([participantId])
 }
 
 model Track {

--- a/src/app/api/sessions/[id]/recording-state/route.ts
+++ b/src/app/api/sessions/[id]/recording-state/route.ts
@@ -1,0 +1,358 @@
+import { NextRequest, NextResponse } from "next/server";
+import { db } from "@/lib/db";
+import {
+  principalParticipantId,
+  resolvePrincipal,
+  type Principal,
+} from "@/lib/auth";
+
+type RecordingTakeWithStatuses = {
+  id: string;
+  sessionId: string;
+  startedAt: Date;
+  stoppedAt: Date | null;
+  participantStatuses?: Array<{
+    participantId: string;
+    participantName: string | null;
+    readinessStatus: string | null;
+    recordingStatus: string | null;
+    statusReason: string | null;
+    updatedAt: Date;
+  }>;
+};
+
+const READINESS_STATUSES = new Set(["ready", "not_ready"]);
+const RECORDING_STATUSES = new Set([
+  "connected",
+  "recording",
+  "finalizing",
+  "complete",
+  "failed",
+]);
+
+function parseStartedAt(value: unknown): Date | null {
+  if (typeof value !== "string") return null;
+  const parsed = Date.parse(value);
+  if (Number.isNaN(parsed)) return null;
+  return new Date(parsed);
+}
+
+function parseOptionalStatus(
+  value: unknown,
+  allowed: Set<string>,
+): string | null | undefined {
+  if (value === undefined) return undefined;
+  if (value === null) return null;
+  if (typeof value === "string" && allowed.has(value)) return value;
+  return "__invalid__";
+}
+
+function cleanReason(value: unknown): string | null | undefined {
+  if (value === undefined) return undefined;
+  if (value === null) return null;
+  if (typeof value !== "string") return null;
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed.slice(0, 240) : null;
+}
+
+function participantNameFor(principal: Principal, value: unknown): string | null {
+  if (principal.kind === "guest") return principal.name;
+  if (typeof value !== "string") return null;
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed.slice(0, 80) : null;
+}
+
+async function requirePrincipal(req: NextRequest, sessionId: string) {
+  const principal = await resolvePrincipal(req, sessionId);
+  if (!principal) return { error: "unauthorized", status: 401 } as const;
+  if (principal.kind === "guest" && principal.sessionId !== sessionId) {
+    return { error: "forbidden", status: 403 } as const;
+  }
+  return { principal } as const;
+}
+
+async function requireSession(sessionId: string) {
+  return await db.session.findUnique({
+    where: { id: sessionId },
+    select: { id: true },
+  });
+}
+
+async function findActiveTake(
+  sessionId: string,
+): Promise<RecordingTakeWithStatuses | null> {
+  return await db.recordingTake.findFirst({
+    where: { sessionId, stoppedAt: null },
+    orderBy: { startedAt: "desc" },
+    include: {
+      participantStatuses: { orderBy: { participantName: "asc" } },
+    },
+  });
+}
+
+function serializeTake(take: RecordingTakeWithStatuses | null) {
+  if (!take) return null;
+  return {
+    id: take.id,
+    sessionId: take.sessionId,
+    startedAt: take.startedAt.toISOString(),
+    stoppedAt: take.stoppedAt?.toISOString() ?? null,
+    participantStatuses: (take.participantStatuses ?? []).map((status) => ({
+      participantId: status.participantId,
+      participantName: status.participantName,
+      readinessStatus: status.readinessStatus,
+      recordingStatus: status.recordingStatus,
+      statusReason: status.statusReason,
+      updatedAt: status.updatedAt.toISOString(),
+    })),
+  };
+}
+
+function serializeRecordingState(
+  take: RecordingTakeWithStatuses | null,
+  active: boolean,
+) {
+  return {
+    active,
+    sessionStartedAt: active ? take?.startedAt.toISOString() ?? null : null,
+    take: serializeTake(take),
+  };
+}
+
+function serializeParticipantStatus(status: {
+  takeId: string;
+  participantId: string;
+  participantName: string | null;
+  readinessStatus: string | null;
+  recordingStatus: string | null;
+  statusReason: string | null;
+  updatedAt: Date;
+}) {
+  return {
+    takeId: status.takeId,
+    participantId: status.participantId,
+    participantName: status.participantName,
+    readinessStatus: status.readinessStatus,
+    recordingStatus: status.recordingStatus,
+    statusReason: status.statusReason,
+    updatedAt: status.updatedAt.toISOString(),
+  };
+}
+
+function isUniqueActiveTakeConflict(error: unknown): boolean {
+  return (
+    typeof error === "object" &&
+    error !== null &&
+    "code" in error &&
+    (error as { code?: unknown }).code === "P2002"
+  );
+}
+
+export async function GET(
+  req: NextRequest,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  try {
+    const { id } = await params;
+    const auth = await requirePrincipal(req, id);
+    if ("error" in auth) {
+      return NextResponse.json({ error: auth.error }, { status: auth.status });
+    }
+
+    const session = await requireSession(id);
+    if (!session) {
+      return NextResponse.json({ error: "Session not found" }, { status: 404 });
+    }
+
+    const take = await findActiveTake(id);
+    return NextResponse.json(serializeRecordingState(take, Boolean(take)));
+  } catch (error) {
+    console.error("Failed to read recording state:", error);
+    return NextResponse.json(
+      { error: "Failed to read recording state" },
+      { status: 500 },
+    );
+  }
+}
+
+export async function POST(
+  req: NextRequest,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  try {
+    const { id } = await params;
+    const auth = await requirePrincipal(req, id);
+    if ("error" in auth) {
+      return NextResponse.json({ error: auth.error }, { status: auth.status });
+    }
+    if (auth.principal.kind !== "host") {
+      return NextResponse.json({ error: "forbidden" }, { status: 403 });
+    }
+
+    const session = await requireSession(id);
+    if (!session) {
+      return NextResponse.json({ error: "Session not found" }, { status: 404 });
+    }
+
+    const body = await req.json().catch(() => ({}));
+    const active = body?.active === true;
+
+    if (active) {
+      const startedAt = parseStartedAt(body?.sessionStartedAt);
+      if (!startedAt) {
+        return NextResponse.json(
+          { error: "sessionStartedAt is required when active is true" },
+          { status: 400 },
+        );
+      }
+
+      const existing = await findActiveTake(id);
+      if (existing) {
+        return NextResponse.json(serializeRecordingState(existing, true));
+      }
+
+      try {
+        const created = await db.recordingTake.create({
+          data: { sessionId: id, startedAt },
+          include: { participantStatuses: true },
+        });
+        return NextResponse.json(serializeRecordingState(created, true));
+      } catch (error) {
+        if (isUniqueActiveTakeConflict(error)) {
+          const current = await findActiveTake(id);
+          return NextResponse.json(serializeRecordingState(current, Boolean(current)));
+        }
+        throw error;
+      }
+    }
+
+    const current = await findActiveTake(id);
+    if (!current) {
+      return NextResponse.json(serializeRecordingState(null, false));
+    }
+
+    const stopped = await db.recordingTake.update({
+      where: { id: current.id },
+      data: { stoppedAt: new Date() },
+      include: {
+        participantStatuses: { orderBy: { participantName: "asc" } },
+      },
+    });
+    return NextResponse.json(serializeRecordingState(stopped, false));
+  } catch (error) {
+    console.error("Failed to update recording state:", error);
+    return NextResponse.json(
+      { error: "Failed to update recording state" },
+      { status: 500 },
+    );
+  }
+}
+
+export async function PATCH(
+  req: NextRequest,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  try {
+    const { id } = await params;
+    const auth = await requirePrincipal(req, id);
+    if ("error" in auth) {
+      return NextResponse.json({ error: auth.error }, { status: auth.status });
+    }
+
+    const body = await req.json().catch(() => ({}));
+    const readinessStatus = parseOptionalStatus(
+      body?.readinessStatus,
+      READINESS_STATUSES,
+    );
+    if (readinessStatus === "__invalid__") {
+      return NextResponse.json(
+        { error: "readinessStatus must be ready or not_ready" },
+        { status: 400 },
+      );
+    }
+
+    const recordingStatus = parseOptionalStatus(
+      body?.recordingStatus,
+      RECORDING_STATUSES,
+    );
+    if (recordingStatus === "__invalid__") {
+      return NextResponse.json(
+        {
+          error:
+            "recordingStatus must be connected, recording, finalizing, complete, or failed",
+        },
+        { status: 400 },
+      );
+    }
+
+    const statusReason = cleanReason(body?.reason);
+    if (
+      readinessStatus === undefined &&
+      recordingStatus === undefined &&
+      statusReason === undefined
+    ) {
+      return NextResponse.json(
+        { error: "At least one participant status field is required" },
+        { status: 400 },
+      );
+    }
+
+    const requestedTakeId = typeof body?.takeId === "string" ? body.takeId : null;
+    const take = requestedTakeId
+      ? await db.recordingTake.findUnique({
+          where: { id: requestedTakeId },
+          include: { participantStatuses: true },
+        })
+      : await findActiveTake(id);
+
+    if (!take) {
+      return NextResponse.json(
+        { error: "Recording take not found" },
+        { status: 404 },
+      );
+    }
+    if (take.sessionId !== id) {
+      return NextResponse.json({ error: "forbidden" }, { status: 403 });
+    }
+
+    const participantId = principalParticipantId(auth.principal);
+    const participantName = participantNameFor(
+      auth.principal,
+      body?.participantName,
+    );
+    const update = {
+      participantName,
+      ...(readinessStatus !== undefined ? { readinessStatus } : {}),
+      ...(recordingStatus !== undefined ? { recordingStatus } : {}),
+      ...(statusReason !== undefined ? { statusReason } : {}),
+    };
+
+    const status = await db.recordingTakeParticipantStatus.upsert({
+      where: {
+        takeId_participantId: {
+          takeId: take.id,
+          participantId,
+        },
+      },
+      create: {
+        takeId: take.id,
+        participantId,
+        participantName,
+        readinessStatus: readinessStatus ?? null,
+        recordingStatus: recordingStatus ?? null,
+        statusReason: statusReason ?? null,
+      },
+      update,
+    });
+
+    return NextResponse.json({
+      participantStatus: serializeParticipantStatus(status),
+    });
+  } catch (error) {
+    console.error("Failed to report recording participant status:", error);
+    return NextResponse.json(
+      { error: "Failed to report recording participant status" },
+      { status: 500 },
+    );
+  }
+}

--- a/src/app/studio/[id]/page.tsx
+++ b/src/app/studio/[id]/page.tsx
@@ -35,6 +35,11 @@ import {
   completeUpload,
 } from "@/lib/upload";
 import {
+  reportRecordingTakeParticipantStatus,
+  startRecordingTake,
+  stopRecordingTake,
+} from "@/lib/recording-state";
+import {
   browserRecordingBackupStore,
   recordingBackupId,
   type RecordingBackupManifest,
@@ -88,6 +93,7 @@ type StudioState = "prejoin" | "connected" | "recording" | "finalizing";
 type AudioQualityMode = "full" | "bandwidth-saving";
 type RemoteRecordingStatus = {
   state: RecordingStatusState;
+  takeId?: string;
   sessionStartedAt?: string;
   reason?: string;
   updatedAt: number;
@@ -791,6 +797,7 @@ function RoomContent({
   const [recordingSessionStartedAt, setRecordingSessionStartedAt] =
     useState<string | null>(null);
   const recordingSessionStartedAtRef = useRef<string | null>(null);
+  const recordingTakeIdRef = useRef<string | null>(null);
   const setRecordingSessionStartedAtSync = useCallback((next: string | null) => {
     recordingSessionStartedAtRef.current = next;
     setRecordingSessionStartedAt(next);
@@ -928,19 +935,34 @@ function RoomContent({
       state: RecordingStatusState,
       sessionStartedAt?: string,
       reason?: string,
+      takeId?: string | null,
     ) => {
+      const effectiveTakeId = takeId ?? recordingTakeIdRef.current;
       try {
         await transport.sendControlMessage({
           type: "recording_status",
           state,
+          ...(effectiveTakeId ? { takeId: effectiveTakeId } : {}),
           ...(sessionStartedAt !== undefined ? { sessionStartedAt } : {}),
           ...(reason !== undefined ? { reason } : {}),
         });
       } catch (err) {
         console.error("Failed to broadcast recording_status:", err);
       }
+
+      if (!effectiveTakeId) return;
+      try {
+        await reportRecordingTakeParticipantStatus(sessionId, {
+          takeId: effectiveTakeId,
+          participantName,
+          recordingStatus: state,
+          ...(reason !== undefined ? { reason } : {}),
+        });
+      } catch (err) {
+        console.error("Failed to report recording participant status:", err);
+      }
     },
-    [transport],
+    [participantName, sessionId, transport],
   );
 
   const switchAudioQuality = useCallback(
@@ -1223,7 +1245,9 @@ function RoomContent({
   // already recording (our own click echoed via a later remote message, or the
   // button pressed twice), this is a no-op.
   const startRecordingLocal = useCallback(
-    async (sessionStartedAtIso: string) => {
+    async (sessionStartedAtIso: string, takeId?: string | null) => {
+      const effectiveTakeId = takeId ?? recordingTakeIdRef.current;
+      if (effectiveTakeId) recordingTakeIdRef.current = effectiveTakeId;
       // Hard invariant from issue #61: cannot start a new recording while a
       // previous one is finalizing. Enforced here so both local and remote
       // (control-message) start paths honor the invariant.
@@ -1233,6 +1257,7 @@ function RoomContent({
           "failed",
           sessionStartedAtIso,
           "still finalizing previous recording",
+          effectiveTakeId,
         );
         return false;
       }
@@ -1240,6 +1265,8 @@ function RoomContent({
         void broadcastRecordingStatus(
           "recording",
           recordingSessionStartedAtRef.current ?? sessionStartedAtIso,
+          undefined,
+          effectiveTakeId,
         );
         return true;
       }
@@ -1251,6 +1278,7 @@ function RoomContent({
           "failed",
           sessionStartedAtIso,
           "microphone stream unavailable",
+          effectiveTakeId,
         );
         return false;
       }
@@ -1297,6 +1325,7 @@ function RoomContent({
           "failed",
           sessionStartedAtIso,
           "upload initialization failed",
+          effectiveTakeId,
         );
         return false;
       }
@@ -1416,6 +1445,7 @@ function RoomContent({
           "failed",
           sessionStartedAtIso,
           "recorder failed to start",
+          effectiveTakeId,
         );
         return false;
       }
@@ -1423,7 +1453,12 @@ function RoomContent({
       setRecordingSessionStartedAtSync(sessionStartedAtIso);
       scheduleRecordingConfirmationCheck(sessionStartedAtIso);
       setStudioStateSync("recording");
-      void broadcastRecordingStatus("recording", sessionStartedAtIso);
+      void broadcastRecordingStatus(
+        "recording",
+        sessionStartedAtIso,
+        undefined,
+        effectiveTakeId,
+      );
 
       // Auto-switch to bandwidth-saving mode for the LiveKit preview
       const switched = await switchAudioQuality("bandwidth-saving");
@@ -1460,12 +1495,19 @@ function RoomContent({
   const stopRecordingLocal = useCallback(async () => {
     const sessionStartedAtForStatus =
       recordingSessionStartedAtRef.current ?? undefined;
+    const takeIdForStatus = recordingTakeIdRef.current;
     if (studioStateRef.current === "finalizing") return;
     clearRecordingConfirmationState(false);
 
     if (!recorderRef.current) {
       setRecordingSessionStartedAtSync(null);
-      void broadcastRecordingStatus("connected", sessionStartedAtForStatus);
+      recordingTakeIdRef.current = null;
+      void broadcastRecordingStatus(
+        "connected",
+        sessionStartedAtForStatus,
+        undefined,
+        takeIdForStatus,
+      );
       return;
     }
 
@@ -1480,7 +1522,12 @@ function RoomContent({
     const recordingUploadToken = recordingUploadTokenRef.current;
     const startedAt = recordingStartRef.current;
     setStudioStateSync("finalizing");
-    void broadcastRecordingStatus("finalizing", sessionStartedAtForStatus);
+    void broadcastRecordingStatus(
+      "finalizing",
+      sessionStartedAtForStatus,
+      undefined,
+      takeIdForStatus,
+    );
 
     try {
       const blob = await recorder.stop();
@@ -1580,7 +1627,13 @@ function RoomContent({
       }
       setStudioStateSync("connected");
       setRecordingSessionStartedAtSync(null);
-      void broadcastRecordingStatus("connected", sessionStartedAtForStatus);
+      recordingTakeIdRef.current = null;
+      void broadcastRecordingStatus(
+        "connected",
+        sessionStartedAtForStatus,
+        undefined,
+        takeIdForStatus,
+      );
       // Best-effort restoration of full-quality preview. Fire-and-forget —
       // a failure here must not keep us stuck in `finalizing`.
       void switchAudioQuality("full").catch((err) => {
@@ -1713,16 +1766,43 @@ function RoomContent({
 
     startingRef.current = true;
     try {
-      const sessionStartedAt = new Date().toISOString();
+      const requestedSessionStartedAt = new Date().toISOString();
+      let sessionStartedAt = requestedSessionStartedAt;
+      let takeId: string | null = null;
       try {
-        await transport.sendControlMessage({ type: "recording_start", sessionStartedAt });
+        const takeState = await startRecordingTake(
+          sessionId,
+          requestedSessionStartedAt,
+        );
+        sessionStartedAt =
+          takeState.sessionStartedAt ?? requestedSessionStartedAt;
+        takeId = takeState.take?.id ?? null;
+        recordingTakeIdRef.current = takeId;
       } catch (err) {
-        console.error("Failed to broadcast recording_start:", err);
-        showNotification("Couldn't tell the room to start recording");
+        console.error("Failed to activate recording take:", err);
+        showNotification("Couldn't update recording state");
         return;
       }
 
-      const started = await startRecordingLocal(sessionStartedAt);
+      try {
+        await transport.sendControlMessage({
+          type: "recording_start",
+          sessionStartedAt,
+          ...(takeId ? { takeId } : {}),
+        });
+      } catch (err) {
+        console.error("Failed to broadcast recording_start:", err);
+        showNotification("Couldn't tell the room to start recording");
+        try {
+          await stopRecordingTake(sessionId);
+        } catch (stopErr) {
+          console.error("Failed to close recording take after broadcast failure:", stopErr);
+        }
+        recordingTakeIdRef.current = null;
+        return;
+      }
+
+      const started = await startRecordingLocal(sessionStartedAt, takeId);
       if (!started) {
         showNotification("Couldn't start your recorder — stopping the room");
         try {
@@ -1730,17 +1810,29 @@ function RoomContent({
         } catch (err) {
           console.error("Failed to broadcast recording_stop after start failure:", err);
         }
+        try {
+          await stopRecordingTake(sessionId);
+        } catch (stopErr) {
+          console.error("Failed to close recording take after local start failure:", stopErr);
+        }
+        recordingTakeIdRef.current = null;
       }
     } finally {
       startingRef.current = false;
     }
-  }, [isHost, transport, startRecordingLocal, showNotification]);
+  }, [isHost, sessionId, transport, startRecordingLocal, showNotification]);
 
   const handleStopRecording = useCallback(async () => {
     if (!isHost) return;
     if (stoppingRef.current) return;
     stoppingRef.current = true;
     try {
+      try {
+        await stopRecordingTake(sessionId);
+      } catch (err) {
+        console.error("Failed to close recording take:", err);
+        showNotification("Couldn't update recording state");
+      }
       try {
         await transport.sendControlMessage({ type: "recording_stop" });
       } catch (err) {
@@ -1751,7 +1843,7 @@ function RoomContent({
     } finally {
       stoppingRef.current = false;
     }
-  }, [isHost, transport, stopRecordingLocal, showNotification]);
+  }, [isHost, sessionId, transport, stopRecordingLocal, showNotification]);
 
   // Subscribe to remote control messages. LiveKit does not echo the sender's
   // own messages back, but startRecordingLocal/stopRecordingLocal are
@@ -1780,7 +1872,7 @@ function RoomContent({
         showNotification(
           `Recording started by ${senderName}`,
         );
-        void startRecordingLocal(msg.sessionStartedAt).then((started) => {
+        void startRecordingLocal(msg.sessionStartedAt, msg.takeId).then((started) => {
           if (!started) {
             showNotification("Couldn't start your recorder — check your mic");
           }
@@ -1795,6 +1887,7 @@ function RoomContent({
         if (!fromParticipant) return;
         updateRemoteRecordingStatus(fromParticipant, {
           state: msg.state,
+          takeId: msg.takeId,
           sessionStartedAt: msg.sessionStartedAt,
           reason: msg.reason,
           updatedAt: Date.now(),

--- a/src/lib/recording-state.ts
+++ b/src/lib/recording-state.ts
@@ -1,0 +1,86 @@
+"use client";
+
+export type ParticipantReadinessStatus = "ready" | "not_ready";
+export type ParticipantRecordingStatus =
+  | "connected"
+  | "recording"
+  | "finalizing"
+  | "complete"
+  | "failed";
+
+export type RecordingTakeState = {
+  active: boolean;
+  sessionStartedAt: string | null;
+  take: {
+    id: string;
+    sessionId: string;
+    startedAt: string;
+    stoppedAt: string | null;
+  } | null;
+};
+
+async function parseError(res: Response): Promise<string> {
+  try {
+    const data = await res.json();
+    if (typeof data?.error === "string") return data.error;
+  } catch {
+    // Fall back to status text below.
+  }
+  return res.statusText;
+}
+
+async function jsonRequest<T>(
+  path: string,
+  method: "PATCH" | "POST",
+  body: Record<string, unknown>,
+): Promise<T> {
+  const res = await fetch(path, {
+    method,
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+
+  if (!res.ok) {
+    throw new Error(await parseError(res));
+  }
+
+  return (await res.json()) as T;
+}
+
+export async function startRecordingTake(
+  sessionId: string,
+  sessionStartedAt: string,
+): Promise<RecordingTakeState> {
+  return await jsonRequest<RecordingTakeState>(
+    `/api/sessions/${encodeURIComponent(sessionId)}/recording-state`,
+    "POST",
+    { active: true, sessionStartedAt },
+  );
+}
+
+export async function stopRecordingTake(
+  sessionId: string,
+): Promise<RecordingTakeState> {
+  return await jsonRequest<RecordingTakeState>(
+    `/api/sessions/${encodeURIComponent(sessionId)}/recording-state`,
+    "POST",
+    { active: false },
+  );
+}
+
+export async function reportRecordingTakeParticipantStatus(
+  sessionId: string,
+  input: {
+    takeId?: string | null;
+    participantName?: string;
+    readinessStatus?: ParticipantReadinessStatus | null;
+    recordingStatus?: ParticipantRecordingStatus | null;
+    reason?: string | null;
+  },
+): Promise<void> {
+  await jsonRequest(
+    `/api/sessions/${encodeURIComponent(sessionId)}/recording-state`,
+    "PATCH",
+    input,
+  );
+}

--- a/src/lib/transport/livekit-transport.ts
+++ b/src/lib/transport/livekit-transport.ts
@@ -56,7 +56,12 @@ function parseControlMessage(raw: unknown): ControlMessage | null {
   const obj = raw as Record<string, unknown>;
   if (obj.type === "recording_start") {
     if (typeof obj.sessionStartedAt !== "string") return null;
-    return { type: "recording_start", sessionStartedAt: obj.sessionStartedAt };
+    if (obj.takeId !== undefined && typeof obj.takeId !== "string") return null;
+    return {
+      type: "recording_start",
+      sessionStartedAt: obj.sessionStartedAt,
+      ...(obj.takeId !== undefined ? { takeId: obj.takeId } : {}),
+    };
   }
   if (obj.type === "recording_stop") {
     return { type: "recording_stop" };
@@ -68,10 +73,12 @@ function parseControlMessage(raw: unknown): ControlMessage | null {
       typeof obj.sessionStartedAt !== "string"
     )
       return null;
+    if (obj.takeId !== undefined && typeof obj.takeId !== "string") return null;
     if (obj.reason !== undefined && typeof obj.reason !== "string") return null;
     return {
       type: "recording_status",
       state: obj.state,
+      ...(obj.takeId !== undefined ? { takeId: obj.takeId } : {}),
       ...(obj.sessionStartedAt !== undefined
         ? { sessionStartedAt: obj.sessionStartedAt }
         : {}),

--- a/src/lib/transport/types.ts
+++ b/src/lib/transport/types.ts
@@ -25,11 +25,16 @@ export type RecordingStatusState =
   | "failed";
 
 export type ControlMessage =
-  | { type: "recording_start"; sessionStartedAt: string /* ISO8601 */ }
+  | {
+      type: "recording_start";
+      sessionStartedAt: string /* ISO8601 */;
+      takeId?: string;
+    }
   | { type: "recording_stop" }
   | {
       type: "recording_status";
       state: RecordingStatusState;
+      takeId?: string;
       sessionStartedAt?: string /* ISO8601 */;
       reason?: string;
     };

--- a/tests/browser/recording-smoke.spec.ts
+++ b/tests/browser/recording-smoke.spec.ts
@@ -87,6 +87,14 @@ test.afterEach(async () => {
   const bucket = requiredEnv("S3_BUCKET_NAME");
 
   for (const sessionId of cleanupSessions) {
+    const takes = await db.recordingTake.findMany({
+      where: { sessionId },
+      select: { id: true },
+    });
+    await db.recordingTakeParticipantStatus.deleteMany({
+      where: { takeId: { in: takes.map((take) => take.id) } },
+    });
+    await db.recordingTake.deleteMany({ where: { sessionId } });
     await db.track.deleteMany({ where: { sessionId } });
     await db.session.deleteMany({ where: { id: sessionId } });
     await deletePrefix(s3, bucket, `sessions/${sessionId}/`);

--- a/tests/recording-take.test.ts
+++ b/tests/recording-take.test.ts
@@ -1,0 +1,337 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+
+type RecordingTake = {
+  id: string;
+  sessionId: string;
+  startedAt: Date;
+  stoppedAt: Date | null;
+  participantStatuses?: RecordingTakeParticipantStatus[];
+};
+
+type RecordingTakeParticipantStatus = {
+  takeId: string;
+  participantId: string;
+  participantName: string | null;
+  readinessStatus: string | null;
+  recordingStatus: string | null;
+  statusReason: string | null;
+  updatedAt: Date;
+};
+
+const mocks = vi.hoisted(() => ({
+  sessions: new Set<string>(),
+  takes: new Map<string, RecordingTake>(),
+  participantStatuses: new Map<string, RecordingTakeParticipantStatus>(),
+  resolvePrincipal: vi.fn(),
+  nextTakeId: 1,
+}));
+
+function cloneTake(take: RecordingTake): RecordingTake {
+  return structuredClone({
+    ...take,
+    participantStatuses: Array.from(mocks.participantStatuses.values())
+      .filter((status) => status.takeId === take.id)
+      .map((status) => ({ ...status })),
+  });
+}
+
+function activeTakeFor(sessionId: string): RecordingTake | null {
+  return (
+    Array.from(mocks.takes.values()).find(
+      (take) => take.sessionId === sessionId && take.stoppedAt === null,
+    ) ?? null
+  );
+}
+
+vi.mock("@/lib/db", () => ({
+  db: {
+    session: {
+      findUnique: vi.fn(async ({ where: { id } }: { where: { id: string } }) =>
+        mocks.sessions.has(id) ? { id } : null,
+      ),
+    },
+    recordingTake: {
+      findFirst: vi.fn(
+        async ({
+          where,
+        }: {
+          where: { sessionId: string; stoppedAt?: null };
+        }) => {
+          let take: RecordingTake | null = null;
+          if (where.stoppedAt === null) {
+            take = activeTakeFor(where.sessionId);
+          } else {
+            take =
+              Array.from(mocks.takes.values()).find(
+                (candidate) => candidate.sessionId === where.sessionId,
+              ) ?? null;
+          }
+          return take ? cloneTake(take) : null;
+        },
+      ),
+      findUnique: vi.fn(
+        async ({ where: { id } }: { where: { id: string } }) => {
+          const take = mocks.takes.get(id);
+          return take ? cloneTake(take) : null;
+        },
+      ),
+      create: vi.fn(
+        async ({
+          data,
+        }: {
+          data: { sessionId: string; startedAt: Date };
+        }) => {
+          const take: RecordingTake = {
+            id: `take-${mocks.nextTakeId++}`,
+            sessionId: data.sessionId,
+            startedAt: data.startedAt,
+            stoppedAt: null,
+          };
+          mocks.takes.set(take.id, take);
+          return cloneTake(take);
+        },
+      ),
+      update: vi.fn(
+        async ({
+          where: { id },
+          data,
+        }: {
+          where: { id: string };
+          data: { stoppedAt?: Date | null };
+        }) => {
+          const take = mocks.takes.get(id);
+          if (!take) throw new Error("take not found");
+          const updated = { ...take, ...data };
+          mocks.takes.set(id, updated);
+          return cloneTake(updated);
+        },
+      ),
+    },
+    recordingTakeParticipantStatus: {
+      upsert: vi.fn(
+        async ({
+          where: { takeId_participantId },
+          create,
+          update,
+        }: {
+          where: {
+            takeId_participantId: { takeId: string; participantId: string };
+          };
+          create: RecordingTakeParticipantStatus;
+          update: Partial<RecordingTakeParticipantStatus>;
+        }) => {
+          const key = `${takeId_participantId.takeId}:${takeId_participantId.participantId}`;
+          const existing = mocks.participantStatuses.get(key);
+          const next = existing
+            ? { ...existing, ...update, updatedAt: new Date() }
+            : { ...create, updatedAt: new Date() };
+          mocks.participantStatuses.set(key, next);
+          return { ...next };
+        },
+      ),
+    },
+  },
+}));
+
+vi.mock("@/lib/auth", async () => {
+  const actual = await vi.importActual<typeof import("@/lib/auth")>(
+    "@/lib/auth",
+  );
+  return {
+    ...actual,
+    resolvePrincipal: mocks.resolvePrincipal,
+  };
+});
+
+import { NextRequest } from "next/server";
+import {
+  GET as getRecordingState,
+  PATCH as reportRecordingState,
+  POST as setRecordingState,
+} from "@/app/api/sessions/[id]/recording-state/route";
+
+function params(id = "s1") {
+  return { params: Promise.resolve({ id }) };
+}
+
+function request(method: "GET" | "PATCH" | "POST", body?: Record<string, unknown>) {
+  return new NextRequest("http://localhost/api/sessions/s1/recording-state", {
+    method,
+    headers: body ? { "content-type": "application/json" } : undefined,
+    body: body ? JSON.stringify(body) : undefined,
+  });
+}
+
+beforeEach(() => {
+  mocks.sessions.clear();
+  mocks.takes.clear();
+  mocks.participantStatuses.clear();
+  mocks.sessions.add("s1");
+  mocks.nextTakeId = 1;
+  vi.clearAllMocks();
+  mocks.resolvePrincipal.mockResolvedValue({
+    kind: "host",
+    participantId: "host",
+  });
+});
+
+describe("/api/sessions/[id]/recording-state", () => {
+  it("lets hosts create, read, and close an active recording take", async () => {
+    const startedAt = "2026-06-01T12:00:00.000Z";
+
+    const start = await setRecordingState(
+      request("POST", { active: true, sessionStartedAt: startedAt }),
+      params(),
+    );
+    expect(start.status).toBe(200);
+    await expect(start.json()).resolves.toMatchObject({
+      active: true,
+      sessionStartedAt: startedAt,
+      take: {
+        id: "take-1",
+        sessionId: "s1",
+        startedAt,
+        stoppedAt: null,
+      },
+    });
+
+    const read = await getRecordingState(request("GET"), params());
+    expect(read.status).toBe(200);
+    await expect(read.json()).resolves.toMatchObject({
+      active: true,
+      sessionStartedAt: startedAt,
+      take: { id: "take-1", startedAt, stoppedAt: null },
+    });
+
+    const stop = await setRecordingState(request("POST", { active: false }), params());
+    expect(stop.status).toBe(200);
+    const stopBody = (await stop.json()) as {
+      active: boolean;
+      sessionStartedAt: string | null;
+      take: { id: string; stoppedAt: string | null };
+    };
+    expect(stopBody.active).toBe(false);
+    expect(stopBody.sessionStartedAt).toBeNull();
+    expect(stopBody.take.id).toBe("take-1");
+    expect(stopBody.take.stoppedAt).toEqual(expect.any(String));
+
+    const inactiveRead = await getRecordingState(request("GET"), params());
+    await expect(inactiveRead.json()).resolves.toMatchObject({
+      active: false,
+      sessionStartedAt: null,
+      take: null,
+    });
+  });
+
+  it("reuses the current active take when host start is repeated", async () => {
+    const first = await setRecordingState(
+      request("POST", {
+        active: true,
+        sessionStartedAt: "2026-06-01T12:00:00.000Z",
+      }),
+      params(),
+    );
+    const second = await setRecordingState(
+      request("POST", {
+        active: true,
+        sessionStartedAt: "2026-06-01T12:05:00.000Z",
+      }),
+      params(),
+    );
+
+    expect(first.status).toBe(200);
+    expect(second.status).toBe(200);
+    await expect(second.json()).resolves.toMatchObject({
+      active: true,
+      sessionStartedAt: "2026-06-01T12:00:00.000Z",
+      take: { id: "take-1" },
+    });
+    expect(mocks.takes).toHaveLength(1);
+  });
+
+  it("allows guests to read but not mutate room-level active state", async () => {
+    mocks.resolvePrincipal.mockResolvedValue({
+      kind: "guest",
+      sessionId: "s1",
+      name: "Alice",
+      participantId: "guest_alice",
+    });
+
+    const read = await getRecordingState(request("GET"), params());
+    expect(read.status).toBe(200);
+
+    const write = await setRecordingState(
+      request("POST", {
+        active: true,
+        sessionStartedAt: "2026-06-01T12:00:00.000Z",
+      }),
+      params(),
+    );
+    expect(write.status).toBe(403);
+    expect(mocks.takes).toHaveLength(0);
+  });
+
+  it("records participant status only for the authenticated participant", async () => {
+    mocks.takes.set("take-1", {
+      id: "take-1",
+      sessionId: "s1",
+      startedAt: new Date("2026-06-01T12:00:00.000Z"),
+      stoppedAt: null,
+    });
+    mocks.resolvePrincipal.mockResolvedValue({
+      kind: "guest",
+      sessionId: "s1",
+      name: "Alice",
+      participantId: "guest_alice",
+    });
+
+    const res = await reportRecordingState(
+      request("PATCH", {
+        takeId: "take-1",
+        participantId: "host",
+        participantName: "Mallory",
+        readinessStatus: "ready",
+        recordingStatus: "recording",
+      }),
+      params(),
+    );
+
+    expect(res.status).toBe(200);
+    await expect(res.json()).resolves.toMatchObject({
+      participantStatus: {
+        takeId: "take-1",
+        participantId: "guest_alice",
+        participantName: "Alice",
+        readinessStatus: "ready",
+        recordingStatus: "recording",
+      },
+    });
+    expect(
+      mocks.participantStatuses.get("take-1:guest_alice"),
+    ).toMatchObject({
+      participantId: "guest_alice",
+      participantName: "Alice",
+    });
+    expect(mocks.participantStatuses.has("take-1:host")).toBe(false);
+  });
+
+  it("rejects invalid participant readiness and recording statuses", async () => {
+    mocks.takes.set("take-1", {
+      id: "take-1",
+      sessionId: "s1",
+      startedAt: new Date("2026-06-01T12:00:00.000Z"),
+      stoppedAt: null,
+    });
+
+    const res = await reportRecordingState(
+      request("PATCH", {
+        takeId: "take-1",
+        readinessStatus: "sure",
+        recordingStatus: "maybe_recording",
+      }),
+      params(),
+    );
+
+    expect(res.status).toBe(400);
+  });
+});


### PR DESCRIPTION
## Summary

- Add `RecordingTake` and `RecordingTakeParticipantStatus` with a migration and an active-take uniqueness guard.
- Add `/api/sessions/[id]/recording-state` for authenticated reads, host-only take start/stop, and participant-owned readiness/recording status reports.
- Wire the studio host start/stop flow into the take lifecycle and propagate an optional take id through recording control/status messages.
- Fix browser smoke teardown to remove recording take child rows before deleting test sessions.

## Scope

Refs #111.

This implements stack 2 only. Logical tracks, physical segments, stitching/materialization, and reconnect auto-resume are left for later stacks.

## Verification

- `npm run db:generate` passed.
- `npm test -- tests/recording-take.test.ts tests/participant-role.test.ts tests/livekit-token.test.ts`: 3 files passed, 20 tests passed.
- `npm run typecheck` passed.
- `npm run lint` passed with 0 ESLint warnings or errors. Next.js emitted the existing workspace-root/deprecation warnings.
- `npm test`: 21 files passed, 139 tests passed.
- `npm run build` passed and listed `/api/sessions/[id]/recording-state` in the route table.
- `npm run test:browser`: 2 tests passed.
- GitHub Actions after `a6a46c4`: Baseline validation passed, Browser recording smoke passed, Prisma and storage integration passed.
