### PR TITLE
[codex] Tier CI workflows by changed paths

### DIFF
--- a/.github/workflows/browser-smoke.yml
+++ b/.github/workflows/browser-smoke.yml
@@ -2,9 +2,35 @@ name: Browser smoke
 
 on:
   pull_request:
+    paths:
+      - ".github/workflows/browser-smoke.yml"
+      - "package.json"
+      - "package-lock.json"
+      - "playwright.config.ts"
+      - "scripts/test-browser-smoke.sh"
+      - "src/app/session/**"
+      - "src/app/studio/**"
+      - "src/components/**"
+      - "src/hooks/**"
+      - "src/lib/recorder.ts"
+      - "src/lib/transport/**"
+      - "tests/browser/**"
   push:
     branches:
       - main
+    paths:
+      - ".github/workflows/browser-smoke.yml"
+      - "package.json"
+      - "package-lock.json"
+      - "playwright.config.ts"
+      - "scripts/test-browser-smoke.sh"
+      - "src/app/session/**"
+      - "src/app/studio/**"
+      - "src/components/**"
+      - "src/hooks/**"
+      - "src/lib/recorder.ts"
+      - "src/lib/transport/**"
+      - "tests/browser/**"
 
 permissions:
   contents: read

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,9 +2,17 @@ name: CI
 
 on:
   pull_request:
+    paths-ignore:
+      - "*.md"
+      - "**/*.md"
+      - "docs/**"
   push:
     branches:
       - main
+    paths-ignore:
+      - "*.md"
+      - "**/*.md"
+      - "docs/**"
 
 permissions:
   contents: read

--- a/.github/workflows/codex-review.yml
+++ b/.github/workflows/codex-review.yml
@@ -1,8 +1,6 @@
 name: Codex review
 
 on:
-  pull_request:
-    types: [opened, ready_for_review, reopened]
   issue_comment:
     types: [created]
 
@@ -10,17 +8,9 @@ jobs:
   codex:
     if: >-
       ${{
-        (
-          github.event_name == 'pull_request' &&
-          github.event.pull_request.draft == false &&
-          github.event.pull_request.user.type != 'Bot'
-        ) ||
-        (
-          github.event_name == 'issue_comment' &&
-          github.event.issue.pull_request &&
-          startsWith(github.event.comment.body, '/codex review') &&
-          contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.comment.author_association)
-        )
+        github.event.issue.pull_request &&
+        startsWith(github.event.comment.body, '/codex review') &&
+        contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.comment.author_association)
       }}
     runs-on: ubuntu-latest
     permissions:
@@ -34,17 +24,13 @@ jobs:
         uses: actions/github-script@v7
         with:
           script: |
-            const prNumber = context.eventName === "pull_request"
-              ? context.payload.pull_request.number
-              : context.payload.issue.number;
+            const prNumber = context.payload.issue.number;
 
-            const pr = context.eventName === "pull_request"
-              ? context.payload.pull_request
-              : (await github.rest.pulls.get({
-                  owner: context.repo.owner,
-                  repo: context.repo.repo,
-                  pull_number: prNumber,
-                })).data;
+            const pr = (await github.rest.pulls.get({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: prNumber,
+            })).data;
 
             core.setOutput("number", String(pr.number));
             core.setOutput("base_ref", pr.base.ref);

--- a/.github/workflows/pr-gate.yml
+++ b/.github/workflows/pr-gate.yml
@@ -1,0 +1,98 @@
+name: PR gate
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
+
+permissions:
+  contents: read
+  pull-requests: read
+
+jobs:
+  classify:
+    name: Required PR gate
+    runs-on: ubuntu-latest
+    steps:
+      - name: Report CI tier
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const files = await github.paginate(github.rest.pulls.listFiles, {
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: context.payload.pull_request.number,
+              per_page: 100,
+            });
+
+            const names = files.map((file) => file.filename);
+            const code = (value) => `\`${String(value).replaceAll("`", "\\`")}\``;
+            const isDocsOnlyFile = (name) =>
+              name.endsWith(".md") ||
+              name.startsWith("docs/");
+
+            const touchesServiceIntegration = (name) =>
+              name === ".github/workflows/service-integration.yml" ||
+              name === "package.json" ||
+              name === "package-lock.json" ||
+              name === "vitest.integration.config.ts" ||
+              name.startsWith("prisma/") ||
+              name.startsWith("src/app/api/") ||
+              name === "src/lib/api-auth.ts" ||
+              name === "src/lib/auth.ts" ||
+              name === "src/lib/db.ts" ||
+              name === "src/lib/recovery.ts" ||
+              name === "src/lib/s3.ts" ||
+              name === "src/lib/sessions.ts" ||
+              /^src\/lib\/upload.*\.ts$/.test(name) ||
+              name.startsWith("tests/integration/");
+
+            const touchesBrowserSmoke = (name) =>
+              name === ".github/workflows/browser-smoke.yml" ||
+              name === "package.json" ||
+              name === "package-lock.json" ||
+              name === "playwright.config.ts" ||
+              name === "scripts/test-browser-smoke.sh" ||
+              name.startsWith("src/app/session/") ||
+              name.startsWith("src/app/studio/") ||
+              name.startsWith("src/components/") ||
+              name.startsWith("src/hooks/") ||
+              name === "src/lib/recorder.ts" ||
+              name.startsWith("src/lib/transport/") ||
+              name.startsWith("tests/browser/");
+
+            const docsOnly = names.length > 0 && names.every(isDocsOnlyFile);
+            const baseline = !docsOnly;
+            const serviceIntegration = names.some(touchesServiceIntegration);
+            const browserSmoke = names.some(touchesBrowserSmoke);
+            const tier = docsOnly
+              ? "docs-only"
+              : serviceIntegration && browserSmoke
+                ? "full"
+                : serviceIntegration
+                  ? "service"
+                  : browserSmoke
+                    ? "browser"
+                    : "baseline";
+
+            const summary = [
+              "# PR gate",
+              "",
+              `Detected CI tier: **${tier}**`,
+              "",
+              "| Check | Expected behavior |",
+              "| --- | --- |",
+              `| Baseline validation | ${baseline ? "runs" : "skipped for docs-only changes"} |`,
+              `| Browser recording smoke | ${browserSmoke ? "runs" : "skipped"} |`,
+              `| Prisma and storage integration | ${serviceIntegration ? "runs" : "skipped"} |`,
+              "| Codex review | manual via `/codex review` |",
+              "",
+              "<details>",
+              "<summary>Changed files</summary>",
+              "",
+              ...names.map((name) => `- ${code(name)}`),
+              "",
+              "</details>",
+            ].join("\n");
+
+            await core.summary.addRaw(summary).write();
+            core.notice(`Detected CI tier: ${tier}`);

--- a/.github/workflows/service-integration.yml
+++ b/.github/workflows/service-integration.yml
@@ -2,9 +2,39 @@ name: Service integration
 
 on:
   pull_request:
+    paths:
+      - ".github/workflows/service-integration.yml"
+      - "package.json"
+      - "package-lock.json"
+      - "prisma/**"
+      - "src/app/api/**"
+      - "src/lib/api-auth.ts"
+      - "src/lib/auth.ts"
+      - "src/lib/db.ts"
+      - "src/lib/recovery.ts"
+      - "src/lib/s3.ts"
+      - "src/lib/sessions.ts"
+      - "src/lib/upload*.ts"
+      - "tests/integration/**"
+      - "vitest.integration.config.ts"
   push:
     branches:
       - main
+    paths:
+      - ".github/workflows/service-integration.yml"
+      - "package.json"
+      - "package-lock.json"
+      - "prisma/**"
+      - "src/app/api/**"
+      - "src/lib/api-auth.ts"
+      - "src/lib/auth.ts"
+      - "src/lib/db.ts"
+      - "src/lib/recovery.ts"
+      - "src/lib/s3.ts"
+      - "src/lib/sessions.ts"
+      - "src/lib/upload*.ts"
+      - "tests/integration/**"
+      - "vitest.integration.config.ts"
 
 permissions:
   contents: read


### PR DESCRIPTION
## Summary

- Add a lightweight always-on `PR gate` workflow that reports the detected CI tier and expected checks for each PR.
- Skip baseline CI for docs-only changes.
- Path-gate browser smoke and service integration so those heavier workflows only run for relevant surfaces.
- Make Codex review manual-only via `/codex review` instead of running automatically for every PR.

## Notes

This PR changes the workflow files themselves, so the heavy workflows should still run on this PR once. After merge, docs-only PRs should only need the PR gate, and targeted app changes should run the tier that matches the changed paths.

## Validation

- `git diff --check`
- Parsed all `.github/workflows/*.yml` with Ruby YAML
- Checked embedded `github-script` snippets with `node --input-type=module --check`