### PR TITLE
[codex] Rename cohost invite UI

### DIFF
--- a/src/app/session/[id]/page.tsx
+++ b/src/app/session/[id]/page.tsx
@@ -361,9 +361,9 @@ function InviteButton({ sessionId }: { sessionId: string }) {
         size="md"
         onClick={onClick}
         disabled={state.kind === "pending"}
-        title="Generate an invite link for a cohost. The link works until it expires; anyone with it can join until then."
+        title="Generate an invite link for a participant. The link works until it expires; anyone with it can join until then."
       >
-        {state.kind === "pending" ? "Generating…" : "Invite cohost"}
+        {state.kind === "pending" ? "Generating…" : "Invite participant"}
       </Button>
       {state.kind === "ready" && (
         <div className="text-[11px] font-mono text-text-3 break-all max-w-[520px]">
@@ -379,4 +379,3 @@ function InviteButton({ sessionId }: { sessionId: string }) {
     </div>
   );
 }
-

--- a/src/app/studio/[id]/page.tsx
+++ b/src/app/studio/[id]/page.tsx
@@ -313,13 +313,13 @@ function ParticipantStrip({
   );
 }
 
-// ---------- Invite Cohost Tile ----------
+// ---------- Invite Participant Tile ----------
 
 // Host-only tile. Clicking mints a fresh invite URL via the session's invite
 // endpoint, copies it to the clipboard, and shows a modal so the host can
 // re-copy or see the expiry. Each click mints a new token — we don't persist
 // the last one; it's cheap and keeps the UI stateless across reloads.
-function InviteCohostTile({ sessionId }: { sessionId: string }) {
+function InviteParticipantTile({ sessionId }: { sessionId: string }) {
   const [pending, setPending] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [invite, setInvite] = useState<{
@@ -364,7 +364,7 @@ function InviteCohostTile({ sessionId }: { sessionId: string }) {
         disabled={pending}
         className="rounded-lg px-4 py-3.5 flex items-center gap-3 border border-dashed hover:bg-card/40 focus:outline-none focus:ring-1 focus:ring-[var(--border-hi)] transition-colors disabled:opacity-60 disabled:cursor-wait text-left"
         style={{ borderColor: "var(--border)" }}
-        title="Generate a shareable invite link for a cohost"
+        title="Generate a shareable invite link for a participant"
       >
         <div
           className="w-8 h-8 rounded-full flex items-center justify-center border border-dashed"
@@ -373,7 +373,7 @@ function InviteCohostTile({ sessionId }: { sessionId: string }) {
           <IcoPlus size={14} color="var(--text-3)" />
         </div>
         <span className="text-[13px] text-text-2">
-          {pending ? "Generating invite…" : "Invite a cohost…"}
+          {pending ? "Generating invite…" : "Invite a participant…"}
         </span>
         <div className="ml-auto">
           <IcoLink size={13} color="var(--text-3)" />
@@ -493,7 +493,7 @@ function InviteLinkModal({
             id="invite-link-title"
             className="text-lg font-semibold text-text"
           >
-            Invite a cohost
+            Invite a participant
           </h2>
           <p className="text-sm text-text-2 mt-1.5">
             Share this link. Anyone who opens it can join this session; it
@@ -2030,7 +2030,7 @@ function RoomContent({
 
           {/* Invite tile — host-only. Guests don't see the affordance; the
               underlying API also rejects non-host callers. */}
-          {isHost && <InviteCohostTile sessionId={sessionId} />}
+          {isHost && <InviteParticipantTile sessionId={sessionId} />}
 
           {/* Monitor toggle kept below the strips so it doesn't crowd the meters */}
           <div className="mt-2">
@@ -2210,7 +2210,7 @@ export default function StudioPage() {
   const [monitorVolume, setMonitorVolume] = useState(70);
   const [isMobile, setIsMobile] = useState(false);
   const [mobileWarningDismissed, setMobileWarningDismissed] = useState(false);
-  // Role drives host-only affordances (e.g. the cohost invite tile). Guests
+  // Role drives host-only affordances (e.g. the participant invite tile). Guests
   // arriving via /join have their display name recorded in the cookie; we
   // use it to prefill the prejoin form.
   const [isHost, setIsHost] = useState(false);

--- a/src/hooks/useRemoteAudioLevels.ts
+++ b/src/hooks/useRemoteAudioLevels.ts
@@ -5,7 +5,7 @@
 //
 // This is the Option A fix from issue #47: audio levels here are POST-network
 // (decoded receiver side, after the jitter buffer and any browser gain), not
-// the co-host's true pre-network signal. It's the pragmatic version that
+// the remote participant's true pre-network signal. It's the pragmatic version that
 // works on existing clients without any data-channel coordination. Option B
 // (each client publishes its own pre-network level) is tracked separately.
 


### PR DESCRIPTION
## Summary

- Rename visible invite copy from "cohost" to "participant" on the session detail page and studio invite flow.
- Update the studio invite component name/comment and remote-audio comment so future code searches do not keep surfacing the old wording.
- Keep the underlying host/guest auth model unchanged.

## Validation

- `rg "cohost|co-host|Invite a cohost|Invite cohost" src README.md docs tests -S` found no remaining matches.
- `git diff --check` passed.
- `npm run typecheck` was attempted but this worktree has no `node_modules`; it failed on missing dependency/type modules before this change.