### PR TITLE
Add three-participant browser smoke coverage

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,9 +171,7 @@ npm run test:browser
 MinIO bucket, pushes the Prisma schema, starts Next.js on port 3101, signs in
 as the host with test-only credentials, records with Chromium's fake
 microphone, and verifies a complete track row plus a non-empty
-`recording.webm` object in MinIO. It also includes a three-participant
-host-plus-two-guests lifecycle smoke test. The broader production-like
-multi-participant E2E harness remains separate.
+`recording.webm` object in MinIO.
 
 ## Project Structure
 

--- a/README.md
+++ b/README.md
@@ -171,8 +171,9 @@ npm run test:browser
 MinIO bucket, pushes the Prisma schema, starts Next.js on port 3101, signs in
 as the host with test-only credentials, records with Chromium's fake
 microphone, and verifies a complete track row plus a non-empty
-`recording.webm` object in MinIO. It is intentionally single-browser coverage;
-the multi-participant E2E harness remains separate.
+`recording.webm` object in MinIO. It also includes a three-participant
+host-plus-two-guests lifecycle smoke test. The broader production-like
+multi-participant E2E harness remains separate.
 
 ## Project Structure
 

--- a/tests/browser/recording-smoke.spec.ts
+++ b/tests/browser/recording-smoke.spec.ts
@@ -1,4 +1,4 @@
-import { expect, test, type Page } from "@playwright/test";
+import { expect, test, type BrowserContext, type Page } from "@playwright/test";
 import {
   DeleteObjectsCommand,
   HeadObjectCommand,
@@ -122,7 +122,19 @@ async function createAndJoinHostStudio(
   }
   cleanupSessions.add(sessionId);
 
-  await test.step("join the studio with a fake microphone", async () => {
+  await joinStudioWithFakeMicrophone(page, participantName, {
+    expectHostControls: true,
+  });
+
+  return sessionId;
+}
+
+async function joinStudioWithFakeMicrophone(
+  page: Page,
+  participantName: string,
+  options: { expectHostControls: boolean },
+) {
+  await test.step(`join the studio as ${participantName}`, async () => {
     await page.getByPlaceholder("Enter your name").fill(participantName);
     await page.getByRole("button", { name: "Join Studio" }).click();
 
@@ -133,12 +145,64 @@ async function createAndJoinHostStudio(
       await continueWithBuiltInMic.click();
     }
 
-    await expect(
-      page.getByRole("button", { name: "Start recording" }),
-    ).toBeVisible();
+    if (options.expectHostControls) {
+      await expect(
+        page.getByRole("button", { name: "Start recording" }),
+      ).toBeVisible();
+    } else {
+      await expect(page.getByText("Host controls recording")).toBeVisible();
+    }
   });
+}
 
-  return sessionId;
+async function createInviteUrl(hostPage: Page, sessionId: string): Promise<string> {
+  const response = await hostPage.request.post(
+    new URL(`/api/sessions/${sessionId}/invite`, hostPage.url()).toString(),
+  );
+  expect(response.ok()).toBe(true);
+
+  const body = (await response.json()) as { url?: string };
+  expect(body.url).toEqual(expect.stringContaining("/join/"));
+  return body.url!;
+}
+
+async function joinGuestStudio(
+  page: Page,
+  inviteUrl: string,
+  sessionId: string,
+  participantName: string,
+) {
+  await page.goto(inviteUrl);
+  await page.getByLabel("Your name").fill(participantName);
+  await page.getByRole("button", { name: "Join session" }).click();
+  await expect(page).toHaveURL(new RegExp(`/studio/${sessionId}$`));
+  await joinStudioWithFakeMicrophone(page, participantName, {
+    expectHostControls: false,
+  });
+}
+
+async function assertStoredRecording(
+  sessionId: string,
+  track: { durationMs: number | null; s3Key: string | null },
+) {
+  expect(track.durationMs ?? 0).toBeGreaterThan(0);
+  expect(track.s3Key).toEqual(
+    expect.stringMatching(
+      new RegExp(`^sessions/${sessionId}/tracks/[^/]+/recording\\.webm$`),
+    ),
+  );
+
+  if (!track.s3Key) {
+    throw new Error("Expected completed track to have an S3 key");
+  }
+
+  const head = await createS3Client().send(
+    new HeadObjectCommand({
+      Bucket: requiredEnv("S3_BUCKET_NAME"),
+      Key: track.s3Key,
+    }),
+  );
+  expect(head.ContentLength).toBeGreaterThan(0);
 }
 
 test("records a host track through the browser and stores a completed WebM", async ({
@@ -185,18 +249,7 @@ test("records a host track through the browser and stores a completed WebM", asy
       select: { durationMs: true, s3Key: true },
     });
 
-    expect(track.durationMs).toBeGreaterThan(0);
-    expect(track.s3Key).toMatch(
-      new RegExp(`^sessions/${sessionId}/tracks/[^/]+/recording\\.webm$`),
-    );
-
-    const head = await createS3Client().send(
-      new HeadObjectCommand({
-        Bucket: requiredEnv("S3_BUCKET_NAME"),
-        Key: track.s3Key,
-      }),
-    );
-    expect(head.ContentLength).toBeGreaterThan(0);
+    await assertStoredRecording(sessionId, track);
   });
 
   await test.step("finish the recording from the studio UI", async () => {
@@ -291,17 +344,120 @@ test("recovers a failed final upload from the local browser backup", async ({
       select: { durationMs: true, s3Key: true },
     });
 
-    expect(track.durationMs).toBeGreaterThan(0);
-    expect(track.s3Key).toMatch(
-      new RegExp(`^sessions/${sessionId}/tracks/[^/]+/recording\\.webm$`),
-    );
+    await assertStoredRecording(sessionId, track);
+  });
+});
 
-    const head = await createS3Client().send(
-      new HeadObjectCommand({
-        Bucket: requiredEnv("S3_BUCKET_NAME"),
-        Key: track.s3Key,
+test("records host plus two guests and stores three completed WebMs", async ({
+  browser,
+  page,
+}) => {
+  const participantNames = [
+    "Three Person Host",
+    "Three Person Guest A",
+    "Three Person Guest B",
+  ];
+  const guestContexts: BrowserContext[] = [];
+
+  try {
+    const sessionName = `Three participant smoke ${Date.now()}`;
+    const sessionId = await createAndJoinHostStudio(
+      page,
+      sessionName,
+      participantNames[0],
+    );
+    const inviteUrl = await createInviteUrl(page, sessionId);
+
+    const guestPages = await Promise.all(
+      participantNames.slice(1).map(async () => {
+        const context = await browser.newContext({
+          permissions: ["microphone"],
+          viewport: { width: 1280, height: 720 },
+        });
+        guestContexts.push(context);
+        return await context.newPage();
       }),
     );
-    expect(head.ContentLength).toBeGreaterThan(0);
-  });
+
+    await Promise.all(
+      guestPages.map((guestPage, index) =>
+        joinGuestStudio(guestPage, inviteUrl, sessionId, participantNames[index + 1]),
+      ),
+    );
+
+    await test.step("wait for both guests to appear in the host room", async () => {
+      for (const participantName of participantNames.slice(1)) {
+        await expect(page.getByText(participantName, { exact: true })).toBeVisible({
+          timeout: 30_000,
+        });
+      }
+    });
+
+    await test.step("start and stop a three-person recording", async () => {
+      await page.waitForTimeout(1_000);
+      await page.getByRole("button", { name: "Start recording" }).click();
+      await expect(
+        page.getByRole("button", { name: "Stop recording" }),
+      ).toBeVisible();
+
+      for (const guestPage of guestPages) {
+        await expect(
+          guestPage.getByRole("status", { name: "Recording in progress" }),
+        ).toBeVisible({ timeout: 30_000 });
+      }
+
+      await page.waitForTimeout(3_000);
+      await page.getByRole("button", { name: "Stop recording" }).click();
+      await expect(page.getByText("FINALIZING").first()).toBeVisible();
+      await expect(
+        page.getByRole("button", { name: "Start recording" }),
+      ).toBeVisible({ timeout: 60_000 });
+    });
+
+    await test.step("assert all three participant recordings completed", async () => {
+      await expect
+        .poll(
+          async () => {
+            const tracks = await db.track.findMany({
+              where: {
+                sessionId,
+                participantName: { in: participantNames },
+              },
+              select: { participantName: true, status: true },
+              orderBy: { participantName: "asc" },
+            });
+            return tracks.map((track) => `${track.participantName}:${track.status}`);
+          },
+          { timeout: 60_000 },
+        )
+        .toEqual(
+          [...participantNames]
+            .sort()
+            .map((participantName) => `${participantName}:complete`),
+        );
+
+      const tracks = await db.track.findMany({
+        where: {
+          sessionId,
+          participantName: { in: participantNames },
+        },
+        select: { participantName: true, durationMs: true, s3Key: true },
+        orderBy: { participantName: "asc" },
+      });
+      expect(tracks).toHaveLength(3);
+
+      for (const track of tracks) {
+        await assertStoredRecording(sessionId, track);
+      }
+    });
+
+    await test.step("finish the recording from the host UI", async () => {
+      await page.getByRole("button", { name: "Finish recording" }).click();
+      await expect(page.getByText("Ready for ingest")).toBeVisible({
+        timeout: 45_000,
+      });
+    });
+  } finally {
+    await Promise.all(guestContexts.map((context) => context.close()));
+  }
 });


### PR DESCRIPTION
## Summary
- add Playwright helpers for host and guest studio joins
- add browser smoke coverage for one host plus two guests recording together
- assert all three participant tracks complete with non-empty stored WebMs
- update README browser smoke coverage docs

## Validation
- npm run typecheck
- npm run lint
- npm run test:browser against an isolated local Postgres database