### PR TITLE
[codex] Add logical track segments

### DIFF
--- a/prisma/migrations/20260611170000_track_segments/migration.sql
+++ b/prisma/migrations/20260611170000_track_segments/migration.sql
@@ -1,0 +1,63 @@
+-- Attach logical tracks to recording takes and introduce internal physical segments.
+ALTER TABLE "Track" ADD COLUMN "takeId" TEXT;
+
+CREATE TABLE "TrackSegment" (
+    "id" TEXT NOT NULL,
+    "trackId" TEXT NOT NULL,
+    "segmentIndex" INTEGER NOT NULL,
+    "s3Prefix" TEXT NOT NULL,
+    "status" TEXT NOT NULL DEFAULT 'recording',
+    "durationMs" INTEGER,
+    "startedAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "completedAt" TIMESTAMP(3),
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "TrackSegment_pkey" PRIMARY KEY ("id")
+);
+
+-- Existing recordings are single-segment logical tracks. Reuse the track id as
+-- the default segment id so today's S3 keys remain valid.
+INSERT INTO "TrackSegment" (
+    "id",
+    "trackId",
+    "segmentIndex",
+    "s3Prefix",
+    "status",
+    "durationMs",
+    "startedAt",
+    "completedAt",
+    "createdAt",
+    "updatedAt"
+)
+SELECT
+    "id",
+    "id",
+    0,
+    'sessions/' || "sessionId" || '/tracks/' || "id" || '/',
+    "status",
+    "durationMs",
+    "createdAt",
+    CASE WHEN "status" = 'complete' THEN "updatedAt" ELSE NULL END,
+    "createdAt",
+    "updatedAt"
+FROM "Track";
+
+CREATE UNIQUE INDEX "Track_takeId_participantId_key"
+    ON "Track"("takeId", "participantId");
+
+CREATE UNIQUE INDEX "TrackSegment_trackId_segmentIndex_key"
+    ON "TrackSegment"("trackId", "segmentIndex");
+
+CREATE INDEX "TrackSegment_trackId_status_idx"
+    ON "TrackSegment"("trackId", "status");
+
+ALTER TABLE "Track"
+    ADD CONSTRAINT "Track_takeId_fkey"
+    FOREIGN KEY ("takeId") REFERENCES "RecordingTake"("id")
+    ON DELETE SET NULL ON UPDATE CASCADE;
+
+ALTER TABLE "TrackSegment"
+    ADD CONSTRAINT "TrackSegment_trackId_fkey"
+    FOREIGN KEY ("trackId") REFERENCES "Track"("id")
+    ON DELETE CASCADE ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -24,14 +24,15 @@ model Session {
 }
 
 model RecordingTake {
-  id                  String                         @id @default(uuid())
+  id                  String                           @id @default(uuid())
   sessionId           String
-  session             Session                        @relation(fields: [sessionId], references: [id])
+  session             Session                          @relation(fields: [sessionId], references: [id])
   startedAt           DateTime
   stoppedAt           DateTime?
-  createdAt           DateTime                       @default(now())
-  updatedAt           DateTime                       @updatedAt
+  createdAt           DateTime                         @default(now())
+  updatedAt           DateTime                         @updatedAt
   participantStatuses RecordingTakeParticipantStatus[]
+  tracks              Track[]
 
   @@index([sessionId, stoppedAt])
 }
@@ -53,21 +54,23 @@ model RecordingTakeParticipantStatus {
 }
 
 model Track {
-  id              String   @id @default(uuid())
-  sessionId       String
-  session         Session  @relation(fields: [sessionId], references: [id])
-  participantName String
+  id               String         @id @default(uuid())
+  sessionId        String
+  session          Session        @relation(fields: [sessionId], references: [id])
+  takeId           String?
+  take             RecordingTake? @relation(fields: [takeId], references: [id], onDelete: SetNull)
+  participantName  String
   // Server-derived stable identity for the participant who created this track.
   // Display names are mutable and not used for reconnect grouping.
-  participantId   String?
-  s3Key           String
-  durationMs      Int?
-  format          String   @default("webm")
-  status          String   @default("recording") // recording | uploading | complete | failed
-  s3PurgedAt      DateTime?
-  deviceLabel     String?
-  deviceId        String?
-  isBuiltInMic    Boolean  @default(false)
+  participantId    String?
+  s3Key            String
+  durationMs       Int?
+  format           String         @default("webm")
+  status           String         @default("recording") // recording | uploading | complete | failed
+  s3PurgedAt       DateTime?
+  deviceLabel      String?
+  deviceId         String?
+  isBuiltInMic     Boolean        @default(false)
   // Broadcast-aligned session start timestamp. Shared across all tracks of a
   // recording triggered from the same click (originator's local clock). Plumbed
   // now for future multi-track alignment; not yet used to align audio.
@@ -75,9 +78,28 @@ model Track {
   // True when this track was recovered server-side from orphaned chunks and
   // at least one chunk was missing from the partNumber sequence. Audio plays
   // but has a gap. See issue #56 (server-side recovery).
-  partial         Boolean  @default(false)
-  createdAt       DateTime @default(now())
-  updatedAt       DateTime @updatedAt
+  partial          Boolean        @default(false)
+  createdAt        DateTime       @default(now())
+  updatedAt        DateTime       @updatedAt
+  segments         TrackSegment[]
 
+  @@unique([takeId, participantId])
   @@index([sessionId, participantId])
+}
+
+model TrackSegment {
+  id           String    @id @default(uuid())
+  trackId      String
+  track        Track     @relation(fields: [trackId], references: [id], onDelete: Cascade)
+  segmentIndex Int
+  s3Prefix     String
+  status       String    @default("recording") // recording | uploading | complete | failed
+  durationMs   Int?
+  startedAt    DateTime  @default(now())
+  completedAt  DateTime?
+  createdAt    DateTime  @default(now())
+  updatedAt    DateTime  @updatedAt
+
+  @@unique([trackId, segmentIndex])
+  @@index([trackId, status])
 }

--- a/src/app/api/ingest/tracks/[id]/download/route.ts
+++ b/src/app/api/ingest/tracks/[id]/download/route.ts
@@ -34,6 +34,16 @@ export async function GET(
       );
     }
 
+    // s3Key is only authoritative for complete tracks. During a re-record it
+    // still points at the previous segment's blob; serving that would pass
+    // the superseded take off as the current artifact.
+    if (track.status !== "complete") {
+      return NextResponse.json(
+        { error: "Track recording is not complete" },
+        { status: 409 }
+      );
+    }
+
     const url = await getPresignedGetUrl(track.s3Key);
 
     return NextResponse.json({ url });

--- a/src/app/api/tracks/[id]/download/route.ts
+++ b/src/app/api/tracks/[id]/download/route.ts
@@ -41,6 +41,16 @@ export async function GET(
       );
     }
 
+    // s3Key is only authoritative for complete tracks. During a re-record it
+    // still points at the previous segment's blob; serving that would pass
+    // the superseded take off as the current artifact.
+    if (track.status !== "complete") {
+      return NextResponse.json(
+        { error: "Track recording is not complete" },
+        { status: 409 }
+      );
+    }
+
     const url = await getPresignedGetUrl(track.s3Key);
 
     return NextResponse.json({ url });

--- a/src/app/api/upload/complete/route.ts
+++ b/src/app/api/upload/complete/route.ts
@@ -1,12 +1,20 @@
 import { NextRequest, NextResponse } from "next/server";
 import { db } from "@/lib/db";
-import { deleteTrackChunks, trackRecordingKey } from "@/lib/s3";
+import {
+  deleteTrackSegmentChunks,
+  trackRecordingKey,
+  trackSegmentRecordingKey,
+} from "@/lib/s3";
 import { resolvePrincipal, verifyRecordingUploadToken } from "@/lib/auth";
 
 export async function POST(req: NextRequest) {
   try {
     const body = await req.json();
     const { sessionId, trackId, durationMs } = body;
+    const segmentId =
+      typeof body?.segmentId === "string" && body.segmentId.length > 0
+        ? body.segmentId
+        : trackId;
 
     if (!sessionId || !trackId) {
       return NextResponse.json(
@@ -42,23 +50,55 @@ export async function POST(req: NextRequest) {
       return NextResponse.json({ error: "forbidden" }, { status: 403 });
     }
 
-    const s3Key = trackRecordingKey(sessionId, trackId);
+    const existingSegment = await db.trackSegment.findUnique({
+      where: { id: segmentId },
+      select: { trackId: true },
+    });
+    if (!existingSegment) {
+      return NextResponse.json({ error: "Track segment not found" }, { status: 404 });
+    }
+    if (existingSegment.trackId !== trackId) {
+      return NextResponse.json({ error: "forbidden" }, { status: 403 });
+    }
 
-    const track = await db.track.update({
-      where: { id: trackId },
+    const s3Key = trackRecordingKey(sessionId, trackId);
+    await db.trackSegment.update({
+      where: { id: segmentId },
       data: {
         status: "complete",
-        s3Key: s3Key,
         durationMs: durationMs ?? null,
-        // Reset any premature partial flag from racing recovery — the client
-        // successfully produced and uploaded its merged blob.
-        partial: false,
+        completedAt: new Date(),
       },
     });
 
-    // After completion, recording.webm is the only authoritative artifact.
-    // Chunk files are temporary crash-safety uploads and can be discarded.
-    await deleteTrackChunks(sessionId, trackId);
+    const segmentRecordingKey = trackSegmentRecordingKey(
+      sessionId,
+      trackId,
+      segmentId,
+    );
+    const isDefaultSegment = segmentRecordingKey === s3Key;
+
+    const track = await db.track.update({
+      where: { id: trackId },
+      data: isDefaultSegment
+        ? {
+            status: "complete",
+            s3Key: s3Key,
+            durationMs: durationMs ?? null,
+            // Reset any premature partial flag from racing recovery — the client
+            // successfully produced and uploaded its merged blob.
+            partial: false,
+          }
+        : {
+            status: "uploading",
+            s3Key: s3Key,
+          },
+    });
+
+    // After segment completion, recording.webm is the authoritative artifact
+    // for that segment. Chunk files are temporary crash-safety uploads and can
+    // be discarded.
+    await deleteTrackSegmentChunks(sessionId, trackId, segmentId);
 
     return NextResponse.json(track);
   } catch (error) {

--- a/src/app/api/upload/complete/route.ts
+++ b/src/app/api/upload/complete/route.ts
@@ -74,17 +74,18 @@ export async function POST(req: NextRequest) {
       orderBy: { segmentIndex: "asc" },
       select: { id: true, status: true, durationMs: true },
     });
-    const allSegmentsComplete = segments.every(
-      (segment) => segment.status === "complete",
-    );
     // Interim semantics until media stitching lands (#111 stack 4): the latest
     // segment's recording is the track's authoritative artifact. Earlier
     // segments stay in S3 and in TrackSegment rows for the future stitcher.
+    // The track is done once its newest segment is — older incomplete
+    // segments are superseded attempts (sequential per participant) and must
+    // not park the track in uploading; only a newer in-flight segment may.
     const latestSegment = segments[segments.length - 1];
+    const latestSegmentComplete = latestSegment.status === "complete";
 
     const track = await db.track.update({
       where: { id: trackId },
-      data: allSegmentsComplete
+      data: latestSegmentComplete
         ? {
             status: "complete",
             s3Key: trackSegmentRecordingKey(

--- a/src/app/api/upload/complete/route.ts
+++ b/src/app/api/upload/complete/route.ts
@@ -2,7 +2,6 @@ import { NextRequest, NextResponse } from "next/server";
 import { db } from "@/lib/db";
 import {
   deleteTrackSegmentChunks,
-  trackRecordingKey,
   trackSegmentRecordingKey,
 } from "@/lib/s3";
 import { resolvePrincipal, verifyRecordingUploadToken } from "@/lib/auth";
@@ -61,7 +60,6 @@ export async function POST(req: NextRequest) {
       return NextResponse.json({ error: "forbidden" }, { status: 403 });
     }
 
-    const s3Key = trackRecordingKey(sessionId, trackId);
     await db.trackSegment.update({
       where: { id: segmentId },
       data: {
@@ -71,27 +69,36 @@ export async function POST(req: NextRequest) {
       },
     });
 
-    const segmentRecordingKey = trackSegmentRecordingKey(
-      sessionId,
-      trackId,
-      segmentId,
+    const segments = await db.trackSegment.findMany({
+      where: { trackId },
+      orderBy: { segmentIndex: "asc" },
+      select: { id: true, status: true, durationMs: true },
+    });
+    const allSegmentsComplete = segments.every(
+      (segment) => segment.status === "complete",
     );
-    const isDefaultSegment = segmentRecordingKey === s3Key;
+    // Interim semantics until media stitching lands (#111 stack 4): the latest
+    // segment's recording is the track's authoritative artifact. Earlier
+    // segments stay in S3 and in TrackSegment rows for the future stitcher.
+    const latestSegment = segments[segments.length - 1];
 
     const track = await db.track.update({
       where: { id: trackId },
-      data: isDefaultSegment
+      data: allSegmentsComplete
         ? {
             status: "complete",
-            s3Key: s3Key,
-            durationMs: durationMs ?? null,
+            s3Key: trackSegmentRecordingKey(
+              sessionId,
+              trackId,
+              latestSegment.id,
+            ),
+            durationMs: latestSegment.durationMs ?? null,
             // Reset any premature partial flag from racing recovery — the client
             // successfully produced and uploaded its merged blob.
             partial: false,
           }
         : {
             status: "uploading",
-            s3Key: s3Key,
           },
     });
 

--- a/src/app/api/upload/complete/route.ts
+++ b/src/app/api/upload/complete/route.ts
@@ -32,6 +32,7 @@ export async function POST(req: NextRequest) {
         token,
         sessionId,
         trackId,
+        segmentId,
       );
       if (!uploadPrincipal) {
         return NextResponse.json({ error: "unauthorized" }, { status: 401 });
@@ -72,7 +73,7 @@ export async function POST(req: NextRequest) {
     const segments = await db.trackSegment.findMany({
       where: { trackId },
       orderBy: { segmentIndex: "asc" },
-      select: { id: true, status: true, durationMs: true },
+      select: { id: true, status: true, durationMs: true, segmentIndex: true },
     });
     // Interim semantics until media stitching lands (#111 stack 4): the latest
     // segment's recording is the track's authoritative artifact. Earlier
@@ -85,8 +86,17 @@ export async function POST(req: NextRequest) {
 
     let track;
     if (latestSegmentComplete) {
-      track = await db.track.update({
-        where: { id: trackId },
+      // Conditional write: a newer segment may have been created between the
+      // segment read above and this update. Promoting then would mark
+      // superseded audio complete and downloadable while the new attempt
+      // records, so the write proves no newer segment exists.
+      await db.track.updateMany({
+        where: {
+          id: trackId,
+          segments: {
+            none: { segmentIndex: { gt: latestSegment.segmentIndex } },
+          },
+        },
         data: {
           status: "complete",
           s3Key: trackSegmentRecordingKey(
@@ -100,6 +110,7 @@ export async function POST(req: NextRequest) {
           partial: false,
         },
       });
+      track = await db.track.findUnique({ where: { id: trackId } });
     } else {
       // Conditional write: an older segment's completion can read the
       // segment list before a concurrent newest-segment completion commits.

--- a/src/app/api/upload/complete/route.ts
+++ b/src/app/api/upload/complete/route.ts
@@ -83,25 +83,34 @@ export async function POST(req: NextRequest) {
     const latestSegment = segments[segments.length - 1];
     const latestSegmentComplete = latestSegment.status === "complete";
 
-    const track = await db.track.update({
-      where: { id: trackId },
-      data: latestSegmentComplete
-        ? {
-            status: "complete",
-            s3Key: trackSegmentRecordingKey(
-              sessionId,
-              trackId,
-              latestSegment.id,
-            ),
-            durationMs: latestSegment.durationMs ?? null,
-            // Reset any premature partial flag from racing recovery — the client
-            // successfully produced and uploaded its merged blob.
-            partial: false,
-          }
-        : {
-            status: "uploading",
-          },
-    });
+    let track;
+    if (latestSegmentComplete) {
+      track = await db.track.update({
+        where: { id: trackId },
+        data: {
+          status: "complete",
+          s3Key: trackSegmentRecordingKey(
+            sessionId,
+            trackId,
+            latestSegment.id,
+          ),
+          durationMs: latestSegment.durationMs ?? null,
+          // Reset any premature partial flag from racing recovery — the client
+          // successfully produced and uploaded its merged blob.
+          partial: false,
+        },
+      });
+    } else {
+      // Conditional write: an older segment's completion can read the
+      // segment list before a concurrent newest-segment completion commits.
+      // It must not demote the track that completion already promoted —
+      // that would strand a fully-complete track in uploading.
+      await db.track.updateMany({
+        where: { id: trackId, status: { not: "complete" } },
+        data: { status: "uploading" },
+      });
+      track = await db.track.findUnique({ where: { id: trackId } });
+    }
 
     // After segment completion, recording.webm is the authoritative artifact
     // for that segment. Chunk files are temporary crash-safety uploads and can

--- a/src/app/api/upload/presign/route.ts
+++ b/src/app/api/upload/presign/route.ts
@@ -170,6 +170,17 @@ async function ensureLogicalTrackAndSegment(input: {
         s3Prefix: trackSegmentPrefix(sessionId, track.id, requestedSegmentId),
       },
     });
+
+    // A new recording attempt is starting on this logical track. If the track
+    // already looked finished (or failed), finalize/downloads would keep
+    // serving the previous recording as final while this segment is in
+    // flight — pull it back to recording until completion resolves it.
+    if (track.status === "complete" || track.status === "failed") {
+      track = await db.track.update({
+        where: { id: track.id },
+        data: { status: "recording" },
+      });
+    }
   }
 
   return { track, segment };

--- a/src/app/api/upload/presign/route.ts
+++ b/src/app/api/upload/presign/route.ts
@@ -159,17 +159,44 @@ async function ensureLogicalTrackAndSegment(input: {
   }
 
   if (!segment) {
-    const segmentIndex = await db.trackSegment.count({
-      where: { trackId: track.id },
-    });
-    segment = await db.trackSegment.create({
-      data: {
-        id: requestedSegmentId,
-        trackId: track.id,
-        segmentIndex,
-        s3Prefix: trackSegmentPrefix(sessionId, track.id, requestedSegmentId),
-      },
-    });
+    // segmentIndex is allocated by counting under a [trackId, segmentIndex]
+    // unique constraint, so concurrent starts for the same participant/take
+    // can collide; the loser recounts and retries.
+    const maxAttempts = 3;
+    for (let attempt = 1; !segment; attempt++) {
+      const segmentIndex = await db.trackSegment.count({
+        where: { trackId: track.id },
+      });
+      try {
+        segment = await db.trackSegment.create({
+          data: {
+            id: requestedSegmentId,
+            trackId: track.id,
+            segmentIndex,
+            s3Prefix: trackSegmentPrefix(
+              sessionId,
+              track.id,
+              requestedSegmentId,
+            ),
+          },
+        });
+      } catch (error) {
+        if (!isUniqueConstraintError(error) || attempt >= maxAttempts) {
+          throw error;
+        }
+        // A duplicate request may have created this exact segment id rather
+        // than just claiming the index — reuse it instead of retrying.
+        const existing = await db.trackSegment.findUnique({
+          where: { id: requestedSegmentId },
+        });
+        if (existing) {
+          if (existing.trackId !== track.id) {
+            throw new Error("SEGMENT_TRACK_MISMATCH");
+          }
+          segment = existing;
+        }
+      }
+    }
 
     // A new recording attempt is starting on this logical track. If the track
     // already looked finished (or failed), finalize/downloads would keep

--- a/src/app/api/upload/presign/route.ts
+++ b/src/app/api/upload/presign/route.ts
@@ -221,12 +221,15 @@ async function ensureLogicalTrackAndSegment(input: {
     // A new recording attempt is starting on this logical track. If the track
     // already looked finished (or failed), finalize/downloads would keep
     // serving the previous recording as final while this segment is in
-    // flight — pull it back to recording until completion resolves it.
-    if (track.status === "complete" || track.status === "failed") {
-      track = await db.track.update({
-        where: { id: track.id },
-        data: { status: "recording" },
-      });
+    // flight — pull it back to recording until completion resolves it. The
+    // condition lives in the write so a completion that landed after our
+    // track read still gets demoted.
+    const demoted = await db.track.updateMany({
+      where: { id: track.id, status: { in: ["complete", "failed"] } },
+      data: { status: "recording" },
+    });
+    if (demoted.count > 0) {
+      track = (await db.track.findUnique({ where: { id: track.id } })) ?? track;
     }
   }
 
@@ -328,7 +331,11 @@ export async function POST(req: NextRequest) {
         throw error;
       }
 
-      recordingToken = await issueRecordingUploadToken(sessionId, logicalTrackId);
+      recordingToken = await issueRecordingUploadToken(
+        sessionId,
+        logicalTrackId,
+        segmentId,
+      );
     } else {
       // Subsequent chunks and the final recording.webm upload accept either
       // the original principal cookie or the recording-scoped upload token.
@@ -341,6 +348,7 @@ export async function POST(req: NextRequest) {
           requestRecordingToken,
           sessionId,
           trackId,
+          segmentId,
         );
         if (!uploadPrincipal) {
           return NextResponse.json({ error: "unauthorized" }, { status: 401 });

--- a/src/app/api/upload/presign/route.ts
+++ b/src/app/api/upload/presign/route.ts
@@ -55,6 +55,7 @@ async function ensureLogicalTrackAndSegment(input: {
   sessionId: string;
   requestedTrackId: string;
   requestedSegmentId: string;
+  requestedTakeId?: string;
   principal: Principal;
   participantName: unknown;
   deviceLabel: unknown;
@@ -66,6 +67,7 @@ async function ensureLogicalTrackAndSegment(input: {
     sessionId,
     requestedTrackId,
     requestedSegmentId,
+    requestedTakeId,
     principal,
     participantName,
     deviceLabel,
@@ -74,7 +76,25 @@ async function ensureLogicalTrackAndSegment(input: {
     sessionStartedAt,
   } = input;
   const participantId = principalParticipantId(principal);
-  const activeTake = await findActiveTake(sessionId);
+  // Prefer the take the client was actually recording for. A delayed start
+  // must not attach its audio to whichever take happens to be active by the
+  // time presign arrives (the host may have moved on to a newer take).
+  let activeTake: { id: string } | null = null;
+  if (requestedTakeId) {
+    const requestedTake = await db.recordingTake.findUnique({
+      where: { id: requestedTakeId },
+      select: { id: true, sessionId: true },
+    });
+    if (!requestedTake) {
+      throw new Error("TAKE_NOT_FOUND");
+    }
+    if (requestedTake.sessionId !== sessionId) {
+      throw new Error("TAKE_SESSION_MISMATCH");
+    }
+    activeTake = { id: requestedTake.id };
+  } else {
+    activeTake = await findActiveTake(sessionId);
+  }
 
   let track = activeTake
     ? await db.track.findFirst({
@@ -226,6 +246,7 @@ export async function POST(req: NextRequest) {
       isBuiltInMic,
       sessionStartedAt,
     } = body;
+    const requestedTakeId = cleanNonEmptyString(body?.takeId) ?? undefined;
 
     if (!sessionId || !trackId || partNumber === undefined) {
       return NextResponse.json(
@@ -270,6 +291,7 @@ export async function POST(req: NextRequest) {
           sessionId,
           requestedTrackId: trackId,
           requestedSegmentId: segmentId,
+          requestedTakeId,
           principal,
           participantName,
           deviceLabel,
@@ -292,9 +314,16 @@ export async function POST(req: NextRequest) {
         if (
           error instanceof Error &&
           (error.message === "TRACK_SESSION_MISMATCH" ||
-            error.message === "SEGMENT_TRACK_MISMATCH")
+            error.message === "SEGMENT_TRACK_MISMATCH" ||
+            error.message === "TAKE_SESSION_MISMATCH")
         ) {
           return NextResponse.json({ error: "forbidden" }, { status: 403 });
+        }
+        if (error instanceof Error && error.message === "TAKE_NOT_FOUND") {
+          return NextResponse.json(
+            { error: "Recording take not found" },
+            { status: 404 }
+          );
         }
         throw error;
       }

--- a/src/app/api/upload/presign/route.ts
+++ b/src/app/api/upload/presign/route.ts
@@ -1,10 +1,17 @@
 import { NextRequest, NextResponse } from "next/server";
 import { db } from "@/lib/db";
-import { trackPartKey, trackRecordingKey, getPresignedPutUrl } from "@/lib/s3";
+import {
+  trackRecordingKey,
+  trackSegmentPartKey,
+  trackSegmentPrefix,
+  trackSegmentRecordingKey,
+  getPresignedPutUrl,
+} from "@/lib/s3";
 import {
   issueRecordingUploadToken,
   principalParticipantId,
   resolvePrincipal,
+  type Principal,
   verifyRecordingUploadToken,
 } from "@/lib/auth";
 
@@ -23,10 +30,164 @@ function getUploadErrorMessage(error: unknown): string {
   return "Failed to generate presigned URL";
 }
 
+function cleanNonEmptyString(value: unknown): string | null {
+  return typeof value === "string" && value.length > 0 ? value : null;
+}
+
+function isUniqueConstraintError(error: unknown): boolean {
+  return (
+    typeof error === "object" &&
+    error !== null &&
+    "code" in error &&
+    (error as { code?: unknown }).code === "P2002"
+  );
+}
+
+async function findActiveTake(sessionId: string): Promise<{ id: string } | null> {
+  return await db.recordingTake.findFirst({
+    where: { sessionId, stoppedAt: null },
+    orderBy: { startedAt: "desc" },
+    select: { id: true },
+  });
+}
+
+async function ensureLogicalTrackAndSegment(input: {
+  sessionId: string;
+  requestedTrackId: string;
+  requestedSegmentId: string;
+  principal: Principal;
+  participantName: unknown;
+  deviceLabel: unknown;
+  deviceId: unknown;
+  isBuiltInMic: unknown;
+  sessionStartedAt: unknown;
+}) {
+  const {
+    sessionId,
+    requestedTrackId,
+    requestedSegmentId,
+    principal,
+    participantName,
+    deviceLabel,
+    deviceId,
+    isBuiltInMic,
+    sessionStartedAt,
+  } = input;
+  const participantId = principalParticipantId(principal);
+  const activeTake = await findActiveTake(sessionId);
+
+  let track = activeTake
+    ? await db.track.findFirst({
+        where: {
+          sessionId,
+          takeId: activeTake.id,
+          participantId,
+        },
+        orderBy: { createdAt: "asc" },
+      })
+    : null;
+
+  if (!track) {
+    const existingTrack = await db.track.findUnique({
+      where: { id: requestedTrackId },
+    });
+
+    if (existingTrack) {
+      if (existingTrack.sessionId !== sessionId) {
+        throw new Error("TRACK_SESSION_MISMATCH");
+      }
+      track = existingTrack;
+    }
+  }
+
+  if (!track) {
+    if (!participantName || typeof participantName !== "string") {
+      throw new Error("PARTICIPANT_NAME_REQUIRED");
+    }
+
+    const safeDeviceLabel =
+      typeof deviceLabel === "string" && deviceLabel.length > 0
+        ? deviceLabel
+        : null;
+    const safeDeviceId =
+      typeof deviceId === "string" && deviceId.length > 0 ? deviceId : null;
+    const safeIsBuiltInMic =
+      typeof isBuiltInMic === "boolean" ? isBuiltInMic : false;
+    const safeSessionStartedAt =
+      typeof sessionStartedAt === "string" &&
+      !Number.isNaN(Date.parse(sessionStartedAt))
+        ? new Date(sessionStartedAt)
+        : null;
+
+    try {
+      track = await db.track.create({
+        data: {
+          id: requestedTrackId,
+          sessionId,
+          takeId: activeTake?.id ?? null,
+          participantName,
+          participantId,
+          s3Key: trackRecordingKey(sessionId, requestedTrackId),
+          deviceLabel: safeDeviceLabel,
+          deviceId: safeDeviceId,
+          isBuiltInMic: safeIsBuiltInMic,
+          sessionStartedAt: safeSessionStartedAt,
+        },
+      });
+    } catch (error) {
+      if (!activeTake || !isUniqueConstraintError(error)) {
+        throw error;
+      }
+      track = await db.track.findFirst({
+        where: {
+          sessionId,
+          takeId: activeTake.id,
+          participantId,
+        },
+        orderBy: { createdAt: "asc" },
+      });
+      if (!track) throw error;
+    }
+  }
+
+  let segment = await db.trackSegment.findUnique({
+    where: { id: requestedSegmentId },
+  });
+
+  if (segment && segment.trackId !== track.id) {
+    throw new Error("SEGMENT_TRACK_MISMATCH");
+  }
+
+  if (!segment) {
+    const segmentIndex = await db.trackSegment.count({
+      where: { trackId: track.id },
+    });
+    segment = await db.trackSegment.create({
+      data: {
+        id: requestedSegmentId,
+        trackId: track.id,
+        segmentIndex,
+        s3Prefix: trackSegmentPrefix(sessionId, track.id, requestedSegmentId),
+      },
+    });
+  }
+
+  return { track, segment };
+}
+
 export async function POST(req: NextRequest) {
   try {
     const body = await req.json();
-    const { sessionId, trackId, partNumber, participantName, deviceLabel, deviceId, isBuiltInMic, sessionStartedAt } = body;
+    const {
+      sessionId,
+      trackId,
+      partNumber,
+      participantName,
+      deviceLabel,
+      deviceId,
+      isBuiltInMic,
+      sessionStartedAt,
+    } = body;
 
     if (!sessionId || !trackId || partNumber === undefined) {
       return NextResponse.json(
@@ -40,6 +201,8 @@ export async function POST(req: NextRequest) {
     const isRecordingStart = partNumber === 0 && !requestRecordingToken;
 
     let recordingToken: string | undefined;
+    let logicalTrackId = trackId;
+    let segmentId = cleanNonEmptyString(body?.segmentId) ?? trackId;
     if (isRecordingStart) {
       // Starting a recording still requires normal host/guest auth. The
       // returned recording token is scoped to this session+track so later
@@ -64,43 +227,41 @@ export async function POST(req: NextRequest) {
         );
       }
 
-      const existingTrack = await db.track.findUnique({
-        where: { id: trackId },
-        select: { id: true },
-      });
-
-      if (!existingTrack) {
-        if (!participantName || typeof participantName !== "string") {
+      try {
+        const { track, segment } = await ensureLogicalTrackAndSegment({
+          sessionId,
+          requestedTrackId: trackId,
+          requestedSegmentId: segmentId,
+          principal,
+          participantName,
+          deviceLabel,
+          deviceId,
+          isBuiltInMic,
+          sessionStartedAt,
+        });
+        logicalTrackId = track.id;
+        segmentId = segment.id;
+      } catch (error) {
+        if (
+          error instanceof Error &&
+          error.message === "PARTICIPANT_NAME_REQUIRED"
+        ) {
           return NextResponse.json(
             { error: "participantName is required to start an upload" },
             { status: 400 }
           );
         }
-
-        const safeDeviceLabel = typeof deviceLabel === "string" && deviceLabel.length > 0 ? deviceLabel : null;
-        const safeDeviceId = typeof deviceId === "string" && deviceId.length > 0 ? deviceId : null;
-        const safeIsBuiltInMic = typeof isBuiltInMic === "boolean" ? isBuiltInMic : false;
-        const safeSessionStartedAt =
-          typeof sessionStartedAt === "string" && !Number.isNaN(Date.parse(sessionStartedAt))
-            ? new Date(sessionStartedAt)
-            : null;
-
-        await db.track.create({
-          data: {
-            id: trackId,
-            sessionId,
-            participantName,
-            participantId: principalParticipantId(principal),
-            s3Key: trackRecordingKey(sessionId, trackId),
-            deviceLabel: safeDeviceLabel,
-            deviceId: safeDeviceId,
-            isBuiltInMic: safeIsBuiltInMic,
-            sessionStartedAt: safeSessionStartedAt,
-          },
-        });
+        if (
+          error instanceof Error &&
+          (error.message === "TRACK_SESSION_MISMATCH" ||
+            error.message === "SEGMENT_TRACK_MISMATCH")
+        ) {
+          return NextResponse.json({ error: "forbidden" }, { status: 403 });
+        }
+        throw error;
       }
 
-      recordingToken = await issueRecordingUploadToken(sessionId, trackId);
+      recordingToken = await issueRecordingUploadToken(sessionId, logicalTrackId);
     } else {
       // Subsequent chunks and the final recording.webm upload accept either
       // the original principal cookie or the recording-scoped upload token.
@@ -122,11 +283,17 @@ export async function POST(req: NextRequest) {
 
     const key =
       partNumber === 9999
-        ? trackRecordingKey(sessionId, trackId)
-        : trackPartKey(sessionId, trackId, partNumber);
+        ? trackSegmentRecordingKey(sessionId, logicalTrackId, segmentId)
+        : trackSegmentPartKey(sessionId, logicalTrackId, segmentId, partNumber);
     const url = await getPresignedPutUrl(key);
 
-    return NextResponse.json({ url, key, recordingToken });
+    return NextResponse.json({
+      url,
+      key,
+      recordingToken,
+      trackId: logicalTrackId,
+      segmentId,
+    });
   } catch (error) {
     console.error("Failed to generate presigned URL:", error);
     return NextResponse.json(

--- a/src/app/api/upload/presign/route.ts
+++ b/src/app/api/upload/presign/route.ts
@@ -317,6 +317,34 @@ export async function POST(req: NextRequest) {
           return NextResponse.json({ error: "unauthorized" }, { status: 401 });
         }
       }
+
+      // The S3 key below is built from caller-supplied ids, and the PUT
+      // happens before /api/upload/complete validates anything — so the
+      // segment must be proven to exist under the authenticated track before
+      // any writable URL is issued.
+      const existingTrack = await db.track.findUnique({
+        where: { id: trackId },
+        select: { sessionId: true },
+      });
+      if (!existingTrack) {
+        return NextResponse.json({ error: "Track not found" }, { status: 404 });
+      }
+      if (existingTrack.sessionId !== sessionId) {
+        return NextResponse.json({ error: "forbidden" }, { status: 403 });
+      }
+      const existingSegment = await db.trackSegment.findUnique({
+        where: { id: segmentId },
+        select: { trackId: true },
+      });
+      if (!existingSegment) {
+        return NextResponse.json(
+          { error: "Track segment not found" },
+          { status: 404 }
+        );
+      }
+      if (existingSegment.trackId !== trackId) {
+        return NextResponse.json({ error: "forbidden" }, { status: 403 });
+      }
     }
 
     const key =

--- a/src/app/studio/[id]/page.tsx
+++ b/src/app/studio/[id]/page.tsx
@@ -713,6 +713,7 @@ function RoomContent({
   );
   const recorderRef = useRef<CozyRecorder | null>(null);
   const trackIdRef = useRef<string>("");
+  const segmentIdRef = useRef<string>("");
   const recordingUploadTokenRef = useRef<string | undefined>(undefined);
   // Raw stream straight from getUserMedia — retained so we can stop the
   // underlying device tracks on teardown.
@@ -1283,14 +1284,17 @@ function RoomContent({
         return false;
       }
 
-      trackIdRef.current = uuidv4();
-      const trackId = trackIdRef.current;
+      const requestedTrackId = uuidv4();
+      trackIdRef.current = requestedTrackId;
+      segmentIdRef.current = requestedTrackId;
+      let trackId = requestedTrackId;
+      let segmentId = requestedTrackId;
       recordingUploadTokenRef.current = undefined;
 
       try {
         const initialUpload = await getPresignedUploadTarget(
           sessionId,
-          trackId,
+          requestedTrackId,
           0,
           participantName,
           {
@@ -1302,6 +1306,10 @@ function RoomContent({
             sessionStartedAt: sessionStartedAtIso,
           },
         );
+        trackId = initialUpload.trackId ?? requestedTrackId;
+        segmentId = initialUpload.segmentId ?? requestedTrackId;
+        trackIdRef.current = trackId;
+        segmentIdRef.current = segmentId;
         recordingUploadTokenRef.current = initialUpload.recordingToken;
         try {
           const backup = await browserRecordingBackupStore.startBackup({
@@ -1380,7 +1388,7 @@ function RoomContent({
               trackId,
               index,
               undefined,
-              undefined,
+              { segmentId },
               recordingUploadTokenRef.current,
             );
             await uploadChunk(url, chunk);
@@ -1518,6 +1526,7 @@ function RoomContent({
     // tears down immediately — even if the upload pipeline below hangs.
     const recorder = recorderRef.current;
     const trackId = trackIdRef.current;
+    const segmentId = segmentIdRef.current || trackId;
     const backupId = trackId ? recordingBackupId(sessionId, trackId) : null;
     const recordingUploadToken = recordingUploadTokenRef.current;
     const startedAt = recordingStartRef.current;
@@ -1575,7 +1584,7 @@ function RoomContent({
           trackId,
           9999,
           undefined,
-          undefined,
+          { segmentId },
           recordingUploadToken,
         );
         await uploadChunk(url, blob);
@@ -1584,7 +1593,13 @@ function RoomContent({
 
       // Wait for any background chunk uploads still settling.
       await trackerWaitForUploads();
-      await completeUpload(sessionId, trackId, durationMs, recordingUploadToken);
+      await completeUpload(
+        sessionId,
+        trackId,
+        durationMs,
+        recordingUploadToken,
+        segmentId,
+      );
 
       setHasRecorded(true);
       if (backupId) {
@@ -1616,6 +1631,7 @@ function RoomContent({
       }
     } finally {
       recorderRef.current = null;
+      segmentIdRef.current = "";
       recordingUploadTokenRef.current = undefined;
       // Hard invariant from issue #61: do not leave `finalizing` until the
       // chunk-upload promise set is drained, regardless of error path. If the

--- a/src/app/studio/[id]/page.tsx
+++ b/src/app/studio/[id]/page.tsx
@@ -1315,6 +1315,7 @@ function RoomContent({
           const backup = await browserRecordingBackupStore.startBackup({
             sessionId,
             trackId,
+            segmentId,
             participantName,
             recordingToken: initialUpload.recordingToken,
           });
@@ -1365,6 +1366,7 @@ function RoomContent({
           .saveChunk({
             sessionId,
             trackId,
+            segmentId,
             chunkIndex: index,
             chunk,
             capturedAt,
@@ -1400,6 +1402,7 @@ function RoomContent({
                   trackId,
                   index,
                   uploadErr,
+                  segmentId,
                 );
                 setRecoveryBackupSync(backup);
               } catch (backupErr) {
@@ -1414,6 +1417,7 @@ function RoomContent({
                 sessionId,
                 trackId,
                 index,
+                segmentId,
               );
               setRecoveryBackupSync(backup);
             } catch (backupErr) {
@@ -1527,7 +1531,7 @@ function RoomContent({
     const recorder = recorderRef.current;
     const trackId = trackIdRef.current;
     const segmentId = segmentIdRef.current || trackId;
-    const backupId = trackId ? recordingBackupId(sessionId, trackId) : null;
+    const backupId = segmentId ? recordingBackupId(sessionId, segmentId) : null;
     const recordingUploadToken = recordingUploadTokenRef.current;
     const startedAt = recordingStartRef.current;
     setStudioStateSync("finalizing");

--- a/src/app/studio/[id]/page.tsx
+++ b/src/app/studio/[id]/page.tsx
@@ -1304,6 +1304,7 @@ function RoomContent({
               isBuiltInMic: selectedMicIsBuiltIn,
             },
             sessionStartedAt: sessionStartedAtIso,
+            takeId: effectiveTakeId ?? undefined,
           },
         );
         trackId = initialUpload.trackId ?? requestedTrackId;

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -147,8 +147,13 @@ export function principalParticipantId(principal: Principal): string {
 export async function issueRecordingUploadToken(
   sessionId: string,
   trackId: string,
+  segmentId?: string,
 ): Promise<string> {
-  return await new SignJWT({ sessionId, trackId })
+  return await new SignJWT({
+    sessionId,
+    trackId,
+    ...(segmentId ? { segmentId } : {}),
+  })
     .setProtectedHeader({ alg: "HS256" })
     .setIssuer("cozytrack")
     .setAudience("cozytrack:recording-upload")
@@ -162,6 +167,7 @@ export async function verifyRecordingUploadToken(
   token: string | undefined,
   sessionId: string,
   trackId: string,
+  segmentId?: string,
 ): Promise<RecordingUploadPrincipal | null> {
   if (!token) return null;
   try {
@@ -170,6 +176,16 @@ export async function verifyRecordingUploadToken(
       audience: "cozytrack:recording-upload",
     });
     if (payload.sessionId !== sessionId || payload.trackId !== trackId) {
+      return null;
+    }
+    // Tokens minted before segments existed carry no segment claim and stay
+    // track-scoped. Segment-scoped tokens only authorize the segment they
+    // were issued for — one attempt's token must not write into another's.
+    if (
+      typeof payload.segmentId === "string" &&
+      segmentId !== undefined &&
+      payload.segmentId !== segmentId
+    ) {
       return null;
     }
     return { kind: "recording_upload", sessionId, trackId };

--- a/src/lib/recording-backup-upload.ts
+++ b/src/lib/recording-backup-upload.ts
@@ -29,6 +29,10 @@ export async function retryLocalRecordingBackupUpload(
 
   await backupStore.markBackupUploading(manifest.id);
 
+  // Manifests persisted before segments existed lack segmentId; their
+  // recordings belong to the default segment, which shares the track id.
+  const segmentId = manifest.segmentId ?? manifest.trackId;
+
   try {
     const recording = await backupStore.buildRecordingBlob(manifest.id);
     const url = await getUploadUrl(
@@ -36,7 +40,7 @@ export async function retryLocalRecordingBackupUpload(
       manifest.trackId,
       9999,
       undefined,
-      undefined,
+      { segmentId },
       manifest.recordingToken,
     );
     await putChunk(url, recording);
@@ -45,6 +49,7 @@ export async function retryLocalRecordingBackupUpload(
       manifest.trackId,
       manifest.durationMs,
       manifest.recordingToken,
+      segmentId,
     );
   } catch (error) {
     await backupStore.markBackupFailed(manifest.id, error);

--- a/src/lib/recording-backup.ts
+++ b/src/lib/recording-backup.ts
@@ -25,6 +25,10 @@ export interface RecordingBackupManifest {
   id: string;
   sessionId: string;
   trackId: string;
+  // Physical segment under the logical track. Absent on manifests persisted
+  // before segments existed; those recordings belong to the default segment
+  // (segmentId === trackId).
+  segmentId?: string;
   participantName: string;
   createdAt: string;
   updatedAt: string;
@@ -39,6 +43,7 @@ export interface RecordingBackupManifest {
 export interface StartRecordingBackupInput {
   sessionId: string;
   trackId: string;
+  segmentId?: string;
   participantName: string;
   recordingToken?: string;
 }
@@ -46,6 +51,7 @@ export interface StartRecordingBackupInput {
 export interface RecordingBackupChunkRef {
   sessionId: string;
   trackId: string;
+  segmentId?: string;
   chunkIndex: number;
 }
 
@@ -112,8 +118,11 @@ type StorageManagerWithDirectory = StorageManager & {
   getDirectory?: () => Promise<DirectoryHandleLike>;
 };
 
-export function recordingBackupId(sessionId: string, trackId: string): string {
-  return `${sessionId}:${trackId}`;
+// Backups are scoped per physical segment (one per recording attempt); the
+// default segment shares the logical track's id, so legacy track-keyed ids
+// stay valid.
+export function recordingBackupId(sessionId: string, segmentId: string): string {
+  return `${sessionId}:${segmentId}`;
 }
 
 function nowIso(): string {
@@ -128,8 +137,12 @@ function normalizeError(error: unknown): string {
   return error instanceof Error ? error.message : "Recording backup failed";
 }
 
+function chunkRecordingId(ref: RecordingBackupChunkRef): string {
+  return ref.segmentId ?? ref.trackId;
+}
+
 function chunkStorageKey(ref: RecordingBackupChunkRef): string {
-  return `${ref.sessionId}:${ref.trackId}:${ref.chunkIndex}`;
+  return `${ref.sessionId}:${chunkRecordingId(ref)}:${ref.chunkIndex}`;
 }
 
 function opfsFilename(chunkIndex: number): string {
@@ -183,7 +196,7 @@ export class BrowserRecordingBackupBackend implements RecordingBackupBackend {
     try {
       const opfsDir = await this.getOpfsTrackDirectory(
         ref.sessionId,
-        ref.trackId,
+        chunkRecordingId(ref),
         true,
       );
       if (opfsDir) {
@@ -196,7 +209,7 @@ export class BrowserRecordingBackupBackend implements RecordingBackupBackend {
         await writable.close();
         return {
           storage: "opfs",
-          storageKey: `${OPFS_ROOT}/${safePathSegment(ref.sessionId)}/${safePathSegment(ref.trackId)}/${filename}`,
+          storageKey: `${OPFS_ROOT}/${safePathSegment(ref.sessionId)}/${safePathSegment(chunkRecordingId(ref))}/${filename}`,
         };
       }
     } catch (error) {
@@ -218,7 +231,7 @@ export class BrowserRecordingBackupBackend implements RecordingBackupBackend {
     if (stored.storage === "opfs") {
       const opfsDir = await this.getOpfsTrackDirectory(
         ref.sessionId,
-        ref.trackId,
+        chunkRecordingId(ref),
         false,
       );
       if (opfsDir) {
@@ -248,7 +261,7 @@ export class BrowserRecordingBackupBackend implements RecordingBackupBackend {
       try {
         const opfsDir = await this.getOpfsTrackDirectory(
           ref.sessionId,
-          ref.trackId,
+          chunkRecordingId(ref),
           false,
         );
         await opfsDir?.removeEntry?.(opfsFilename(ref.chunkIndex));
@@ -418,10 +431,12 @@ export class RecordingBackupStore {
     input: StartRecordingBackupInput,
   ): Promise<RecordingBackupManifest> {
     const now = nowIso();
+    const segmentId = input.segmentId ?? input.trackId;
     const manifest: RecordingBackupManifest = {
-      id: recordingBackupId(input.sessionId, input.trackId),
+      id: recordingBackupId(input.sessionId, segmentId),
       sessionId: input.sessionId,
       trackId: input.trackId,
+      segmentId,
       participantName: input.participantName,
       createdAt: now,
       updatedAt: now,
@@ -456,6 +471,7 @@ export class RecordingBackupStore {
     input: {
       sessionId: string;
       trackId: string;
+      segmentId?: string;
       chunkIndex: number;
       chunk: Blob;
       capturedAt?: Date;
@@ -465,13 +481,14 @@ export class RecordingBackupStore {
       {
         sessionId: input.sessionId,
         trackId: input.trackId,
+        segmentId: input.segmentId,
         chunkIndex: input.chunkIndex,
       },
       input.chunk,
     );
 
     return await this.mutateManifest(
-      recordingBackupId(input.sessionId, input.trackId),
+      recordingBackupId(input.sessionId, input.segmentId ?? input.trackId),
       (manifest) => {
         const chunkManifest: RecordingBackupChunkManifest = {
           chunkIndex: input.chunkIndex,
@@ -500,10 +517,11 @@ export class RecordingBackupStore {
     sessionId: string,
     trackId: string,
     chunkIndex: number,
+    segmentId?: string,
   ): Promise<RecordingBackupManifest> {
     return await this.updateChunkUploadState(
       sessionId,
-      trackId,
+      segmentId ?? trackId,
       chunkIndex,
       "uploaded",
     );
@@ -514,10 +532,11 @@ export class RecordingBackupStore {
     trackId: string,
     chunkIndex: number,
     error: unknown,
+    segmentId?: string,
   ): Promise<RecordingBackupManifest> {
     return await this.updateChunkUploadState(
       sessionId,
-      trackId,
+      segmentId ?? trackId,
       chunkIndex,
       "failed",
       normalizeError(error),
@@ -579,6 +598,7 @@ export class RecordingBackupStore {
           {
             sessionId: manifest.sessionId,
             trackId: manifest.trackId,
+            segmentId: manifest.segmentId,
             chunkIndex: chunk.chunkIndex,
           },
           { storage: chunk.storage, storageKey: chunk.storageKey },
@@ -604,6 +624,7 @@ export class RecordingBackupStore {
         {
           sessionId: manifest.sessionId,
           trackId: manifest.trackId,
+          segmentId: manifest.segmentId,
           chunkIndex: chunk.chunkIndex,
         },
         { storage: chunk.storage, storageKey: chunk.storageKey },
@@ -615,13 +636,13 @@ export class RecordingBackupStore {
 
   private async updateChunkUploadState(
     sessionId: string,
-    trackId: string,
+    recordingId: string,
     chunkIndex: number,
     uploadStatus: RecordingBackupUploadStatus,
     error?: string,
   ): Promise<RecordingBackupManifest> {
     return await this.mutateManifest(
-      recordingBackupId(sessionId, trackId),
+      recordingBackupId(sessionId, recordingId),
       (manifest) => {
         const chunk = manifest.chunks.find(
           (item) => item.chunkIndex === chunkIndex,

--- a/src/lib/recovery.ts
+++ b/src/lib/recovery.ts
@@ -41,6 +41,103 @@ export interface RecoverTrackOptions {
 
 const DEFAULT_MAX_STITCH_BYTES = 512 * 1024 * 1024;
 
+type ChunkPart = {
+  partNumber: number;
+  key: string;
+  size: number;
+  lastModified?: Date;
+};
+
+// Byte-concats a segment's chunk objects into its recording key and marks the
+// segment and track complete. Chunks are preserved in S3 for manual ffmpeg
+// re-stitching. `forcePartial` flags the track partial even without chunk
+// gaps, for when a newer attempt's audio is known to be unrecoverable.
+async function stitchSegmentChunks(input: {
+  sessionId: string;
+  trackId: string;
+  segmentId: string;
+  parts: ChunkPart[];
+  maxStitchBytes?: number;
+  forcePartial: boolean;
+}): Promise<RecoveryResult> {
+  const { sessionId, trackId, segmentId, parts, forcePartial } = input;
+
+  const totalSize = parts.reduce((sum, p) => sum + p.size, 0);
+  const cap = input.maxStitchBytes ?? DEFAULT_MAX_STITCH_BYTES;
+  if (totalSize > cap) {
+    console.warn(
+      `[recovery] track=${trackId} chunks total ${totalSize} bytes exceeds cap ${cap}; marking failed (chunks preserved)`
+    );
+    await db.track.update({
+      where: { id: trackId },
+      data: { status: "failed" },
+    });
+    return {
+      trackId,
+      outcome: "failed_too_large",
+      partial: false,
+      status: "failed",
+      chunkCount: parts.length,
+      missingPartNumbers: [],
+    };
+  }
+
+  const missing: number[] = [];
+  const maxPart = parts[parts.length - 1].partNumber;
+  const present = new Set(parts.map((p) => p.partNumber));
+  for (let i = 0; i <= maxPart; i++) {
+    if (!present.has(i)) missing.push(i);
+  }
+  const partial = missing.length > 0 || forcePartial;
+
+  const chunkBytes: Uint8Array[] = [];
+  for (const part of parts) {
+    chunkBytes.push(await getObjectBytes(part.key));
+  }
+
+  const totalBytes = chunkBytes.reduce((sum, b) => sum + b.byteLength, 0);
+  const merged = new Uint8Array(totalBytes);
+  let offset = 0;
+  for (const bytes of chunkBytes) {
+    merged.set(bytes, offset);
+    offset += bytes.byteLength;
+  }
+
+  const recordingKey = trackSegmentRecordingKey(sessionId, trackId, segmentId);
+  await putObjectBytes(recordingKey, merged);
+
+  // Keep the segment row in sync so later segment completions don't see it
+  // as forever-pending; updateMany tolerates legacy tracks without rows.
+  await db.trackSegment.updateMany({
+    where: { id: segmentId, trackId },
+    data: { status: "complete", completedAt: new Date() },
+  });
+
+  await db.track.update({
+    where: { id: trackId },
+    data: {
+      status: "complete",
+      s3Key: recordingKey,
+      partial,
+    },
+  });
+
+  if (partial) {
+    console.warn(
+      `[recovery] track=${trackId} stitched with gaps; missing partNumbers=${missing.join(",")}`
+    );
+  }
+
+  return {
+    trackId,
+    outcome: partial ? "recovered_partial" : "recovered_from_chunks",
+    partial,
+    status: "complete",
+    chunkCount: parts.length,
+    missingPartNumbers: missing,
+  };
+}
+
 // Recovery preserves chunk objects in S3 even after producing recording.webm.
 // The byte-concat stitch is a best-effort fallback; keeping the chunks gives
 // an operator the option to re-stitch manually with ffmpeg if needed.
@@ -71,10 +168,8 @@ export async function recoverTrack(
   const { sessionId } = track;
 
   // Segment-aware pass. Until media stitching lands (#111 stack 4) the newest
-  // segment whose final recording exists is the track's authoritative
-  // artifact; older segments are preserved for the stitcher. Incomplete
-  // non-default segments that only have chunk files are not stitched here —
-  // their chunks stay in S3 for manual ffmpeg recovery.
+  // segment with recoverable audio is the track's authoritative artifact;
+  // older segments are preserved for the stitcher.
   const segments = await db.trackSegment.findMany({
     where: { trackId },
     orderBy: { segmentIndex: "desc" },
@@ -92,18 +187,19 @@ export async function recoverTrack(
       newest.status === "complete" ||
       (await trackSegmentRecordingExists(sessionId, trackId, newest.id));
 
-    if (!newestRecoverable && newest.id !== trackId) {
-      // The newest attempt has no final artifact. Completing the track from
-      // older audio would race a participant who is still recording, so only
-      // fall back once the attempt shows no recent activity (the default
-      // segment is covered by the chunk-stitch gate below).
+    if (!newestRecoverable) {
+      const newestParts = await listTrackSegmentChunkParts(
+        sessionId,
+        trackId,
+        newest.id
+      );
+
+      // The newest attempt has no final artifact. Recovering anything —
+      // stitching its chunks or falling back to older audio — must not race
+      // a participant who is still recording, so check for recent activity
+      // first (segment row age plus chunk upload times).
       const minAgeMs = options.chunkStitchMinAgeMs;
       if (minAgeMs !== undefined && minAgeMs > 0) {
-        const newestParts = await listTrackSegmentChunkParts(
-          sessionId,
-          trackId,
-          newest.id
-        );
         let lastActivityMs = newest.createdAt.getTime();
         for (const part of newestParts) {
           if (part.lastModified) {
@@ -124,7 +220,23 @@ export async function recoverTrack(
           };
         }
       }
-      newerSegmentLost = true;
+
+      if (newestParts.length > 0) {
+        // The tab died after uploading chunks but before the final blob —
+        // those chunks are the newest attempt's authoritative audio.
+        return await stitchSegmentChunks({
+          sessionId,
+          trackId,
+          segmentId: newest.id,
+          parts: newestParts,
+          maxStitchBytes: options.maxStitchBytes,
+          forcePartial: false,
+        });
+      }
+
+      if (newest.id !== trackId) {
+        newerSegmentLost = true;
+      }
     }
 
     const candidates = newestRecoverable ? [newest] : segments.slice(1);
@@ -222,79 +334,13 @@ export async function recoverTrack(
     }
   }
 
-  const totalSize = parts.reduce((sum, p) => sum + p.size, 0);
-  const cap = options.maxStitchBytes ?? DEFAULT_MAX_STITCH_BYTES;
-  if (totalSize > cap) {
-    console.warn(
-      `[recovery] track=${trackId} chunks total ${totalSize} bytes exceeds cap ${cap}; marking failed (chunks preserved)`
-    );
-    await db.track.update({
-      where: { id: trackId },
-      data: { status: "failed" },
-    });
-    return {
-      trackId,
-      outcome: "failed_too_large",
-      partial: false,
-      status: "failed",
-      chunkCount: parts.length,
-      missingPartNumbers: [],
-    };
-  }
-
-  const missing: number[] = [];
-  const maxPart = parts[parts.length - 1].partNumber;
-  const present = new Set(parts.map((p) => p.partNumber));
-  for (let i = 0; i <= maxPart; i++) {
-    if (!present.has(i)) missing.push(i);
-  }
-  const partial = missing.length > 0 || newerSegmentLost;
-
-  const chunkBytes: Uint8Array[] = [];
-  for (const part of parts) {
-    chunkBytes.push(await getObjectBytes(part.key));
-  }
-
-  const totalBytes = chunkBytes.reduce((sum, b) => sum + b.byteLength, 0);
-  const merged = new Uint8Array(totalBytes);
-  let offset = 0;
-  for (const bytes of chunkBytes) {
-    merged.set(bytes, offset);
-    offset += bytes.byteLength;
-  }
-
-  const recordingKey = trackRecordingKey(sessionId, trackId);
-  await putObjectBytes(recordingKey, merged);
-
   // The stitched chunks belong to the default segment (same id as the track).
-  // Keep its row in sync so later segment completions don't see it as
-  // forever-pending; updateMany tolerates legacy tracks without segment rows.
-  await db.trackSegment.updateMany({
-    where: { id: trackId, trackId },
-    data: { status: "complete", completedAt: new Date() },
-  });
-
-  await db.track.update({
-    where: { id: trackId },
-    data: {
-      status: "complete",
-      s3Key: recordingKey,
-      partial,
-    },
-  });
-
-  if (partial) {
-    console.warn(
-      `[recovery] track=${trackId} stitched with gaps; missing partNumbers=${missing.join(",")}`
-    );
-  }
-
-  return {
+  return await stitchSegmentChunks({
+    sessionId,
     trackId,
-    outcome: partial ? "recovered_partial" : "recovered_from_chunks",
-    partial,
-    status: "complete",
-    chunkCount: parts.length,
-    missingPartNumbers: missing,
-  };
+    segmentId: trackId,
+    parts,
+    maxStitchBytes: options.maxStitchBytes,
+    forcePartial: newerSegmentLost,
+  });
 }

--- a/src/lib/recovery.ts
+++ b/src/lib/recovery.ts
@@ -5,6 +5,8 @@ import {
   putObjectBytes,
   trackRecordingExists,
   trackRecordingKey,
+  trackSegmentRecordingExists,
+  trackSegmentRecordingKey,
 } from "@/lib/s3";
 
 export type RecoveryOutcome =
@@ -67,8 +69,47 @@ export async function recoverTrack(
 
   const { sessionId } = track;
 
+  // Segment-aware pass, newest first. Until media stitching lands (#111
+  // stack 4) the newest segment whose final recording exists is the track's
+  // authoritative artifact; older segments are preserved for the stitcher.
+  // Incomplete non-default segments that only have chunk files are not
+  // stitched here — their chunks stay in S3 for manual ffmpeg recovery.
+  const segments = await db.trackSegment.findMany({
+    where: { trackId },
+    orderBy: { segmentIndex: "desc" },
+    select: { id: true, status: true },
+  });
+  for (const segment of segments) {
+    const recovered =
+      segment.status === "complete" ||
+      (await trackSegmentRecordingExists(sessionId, trackId, segment.id));
+    if (!recovered) continue;
+    if (segment.status !== "complete") {
+      await db.trackSegment.updateMany({
+        where: { id: segment.id },
+        data: { status: "complete", completedAt: new Date() },
+      });
+    }
+    await db.track.update({
+      where: { id: trackId },
+      data: {
+        status: "complete",
+        s3Key: trackSegmentRecordingKey(sessionId, trackId, segment.id),
+      },
+    });
+    return {
+      trackId,
+      outcome: "recovered_from_recording",
+      partial: false,
+      status: "complete",
+      chunkCount: 0,
+      missingPartNumbers: [],
+    };
+  }
+
   // Cheap, race-free signal: if the client uploaded the final blob before
   // its tab died, we can mark the row complete without touching chunks.
+  // Covers legacy tracks that predate TrackSegment rows.
   if (await trackRecordingExists(sessionId, trackId)) {
     await db.track.update({
       where: { id: trackId },
@@ -172,6 +213,14 @@ export async function recoverTrack(
 
   const recordingKey = trackRecordingKey(sessionId, trackId);
   await putObjectBytes(recordingKey, merged);
+
+  // The stitched chunks belong to the default segment (same id as the track).
+  // Keep its row in sync so later segment completions don't see it as
+  // forever-pending; updateMany tolerates legacy tracks without segment rows.
+  await db.trackSegment.updateMany({
+    where: { id: trackId, trackId },
+    data: { status: "complete", completedAt: new Date() },
+  });
 
   await db.track.update({
     where: { id: trackId },

--- a/src/lib/recovery.ts
+++ b/src/lib/recovery.ts
@@ -2,6 +2,7 @@ import { db } from "@/lib/db";
 import {
   getObjectBytes,
   listTrackChunkParts,
+  listTrackSegmentChunkParts,
   putObjectBytes,
   trackRecordingExists,
   trackRecordingKey,
@@ -69,42 +70,93 @@ export async function recoverTrack(
 
   const { sessionId } = track;
 
-  // Segment-aware pass, newest first. Until media stitching lands (#111
-  // stack 4) the newest segment whose final recording exists is the track's
-  // authoritative artifact; older segments are preserved for the stitcher.
-  // Incomplete non-default segments that only have chunk files are not
-  // stitched here — their chunks stay in S3 for manual ffmpeg recovery.
+  // Segment-aware pass. Until media stitching lands (#111 stack 4) the newest
+  // segment whose final recording exists is the track's authoritative
+  // artifact; older segments are preserved for the stitcher. Incomplete
+  // non-default segments that only have chunk files are not stitched here —
+  // their chunks stay in S3 for manual ffmpeg recovery.
   const segments = await db.trackSegment.findMany({
     where: { trackId },
     orderBy: { segmentIndex: "desc" },
-    select: { id: true, status: true },
+    select: { id: true, status: true, createdAt: true },
   });
-  for (const segment of segments) {
-    const recovered =
-      segment.status === "complete" ||
-      (await trackSegmentRecordingExists(sessionId, trackId, segment.id));
-    if (!recovered) continue;
-    if (segment.status !== "complete") {
-      await db.trackSegment.updateMany({
-        where: { id: segment.id },
-        data: { status: "complete", completedAt: new Date() },
-      });
+
+  // Set when the newest attempt left no recoverable audio: any recovery from
+  // older sources must be flagged partial instead of passing the older
+  // recording off as the whole take.
+  let newerSegmentLost = false;
+
+  if (segments.length > 0) {
+    const newest = segments[0];
+    const newestRecoverable =
+      newest.status === "complete" ||
+      (await trackSegmentRecordingExists(sessionId, trackId, newest.id));
+
+    if (!newestRecoverable && newest.id !== trackId) {
+      // The newest attempt has no final artifact. Completing the track from
+      // older audio would race a participant who is still recording, so only
+      // fall back once the attempt shows no recent activity (the default
+      // segment is covered by the chunk-stitch gate below).
+      const minAgeMs = options.chunkStitchMinAgeMs;
+      if (minAgeMs !== undefined && minAgeMs > 0) {
+        const newestParts = await listTrackSegmentChunkParts(
+          sessionId,
+          trackId,
+          newest.id
+        );
+        let lastActivityMs = newest.createdAt.getTime();
+        for (const part of newestParts) {
+          if (part.lastModified) {
+            lastActivityMs = Math.max(
+              lastActivityMs,
+              part.lastModified.getTime()
+            );
+          }
+        }
+        if (Date.now() - lastActivityMs < minAgeMs) {
+          return {
+            trackId,
+            outcome: "skipped_active",
+            partial: track.partial,
+            status: track.status,
+            chunkCount: newestParts.length,
+            missingPartNumbers: [],
+          };
+        }
+      }
+      newerSegmentLost = true;
     }
-    await db.track.update({
-      where: { id: trackId },
-      data: {
+
+    const candidates = newestRecoverable ? [newest] : segments.slice(1);
+    for (const segment of candidates) {
+      const recovered =
+        segment === newest ||
+        segment.status === "complete" ||
+        (await trackSegmentRecordingExists(sessionId, trackId, segment.id));
+      if (!recovered) continue;
+      if (segment.status !== "complete") {
+        await db.trackSegment.updateMany({
+          where: { id: segment.id },
+          data: { status: "complete", completedAt: new Date() },
+        });
+      }
+      await db.track.update({
+        where: { id: trackId },
+        data: {
+          status: "complete",
+          s3Key: trackSegmentRecordingKey(sessionId, trackId, segment.id),
+          partial: newerSegmentLost,
+        },
+      });
+      return {
+        trackId,
+        outcome: "recovered_from_recording",
+        partial: newerSegmentLost,
         status: "complete",
-        s3Key: trackSegmentRecordingKey(sessionId, trackId, segment.id),
-      },
-    });
-    return {
-      trackId,
-      outcome: "recovered_from_recording",
-      partial: false,
-      status: "complete",
-      chunkCount: 0,
-      missingPartNumbers: [],
-    };
+        chunkCount: 0,
+        missingPartNumbers: [],
+      };
+    }
   }
 
   // Cheap, race-free signal: if the client uploaded the final blob before
@@ -196,7 +248,7 @@ export async function recoverTrack(
   for (let i = 0; i <= maxPart; i++) {
     if (!present.has(i)) missing.push(i);
   }
-  const partial = missing.length > 0;
+  const partial = missing.length > 0 || newerSegmentLost;
 
   const chunkBytes: Uint8Array[] = [];
   for (const part of parts) {

--- a/src/lib/s3.ts
+++ b/src/lib/s3.ts
@@ -186,17 +186,9 @@ export async function listTrackChunkParts(
   return parts;
 }
 
-export async function trackRecordingExists(
-  sessionId: string,
-  trackId: string
-): Promise<boolean> {
+async function objectExists(key: string): Promise<boolean> {
   try {
-    await s3.send(
-      new HeadObjectCommand({
-        Bucket: bucket,
-        Key: trackRecordingKey(sessionId, trackId),
-      })
-    );
+    await s3.send(new HeadObjectCommand({ Bucket: bucket, Key: key }));
     return true;
   } catch (error) {
     if (error instanceof NotFound || error instanceof NoSuchKey) {
@@ -211,6 +203,21 @@ export async function trackRecordingExists(
     }
     throw error;
   }
+}
+
+export async function trackRecordingExists(
+  sessionId: string,
+  trackId: string
+): Promise<boolean> {
+  return objectExists(trackRecordingKey(sessionId, trackId));
+}
+
+export async function trackSegmentRecordingExists(
+  sessionId: string,
+  trackId: string,
+  segmentId: string
+): Promise<boolean> {
+  return objectExists(trackSegmentRecordingKey(sessionId, trackId, segmentId));
 }
 
 export async function getObjectBytes(key: string): Promise<Uint8Array> {

--- a/src/lib/s3.ts
+++ b/src/lib/s3.ts
@@ -143,7 +143,17 @@ export async function listTrackChunkParts(
 ): Promise<
   { partNumber: number; key: string; size: number; lastModified?: Date }[]
 > {
-  const prefix = trackPrefix(sessionId, trackId);
+  return listTrackSegmentChunkParts(sessionId, trackId, trackId);
+}
+
+export async function listTrackSegmentChunkParts(
+  sessionId: string,
+  trackId: string,
+  segmentId: string
+): Promise<
+  { partNumber: number; key: string; size: number; lastModified?: Date }[]
+> {
+  const prefix = trackSegmentPrefix(sessionId, trackId, segmentId);
   const chunkKeyPattern = /^(\d+)\.webm$/;
   const parts: {
     partNumber: number;

--- a/src/lib/s3.ts
+++ b/src/lib/s3.ts
@@ -85,6 +85,37 @@ export function trackPrefix(sessionId: string, trackId: string): string {
   return `sessions/${sessionId}/tracks/${trackId}/`;
 }
 
+export function trackSegmentPrefix(
+  sessionId: string,
+  trackId: string,
+  segmentId: string
+): string {
+  if (segmentId === trackId) {
+    return trackPrefix(sessionId, trackId);
+  }
+  return `sessions/${sessionId}/tracks/${trackId}/segments/${segmentId}/`;
+}
+
+export function trackSegmentPartKey(
+  sessionId: string,
+  trackId: string,
+  segmentId: string,
+  partNumber: number
+): string {
+  return `${trackSegmentPrefix(sessionId, trackId, segmentId)}${partNumber}.webm`;
+}
+
+export function trackSegmentRecordingKey(
+  sessionId: string,
+  trackId: string,
+  segmentId: string
+): string {
+  if (segmentId === trackId) {
+    return trackRecordingKey(sessionId, trackId);
+  }
+  return `${trackSegmentPrefix(sessionId, trackId, segmentId)}recording.webm`;
+}
+
 export function sessionPrefix(sessionId: string): string {
   return `sessions/${sessionId}/`;
 }
@@ -263,9 +294,36 @@ export async function deleteTrackChunks(
   sessionId: string,
   trackId: string
 ): Promise<void> {
+  await deleteTrackSegmentChunksWithLabel(
+    sessionId,
+    trackId,
+    trackId,
+    "Failed to delete track chunks:"
+  );
+}
+
+export async function deleteTrackSegmentChunks(
+  sessionId: string,
+  trackId: string,
+  segmentId: string
+): Promise<void> {
+  await deleteTrackSegmentChunksWithLabel(
+    sessionId,
+    trackId,
+    segmentId,
+    "Failed to delete track segment chunks:"
+  );
+}
+
+async function deleteTrackSegmentChunksWithLabel(
+  sessionId: string,
+  trackId: string,
+  segmentId: string,
+  errorLabel: string
+): Promise<void> {
   try {
-    const prefix = trackPrefix(sessionId, trackId);
-    const finalKey = trackRecordingKey(sessionId, trackId);
+    const prefix = trackSegmentPrefix(sessionId, trackId, segmentId);
+    const finalKey = trackSegmentRecordingKey(sessionId, trackId, segmentId);
     const chunkKeyPattern = /^\d+\.webm$/;
     let continuationToken: string | undefined;
 
@@ -293,6 +351,6 @@ export async function deleteTrackChunks(
         : undefined;
     } while (continuationToken);
   } catch (error) {
-    console.error("Failed to delete track chunks:", error);
+    console.error(errorLabel, error);
   }
 }

--- a/src/lib/upload.ts
+++ b/src/lib/upload.ts
@@ -11,11 +11,15 @@ export interface TrackInitInfo {
   // ISO8601 — the originator's local clock at the moment recording started.
   // Shared across all tracks triggered by the same broadcast.
   sessionStartedAt?: string;
+  segmentId?: string;
 }
 
 export interface PresignedUploadTarget {
   url: string;
+  key?: string;
   recordingToken?: string;
+  trackId?: string;
+  segmentId?: string;
 }
 
 export async function getPresignedUploadTarget(
@@ -41,6 +45,7 @@ export async function getPresignedUploadTarget(
       participantName,
       ...(trackInit?.deviceInfo ?? {}),
       sessionStartedAt: trackInit?.sessionStartedAt,
+      segmentId: trackInit?.segmentId,
     }),
   });
 
@@ -62,8 +67,11 @@ export async function getPresignedUploadTarget(
   const data = await res.json();
   return {
     url: data.url,
+    key: typeof data.key === "string" ? data.key : undefined,
     recordingToken:
       typeof data.recordingToken === "string" ? data.recordingToken : undefined,
+    trackId: typeof data.trackId === "string" ? data.trackId : undefined,
+    segmentId: typeof data.segmentId === "string" ? data.segmentId : undefined,
   };
 }
 
@@ -105,6 +113,7 @@ export async function completeUpload(
   trackId: string,
   durationMs?: number,
   recordingToken?: string,
+  segmentId?: string,
 ): Promise<void> {
   const headers: Record<string, string> = { "Content-Type": "application/json" };
   if (recordingToken) {
@@ -114,7 +123,7 @@ export async function completeUpload(
   const res = await fetch("/api/upload/complete", {
     method: "POST",
     headers,
-    body: JSON.stringify({ sessionId, trackId, durationMs }),
+    body: JSON.stringify({ sessionId, trackId, durationMs, segmentId }),
   });
 
   if (!res.ok) {

--- a/src/lib/upload.ts
+++ b/src/lib/upload.ts
@@ -12,6 +12,9 @@ export interface TrackInitInfo {
   // Shared across all tracks triggered by the same broadcast.
   sessionStartedAt?: string;
   segmentId?: string;
+  // The take this recording was broadcast for. Binds a delayed start to its
+  // original take instead of whatever take is active when presign arrives.
+  takeId?: string;
 }
 
 export interface PresignedUploadTarget {
@@ -46,6 +49,7 @@ export async function getPresignedUploadTarget(
       ...(trackInit?.deviceInfo ?? {}),
       sessionStartedAt: trackInit?.sessionStartedAt,
       segmentId: trackInit?.segmentId,
+      takeId: trackInit?.takeId,
     }),
   });
 

--- a/tests/download-routes.test.ts
+++ b/tests/download-routes.test.ts
@@ -3,6 +3,7 @@ import { describe, it, expect, beforeEach, vi } from "vitest";
 type Track = {
   id: string;
   s3Key: string;
+  status: string;
   s3PurgedAt: Date | null;
 };
 
@@ -52,6 +53,7 @@ describe("track download routes", () => {
     mocks.trackStore.set("t1", {
       id: "t1",
       s3Key: "sessions/s1/tracks/t1/recording.webm",
+      status: "complete",
       s3PurgedAt: new Date("2026-05-10T12:00:00.000Z"),
     });
 
@@ -69,6 +71,7 @@ describe("track download routes", () => {
     mocks.trackStore.set("t2", {
       id: "t2",
       s3Key: "sessions/s1/tracks/t2/recording.webm",
+      status: "complete",
       s3PurgedAt: new Date("2026-05-10T12:00:00.000Z"),
     });
 
@@ -82,6 +85,58 @@ describe("track download routes", () => {
     expect(res.status).toBe(410);
     const body = (await res.json()) as { error: string };
     expect(body.error).toBe("Track recording has been purged");
+    expect(mocks.getPresignedGetUrl).not.toHaveBeenCalled();
+  });
+
+  it("serves a browser download for a complete track", async () => {
+    mocks.trackStore.set("t3", {
+      id: "t3",
+      s3Key: "sessions/s1/tracks/t3/recording.webm",
+      status: "complete",
+      s3PurgedAt: null,
+    });
+
+    const res = await browserDownload(req("/api/tracks/t3/download"), {
+      params: Promise.resolve({ id: "t3" }),
+    });
+
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { url: string };
+    expect(body.url).toBe("https://example.com/download");
+  });
+
+  it("blocks browser downloads while a re-record segment is in flight", async () => {
+    // Presign pulled the reused logical track back to recording, but s3Key
+    // still points at the previous segment's blob. Serving it would pass the
+    // superseded take off as the current artifact.
+    mocks.trackStore.set("t4", {
+      id: "t4",
+      s3Key: "sessions/s1/tracks/t4/recording.webm",
+      status: "recording",
+      s3PurgedAt: null,
+    });
+
+    const res = await browserDownload(req("/api/tracks/t4/download"), {
+      params: Promise.resolve({ id: "t4" }),
+    });
+
+    expect(res.status).toBe(409);
+    expect(mocks.getPresignedGetUrl).not.toHaveBeenCalled();
+  });
+
+  it("blocks ingest downloads for tracks that are not complete", async () => {
+    mocks.trackStore.set("t5", {
+      id: "t5",
+      s3Key: "sessions/s1/tracks/t5/recording.webm",
+      status: "uploading",
+      s3PurgedAt: null,
+    });
+
+    const res = await ingestDownload(req("/api/ingest/tracks/t5/download"), {
+      params: Promise.resolve({ id: "t5" }),
+    });
+
+    expect(res.status).toBe(409);
     expect(mocks.getPresignedGetUrl).not.toHaveBeenCalled();
   });
 });

--- a/tests/logical-track-segments.test.ts
+++ b/tests/logical-track-segments.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { describe, it, expect, beforeEach, afterEach, vi, type Mock } from "vitest";
 
 type Principal =
   | { kind: "host"; participantId?: string }
@@ -622,13 +622,15 @@ describe("logical track segments", () => {
     // A concurrent start for the same participant/take grabbed the counted
     // segmentIndex first — the unique [trackId, segmentIndex] constraint
     // rejects the first create attempt.
-    vi.mocked(db.trackSegment.create).mockImplementationOnce(async () => {
-      const err = new Error(
-        "Unique constraint failed on the fields: (`trackId`,`segmentIndex`)",
-      ) as Error & { code: string };
-      err.code = "P2002";
-      throw err;
-    });
+    (db.trackSegment.create as unknown as Mock).mockImplementationOnce(
+      async () => {
+        const err = new Error(
+          "Unique constraint failed on the fields: (`trackId`,`segmentIndex`)",
+        ) as Error & { code: string };
+        err.code = "P2002";
+        throw err;
+      },
+    );
 
     const res = await presignUpload(
       postJson("/api/upload/presign", {

--- a/tests/logical-track-segments.test.ts
+++ b/tests/logical-track-segments.test.ts
@@ -113,6 +113,23 @@ vi.mock("@/lib/db", () => ({
           return { ...updated };
         },
       ),
+      updateMany: vi.fn(
+        async ({
+          where: { id, status },
+          data,
+        }: {
+          where: { id: string; status?: { not: string } };
+          data: Partial<Track>;
+        }) => {
+          const existing = mocks.tracks.get(id);
+          if (!existing) return { count: 0 };
+          if (status?.not !== undefined && existing.status === status.not) {
+            return { count: 0 };
+          }
+          mocks.tracks.set(id, { ...existing, ...data });
+          return { count: 1 };
+        },
+      ),
     },
     trackSegment: {
       count: vi.fn(
@@ -212,6 +229,7 @@ import { NextRequest } from "next/server";
 import { POST as presignUpload } from "@/app/api/upload/presign/route";
 import { POST as completeUpload } from "@/app/api/upload/complete/route";
 import { issueRecordingUploadToken } from "@/lib/auth";
+import { db } from "@/lib/db";
 
 function postJson(
   path: string,
@@ -567,6 +585,121 @@ describe("logical track segments", () => {
       s3Key:
         "sessions/s1/tracks/logical-track/segments/browser-seg-2/recording.webm",
       durationMs: 5000,
+    });
+  });
+
+  it("retries segment creation when a concurrent start claims the index", async () => {
+    mocks.recordingTakes.set("take-1", {
+      id: "take-1",
+      sessionId: "s1",
+      startedAt: new Date("2026-06-11T00:00:00.000Z"),
+      stoppedAt: null,
+    });
+    mocks.tracks.set("logical-track", {
+      id: "logical-track",
+      sessionId: "s1",
+      takeId: "take-1",
+      participantName: "Alice",
+      participantId: "guest_alice",
+      s3Key: "sessions/s1/tracks/logical-track/recording.webm",
+      status: "recording",
+      durationMs: null,
+    });
+    mocks.segments.set("logical-track", {
+      id: "logical-track",
+      trackId: "logical-track",
+      segmentIndex: 0,
+      s3Prefix: "sessions/s1/tracks/logical-track/",
+      status: "recording",
+      durationMs: null,
+    });
+    mocks.resolvePrincipal.mockResolvedValue({
+      kind: "guest",
+      sessionId: "s1",
+      name: "Cookie Alice",
+      participantId: "guest_alice",
+    });
+    // A concurrent start for the same participant/take grabbed the counted
+    // segmentIndex first — the unique [trackId, segmentIndex] constraint
+    // rejects the first create attempt.
+    vi.mocked(db.trackSegment.create).mockImplementationOnce(async () => {
+      const err = new Error(
+        "Unique constraint failed on the fields: (`trackId`,`segmentIndex`)",
+      ) as Error & { code: string };
+      err.code = "P2002";
+      throw err;
+    });
+
+    const res = await presignUpload(
+      postJson("/api/upload/presign", {
+        sessionId: "s1",
+        trackId: "new-browser-segment",
+        partNumber: 0,
+        participantName: "Alice",
+      }),
+    );
+
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { segmentId: string; trackId: string };
+    expect(body.trackId).toBe("logical-track");
+    expect(body.segmentId).toBe("new-browser-segment");
+    expect(mocks.segments.get("new-browser-segment")).toMatchObject({
+      trackId: "logical-track",
+      status: "recording",
+    });
+  });
+
+  it("does not demote a complete track when an older segment completes late", async () => {
+    // Race outcome state: the newest segment's completion already promoted
+    // the track while an older segment's completion was still in flight.
+    mocks.tracks.set("logical-track", {
+      id: "logical-track",
+      sessionId: "s1",
+      participantName: "Alice",
+      participantId: "guest_alice",
+      s3Key:
+        "sessions/s1/tracks/logical-track/segments/browser-seg-2/recording.webm",
+      status: "complete",
+      durationMs: 5000,
+    });
+    mocks.segments.set("logical-track", {
+      id: "logical-track",
+      trackId: "logical-track",
+      segmentIndex: 0,
+      s3Prefix: "sessions/s1/tracks/logical-track/",
+      status: "recording",
+      durationMs: null,
+    });
+    mocks.segments.set("browser-seg-2", {
+      id: "browser-seg-2",
+      trackId: "logical-track",
+      segmentIndex: 1,
+      s3Prefix: "sessions/s1/tracks/logical-track/segments/browser-seg-2/",
+      status: "recording",
+      durationMs: null,
+    });
+    const recordingToken = await issueRecordingUploadToken("s1", "logical-track");
+
+    const res = await completeUpload(
+      postJson(
+        "/api/upload/complete",
+        {
+          sessionId: "s1",
+          trackId: "logical-track",
+          segmentId: "logical-track",
+          durationMs: 1000,
+        },
+        { "x-cozytrack-recording-token": recordingToken },
+      ),
+    );
+
+    expect(res.status).toBe(200);
+    // The older completion must not clobber the already-promoted track back
+    // to uploading — that would block finalize with every segment complete.
+    expect(mocks.tracks.get("logical-track")).toMatchObject({
+      status: "complete",
+      s3Key:
+        "sessions/s1/tracks/logical-track/segments/browser-seg-2/recording.webm",
     });
   });
 

--- a/tests/logical-track-segments.test.ts
+++ b/tests/logical-track-segments.test.ts
@@ -51,6 +51,12 @@ vi.mock("@/lib/db", () => ({
       ),
     },
     recordingTake: {
+      findUnique: vi.fn(
+        async ({ where: { id } }: { where: { id: string } }) => {
+          const take = mocks.recordingTakes.get(id);
+          return take ? { ...take } : null;
+        },
+      ),
       findFirst: vi.fn(
         async ({
           where: { sessionId, stoppedAt },
@@ -586,6 +592,72 @@ describe("logical track segments", () => {
         "sessions/s1/tracks/logical-track/segments/browser-seg-2/recording.webm",
       durationMs: 5000,
     });
+  });
+
+  it("binds a stale recording start to its broadcast take, not the newer active take", async () => {
+    // The participant's start was delayed: by the time presign arrives, the
+    // host has stopped take-a and started take-b. The audio belongs to take-a.
+    mocks.recordingTakes.set("take-a", {
+      id: "take-a",
+      sessionId: "s1",
+      startedAt: new Date("2026-06-11T00:00:00.000Z"),
+      stoppedAt: new Date("2026-06-11T00:05:00.000Z"),
+    });
+    mocks.recordingTakes.set("take-b", {
+      id: "take-b",
+      sessionId: "s1",
+      startedAt: new Date("2026-06-11T00:06:00.000Z"),
+      stoppedAt: null,
+    });
+    mocks.resolvePrincipal.mockResolvedValue({
+      kind: "guest",
+      sessionId: "s1",
+      name: "Cookie Alice",
+      participantId: "guest_alice",
+    });
+
+    const res = await presignUpload(
+      postJson("/api/upload/presign", {
+        sessionId: "s1",
+        trackId: "track-1",
+        partNumber: 0,
+        participantName: "Alice",
+        takeId: "take-a",
+      }),
+    );
+
+    expect(res.status).toBe(200);
+    expect(mocks.tracks.get("track-1")).toMatchObject({
+      takeId: "take-a",
+    });
+  });
+
+  it("rejects a recording start for a take from another session", async () => {
+    mocks.recordingTakes.set("other-take", {
+      id: "other-take",
+      sessionId: "s2",
+      startedAt: new Date("2026-06-11T00:00:00.000Z"),
+      stoppedAt: null,
+    });
+    mocks.resolvePrincipal.mockResolvedValue({
+      kind: "guest",
+      sessionId: "s1",
+      name: "Cookie Alice",
+      participantId: "guest_alice",
+    });
+
+    const res = await presignUpload(
+      postJson("/api/upload/presign", {
+        sessionId: "s1",
+        trackId: "track-1",
+        partNumber: 0,
+        participantName: "Alice",
+        takeId: "other-take",
+      }),
+    );
+
+    expect(res.status).toBe(403);
+    expect(mocks.tracks.has("track-1")).toBe(false);
   });
 
   it("rejects a chunk presign for a segment belonging to another track", async () => {

--- a/tests/logical-track-segments.test.ts
+++ b/tests/logical-track-segments.test.ts
@@ -127,6 +127,22 @@ vi.mock("@/lib/db", () => ({
           return segment ? { ...segment } : null;
         },
       ),
+      findMany: vi.fn(
+        async ({
+          where: { trackId },
+          orderBy,
+        }: {
+          where: { trackId: string };
+          orderBy?: { segmentIndex: "asc" | "desc" };
+        }) => {
+          const list = Array.from(mocks.segments.values())
+            .filter((segment) => segment.trackId === trackId)
+            .sort((a, b) => a.segmentIndex - b.segmentIndex)
+            .map((segment) => ({ ...segment }));
+          if (orderBy?.segmentIndex === "desc") list.reverse();
+          return list;
+        },
+      ),
       create: vi.fn(async ({ data }: { data: TrackSegment }) => {
         const segment = { ...data, status: "recording", durationMs: null };
         mocks.segments.set(segment.id, segment);
@@ -376,5 +392,134 @@ describe("logical track segments", () => {
       "track-1",
       "track-1",
     );
+  });
+
+  it("promotes the logical track to the latest segment once all segments complete", async () => {
+    mocks.tracks.set("logical-track", {
+      id: "logical-track",
+      sessionId: "s1",
+      participantName: "Alice",
+      participantId: "guest_alice",
+      s3Key: "sessions/s1/tracks/logical-track/recording.webm",
+      status: "complete",
+      durationMs: 1000,
+    });
+    mocks.segments.set("logical-track", {
+      id: "logical-track",
+      trackId: "logical-track",
+      segmentIndex: 0,
+      s3Prefix: "sessions/s1/tracks/logical-track/",
+      status: "complete",
+      durationMs: 1000,
+    });
+    mocks.segments.set("browser-seg-2", {
+      id: "browser-seg-2",
+      trackId: "logical-track",
+      segmentIndex: 1,
+      s3Prefix: "sessions/s1/tracks/logical-track/segments/browser-seg-2/",
+      status: "recording",
+      durationMs: null,
+    });
+    const recordingToken = await issueRecordingUploadToken("s1", "logical-track");
+
+    const res = await completeUpload(
+      postJson(
+        "/api/upload/complete",
+        {
+          sessionId: "s1",
+          trackId: "logical-track",
+          segmentId: "browser-seg-2",
+          durationMs: 5000,
+        },
+        { "x-cozytrack-recording-token": recordingToken },
+      ),
+    );
+
+    expect(res.status).toBe(200);
+    expect(mocks.segments.get("browser-seg-2")).toMatchObject({
+      status: "complete",
+      durationMs: 5000,
+    });
+    // The logical track must not be demoted back to uploading — with every
+    // segment complete it stays finalizable and serves the newest audio.
+    expect(mocks.tracks.get("logical-track")).toMatchObject({
+      status: "complete",
+      s3Key:
+        "sessions/s1/tracks/logical-track/segments/browser-seg-2/recording.webm",
+      durationMs: 5000,
+    });
+    expect(mocks.deleteTrackSegmentChunks).toHaveBeenCalledWith(
+      "s1",
+      "logical-track",
+      "browser-seg-2",
+    );
+  });
+
+  it("keeps the logical track pending until every segment completes", async () => {
+    mocks.tracks.set("logical-track", {
+      id: "logical-track",
+      sessionId: "s1",
+      participantName: "Alice",
+      participantId: "guest_alice",
+      s3Key: "sessions/s1/tracks/logical-track/recording.webm",
+      status: "recording",
+      durationMs: null,
+    });
+    mocks.segments.set("logical-track", {
+      id: "logical-track",
+      trackId: "logical-track",
+      segmentIndex: 0,
+      s3Prefix: "sessions/s1/tracks/logical-track/",
+      status: "recording",
+      durationMs: null,
+    });
+    mocks.segments.set("browser-seg-2", {
+      id: "browser-seg-2",
+      trackId: "logical-track",
+      segmentIndex: 1,
+      s3Prefix: "sessions/s1/tracks/logical-track/segments/browser-seg-2/",
+      status: "recording",
+      durationMs: null,
+    });
+    const recordingToken = await issueRecordingUploadToken("s1", "logical-track");
+
+    const secondSegmentRes = await completeUpload(
+      postJson(
+        "/api/upload/complete",
+        {
+          sessionId: "s1",
+          trackId: "logical-track",
+          segmentId: "browser-seg-2",
+          durationMs: 5000,
+        },
+        { "x-cozytrack-recording-token": recordingToken },
+      ),
+    );
+
+    expect(secondSegmentRes.status).toBe(200);
+    expect(mocks.tracks.get("logical-track")?.status).toBe("uploading");
+
+    const defaultSegmentRes = await completeUpload(
+      postJson(
+        "/api/upload/complete",
+        {
+          sessionId: "s1",
+          trackId: "logical-track",
+          segmentId: "logical-track",
+          durationMs: 1000,
+        },
+        { "x-cozytrack-recording-token": recordingToken },
+      ),
+    );
+
+    expect(defaultSegmentRes.status).toBe(200);
+    // Out-of-order completion: the default segment finished last, but the
+    // track must still surface the latest segment's recording.
+    expect(mocks.tracks.get("logical-track")).toMatchObject({
+      status: "complete",
+      s3Key:
+        "sessions/s1/tracks/logical-track/segments/browser-seg-2/recording.webm",
+      durationMs: 5000,
+    });
   });
 });

--- a/tests/logical-track-segments.test.ts
+++ b/tests/logical-track-segments.test.ts
@@ -121,18 +121,39 @@ vi.mock("@/lib/db", () => ({
       ),
       updateMany: vi.fn(
         async ({
-          where: { id, status },
+          where,
           data,
         }: {
-          where: { id: string; status?: { not: string } };
+          where: {
+            id: string;
+            status?: { not?: string; in?: string[] };
+            segments?: { none: { segmentIndex: { gt: number } } };
+          };
           data: Partial<Track>;
         }) => {
-          const existing = mocks.tracks.get(id);
+          const existing = mocks.tracks.get(where.id);
           if (!existing) return { count: 0 };
-          if (status?.not !== undefined && existing.status === status.not) {
+          if (
+            where.status?.not !== undefined &&
+            existing.status === where.status.not
+          ) {
             return { count: 0 };
           }
-          mocks.tracks.set(id, { ...existing, ...data });
+          if (
+            where.status?.in !== undefined &&
+            !where.status.in.includes(existing.status)
+          ) {
+            return { count: 0 };
+          }
+          const noneGt = where.segments?.none?.segmentIndex?.gt;
+          if (noneGt !== undefined) {
+            const hasNewer = Array.from(mocks.segments.values()).some(
+              (segment) =>
+                segment.trackId === where.id && segment.segmentIndex > noneGt,
+            );
+            if (hasNewer) return { count: 0 };
+          }
+          mocks.tracks.set(where.id, { ...existing, ...data });
           return { count: 1 };
         },
       ),

--- a/tests/logical-track-segments.test.ts
+++ b/tests/logical-track-segments.test.ts
@@ -502,7 +502,7 @@ describe("logical track segments", () => {
     );
   });
 
-  it("keeps the logical track pending until every segment completes", async () => {
+  it("keeps the logical track pending while a newer segment is still recording", async () => {
     mocks.tracks.set("logical-track", {
       id: "logical-track",
       sessionId: "s1",
@@ -530,22 +530,8 @@ describe("logical track segments", () => {
     });
     const recordingToken = await issueRecordingUploadToken("s1", "logical-track");
 
-    const secondSegmentRes = await completeUpload(
-      postJson(
-        "/api/upload/complete",
-        {
-          sessionId: "s1",
-          trackId: "logical-track",
-          segmentId: "browser-seg-2",
-          durationMs: 5000,
-        },
-        { "x-cozytrack-recording-token": recordingToken },
-      ),
-    );
-
-    expect(secondSegmentRes.status).toBe(200);
-    expect(mocks.tracks.get("logical-track")?.status).toBe("uploading");
-
+    // The default segment's late completion lands while the newer re-record
+    // attempt is still in flight — the track must not look finished yet.
     const defaultSegmentRes = await completeUpload(
       postJson(
         "/api/upload/complete",
@@ -560,8 +546,76 @@ describe("logical track segments", () => {
     );
 
     expect(defaultSegmentRes.status).toBe(200);
-    // Out-of-order completion: the default segment finished last, but the
-    // track must still surface the latest segment's recording.
+    expect(mocks.tracks.get("logical-track")?.status).toBe("uploading");
+
+    const secondSegmentRes = await completeUpload(
+      postJson(
+        "/api/upload/complete",
+        {
+          sessionId: "s1",
+          trackId: "logical-track",
+          segmentId: "browser-seg-2",
+          durationMs: 5000,
+        },
+        { "x-cozytrack-recording-token": recordingToken },
+      ),
+    );
+
+    expect(secondSegmentRes.status).toBe(200);
+    expect(mocks.tracks.get("logical-track")).toMatchObject({
+      status: "complete",
+      s3Key:
+        "sessions/s1/tracks/logical-track/segments/browser-seg-2/recording.webm",
+      durationMs: 5000,
+    });
+  });
+
+  it("completes the track from the newest segment even when an older segment was abandoned", async () => {
+    mocks.tracks.set("logical-track", {
+      id: "logical-track",
+      sessionId: "s1",
+      participantName: "Alice",
+      participantId: "guest_alice",
+      s3Key: "sessions/s1/tracks/logical-track/recording.webm",
+      status: "recording",
+      durationMs: null,
+    });
+    // The first attempt died without ever completing — its row stays
+    // "recording" forever. The re-record supersedes it.
+    mocks.segments.set("logical-track", {
+      id: "logical-track",
+      trackId: "logical-track",
+      segmentIndex: 0,
+      s3Prefix: "sessions/s1/tracks/logical-track/",
+      status: "recording",
+      durationMs: null,
+    });
+    mocks.segments.set("browser-seg-2", {
+      id: "browser-seg-2",
+      trackId: "logical-track",
+      segmentIndex: 1,
+      s3Prefix: "sessions/s1/tracks/logical-track/segments/browser-seg-2/",
+      status: "recording",
+      durationMs: null,
+    });
+    const recordingToken = await issueRecordingUploadToken("s1", "logical-track");
+
+    const res = await completeUpload(
+      postJson(
+        "/api/upload/complete",
+        {
+          sessionId: "s1",
+          trackId: "logical-track",
+          segmentId: "browser-seg-2",
+          durationMs: 5000,
+        },
+        { "x-cozytrack-recording-token": recordingToken },
+      ),
+    );
+
+    expect(res.status).toBe(200);
+    // The newest attempt is done; the dead older segment must not hold the
+    // track in uploading and block finalize.
     expect(mocks.tracks.get("logical-track")).toMatchObject({
       status: "complete",
       s3Key:

--- a/tests/logical-track-segments.test.ts
+++ b/tests/logical-track-segments.test.ts
@@ -350,6 +350,53 @@ describe("logical track segments", () => {
     });
   });
 
+  it("returns a complete track to recording when a new segment starts", async () => {
+    mocks.recordingTakes.set("take-1", {
+      id: "take-1",
+      sessionId: "s1",
+      startedAt: new Date("2026-06-11T00:00:00.000Z"),
+      stoppedAt: null,
+    });
+    mocks.tracks.set("logical-track", {
+      id: "logical-track",
+      sessionId: "s1",
+      takeId: "take-1",
+      participantName: "Alice",
+      participantId: "guest_alice",
+      s3Key: "sessions/s1/tracks/logical-track/recording.webm",
+      status: "complete",
+      durationMs: 1000,
+    });
+    mocks.segments.set("logical-track", {
+      id: "logical-track",
+      trackId: "logical-track",
+      segmentIndex: 0,
+      s3Prefix: "sessions/s1/tracks/logical-track/",
+      status: "complete",
+      durationMs: 1000,
+    });
+    mocks.resolvePrincipal.mockResolvedValue({
+      kind: "guest",
+      sessionId: "s1",
+      name: "Cookie Alice",
+      participantId: "guest_alice",
+    });
+
+    const res = await presignUpload(
+      postJson("/api/upload/presign", {
+        sessionId: "s1",
+        trackId: "new-browser-segment",
+        partNumber: 0,
+        participantName: "Alice",
+      }),
+    );
+
+    expect(res.status).toBe(200);
+    // While the re-record is in flight the track must not look finished —
+    // otherwise finalize/downloads serve the previous recording as if final.
+    expect(mocks.tracks.get("logical-track")?.status).toBe("recording");
+  });
+
   it("marks the addressed segment complete when the upload completes", async () => {
     mocks.tracks.set("track-1", {
       id: "track-1",

--- a/tests/logical-track-segments.test.ts
+++ b/tests/logical-track-segments.test.ts
@@ -594,6 +594,167 @@ describe("logical track segments", () => {
     });
   });
 
+  it("rejects a segment-scoped token presigning a different segment of the track", async () => {
+    mocks.tracks.set("logical-track", {
+      id: "logical-track",
+      sessionId: "s1",
+      participantName: "Alice",
+      participantId: "guest_alice",
+      s3Key: "sessions/s1/tracks/logical-track/recording.webm",
+      status: "recording",
+      durationMs: null,
+    });
+    mocks.segments.set("logical-track", {
+      id: "logical-track",
+      trackId: "logical-track",
+      segmentIndex: 0,
+      s3Prefix: "sessions/s1/tracks/logical-track/",
+      status: "recording",
+      durationMs: null,
+    });
+    mocks.segments.set("seg-b", {
+      id: "seg-b",
+      trackId: "logical-track",
+      segmentIndex: 1,
+      s3Prefix: "sessions/s1/tracks/logical-track/segments/seg-b/",
+      status: "recording",
+      durationMs: null,
+    });
+    // Token from the first attempt: scoped to the default segment.
+    const recordingToken = await issueRecordingUploadToken(
+      "s1",
+      "logical-track",
+      "logical-track",
+    );
+
+    // A stale tab must not be able to write into the newer attempt's objects.
+    const res = await presignUpload(
+      postJson(
+        "/api/upload/presign",
+        {
+          sessionId: "s1",
+          trackId: "logical-track",
+          partNumber: 5,
+          segmentId: "seg-b",
+        },
+        { "x-cozytrack-recording-token": recordingToken },
+      ),
+    );
+
+    expect(res.status).toBe(401);
+  });
+
+  it("rejects a segment-scoped token completing a different segment of the track", async () => {
+    mocks.tracks.set("logical-track", {
+      id: "logical-track",
+      sessionId: "s1",
+      participantName: "Alice",
+      participantId: "guest_alice",
+      s3Key: "sessions/s1/tracks/logical-track/recording.webm",
+      status: "recording",
+      durationMs: null,
+    });
+    mocks.segments.set("logical-track", {
+      id: "logical-track",
+      trackId: "logical-track",
+      segmentIndex: 0,
+      s3Prefix: "sessions/s1/tracks/logical-track/",
+      status: "recording",
+      durationMs: null,
+    });
+    mocks.segments.set("seg-b", {
+      id: "seg-b",
+      trackId: "logical-track",
+      segmentIndex: 1,
+      s3Prefix: "sessions/s1/tracks/logical-track/segments/seg-b/",
+      status: "recording",
+      durationMs: null,
+    });
+    const recordingToken = await issueRecordingUploadToken(
+      "s1",
+      "logical-track",
+      "logical-track",
+    );
+
+    const res = await completeUpload(
+      postJson(
+        "/api/upload/complete",
+        { sessionId: "s1", trackId: "logical-track", segmentId: "seg-b" },
+        { "x-cozytrack-recording-token": recordingToken },
+      ),
+    );
+
+    expect(res.status).toBe(401);
+    expect(mocks.segments.get("seg-b")?.status).toBe("recording");
+  });
+
+  it("does not promote the track when a newer segment appears mid-completion", async () => {
+    mocks.tracks.set("logical-track", {
+      id: "logical-track",
+      sessionId: "s1",
+      participantName: "Alice",
+      participantId: "guest_alice",
+      s3Key: "sessions/s1/tracks/logical-track/recording.webm",
+      status: "recording",
+      durationMs: null,
+    });
+    mocks.segments.set("logical-track", {
+      id: "logical-track",
+      trackId: "logical-track",
+      segmentIndex: 0,
+      s3Prefix: "sessions/s1/tracks/logical-track/",
+      status: "complete",
+      durationMs: 1000,
+    });
+    mocks.segments.set("browser-seg-2", {
+      id: "browser-seg-2",
+      trackId: "logical-track",
+      segmentIndex: 1,
+      s3Prefix: "sessions/s1/tracks/logical-track/segments/browser-seg-2/",
+      status: "recording",
+      durationMs: null,
+    });
+    // seg-3 is created concurrently: the completion request's segment read
+    // happens before the insert commits, but its track write happens after.
+    mocks.segments.set("browser-seg-3", {
+      id: "browser-seg-3",
+      trackId: "logical-track",
+      segmentIndex: 2,
+      s3Prefix: "sessions/s1/tracks/logical-track/segments/browser-seg-3/",
+      status: "recording",
+      durationMs: null,
+    });
+    (db.trackSegment.findMany as unknown as Mock).mockImplementationOnce(
+      async () => [
+        { ...mocks.segments.get("logical-track") },
+        { ...mocks.segments.get("browser-seg-2"), status: "complete", durationMs: 5000 },
+      ],
+    );
+    const recordingToken = await issueRecordingUploadToken(
+      "s1",
+      "logical-track",
+      "browser-seg-2",
+    );
+
+    const res = await completeUpload(
+      postJson(
+        "/api/upload/complete",
+        {
+          sessionId: "s1",
+          trackId: "logical-track",
+          segmentId: "browser-seg-2",
+          durationMs: 5000,
+        },
+        { "x-cozytrack-recording-token": recordingToken },
+      ),
+    );
+
+    expect(res.status).toBe(200);
+    // Promoting against the stale segment list would make stale audio
+    // downloadable while seg-3 is still recording.
+    expect(mocks.tracks.get("logical-track")?.status).not.toBe("complete");
+  });
+
   it("binds a stale recording start to its broadcast take, not the newer active take", async () => {
     // The participant's start was delayed: by the time presign arrives, the
     // host has stopped take-a and started take-b. The audio belongs to take-a.

--- a/tests/logical-track-segments.test.ts
+++ b/tests/logical-track-segments.test.ts
@@ -1,0 +1,380 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+
+type Principal =
+  | { kind: "host"; participantId?: string }
+  | { kind: "guest"; sessionId: string; name: string; participantId: string };
+
+type RecordingTake = {
+  id: string;
+  sessionId: string;
+  startedAt: Date;
+  stoppedAt: Date | null;
+};
+
+type Track = {
+  id: string;
+  sessionId: string;
+  takeId?: string | null;
+  participantName: string;
+  participantId?: string | null;
+  s3Key: string;
+  status: string;
+  durationMs: number | null;
+};
+
+type TrackSegment = {
+  id: string;
+  trackId: string;
+  segmentIndex: number;
+  s3Prefix: string;
+  status: string;
+  durationMs: number | null;
+  completedAt?: Date | null;
+};
+
+const mocks = vi.hoisted(() => ({
+  sessions: new Set<string>(),
+  recordingTakes: new Map<string, RecordingTake>(),
+  tracks: new Map<string, Track>(),
+  segments: new Map<string, TrackSegment>(),
+  getPresignedPutUrl: vi.fn(async (key: string) => `https://s3.example/${key}`),
+  deleteTrackChunks: vi.fn(async () => undefined),
+  deleteTrackSegmentChunks: vi.fn(async () => undefined),
+  resolvePrincipal: vi.fn<() => Promise<Principal | null>>(),
+}));
+
+vi.mock("@/lib/db", () => ({
+  db: {
+    session: {
+      findUnique: vi.fn(async ({ where: { id } }: { where: { id: string } }) =>
+        mocks.sessions.has(id) ? { id } : null,
+      ),
+    },
+    recordingTake: {
+      findFirst: vi.fn(
+        async ({
+          where: { sessionId, stoppedAt },
+        }: {
+          where: { sessionId: string; stoppedAt: null };
+        }) => {
+          return (
+            Array.from(mocks.recordingTakes.values()).find(
+              (take) =>
+                take.sessionId === sessionId && take.stoppedAt === stoppedAt,
+            ) ?? null
+          );
+        },
+      ),
+    },
+    track: {
+      findUnique: vi.fn(
+        async ({ where: { id } }: { where: { id: string } }) => {
+          const track = mocks.tracks.get(id);
+          return track ? { ...track } : null;
+        },
+      ),
+      findFirst: vi.fn(
+        async ({
+          where: { sessionId, takeId, participantId },
+        }: {
+          where: {
+            sessionId: string;
+            takeId?: string | null;
+            participantId?: string | null;
+          };
+        }) => {
+          return (
+            Array.from(mocks.tracks.values()).find(
+              (track) =>
+                track.sessionId === sessionId &&
+                track.takeId === takeId &&
+                track.participantId === participantId,
+            ) ?? null
+          );
+        },
+      ),
+      create: vi.fn(async ({ data }: { data: Track }) => {
+        const track = { ...data, status: "recording", durationMs: null };
+        mocks.tracks.set(track.id, track);
+        return { ...track };
+      }),
+      update: vi.fn(
+        async ({
+          where: { id },
+          data,
+        }: {
+          where: { id: string };
+          data: Partial<Track>;
+        }) => {
+          const existing = mocks.tracks.get(id);
+          if (!existing) throw new Error("track not found");
+          const updated = { ...existing, ...data };
+          mocks.tracks.set(id, updated);
+          return { ...updated };
+        },
+      ),
+    },
+    trackSegment: {
+      count: vi.fn(
+        async ({ where: { trackId } }: { where: { trackId: string } }) =>
+          Array.from(mocks.segments.values()).filter(
+            (segment) => segment.trackId === trackId,
+          ).length,
+      ),
+      findUnique: vi.fn(
+        async ({ where: { id } }: { where: { id: string } }) => {
+          const segment = mocks.segments.get(id);
+          return segment ? { ...segment } : null;
+        },
+      ),
+      create: vi.fn(async ({ data }: { data: TrackSegment }) => {
+        const segment = { ...data, status: "recording", durationMs: null };
+        mocks.segments.set(segment.id, segment);
+        return { ...segment };
+      }),
+      update: vi.fn(
+        async ({
+          where: { id },
+          data,
+        }: {
+          where: { id: string };
+          data: Partial<TrackSegment>;
+        }) => {
+          const existing = mocks.segments.get(id);
+          if (!existing) throw new Error("segment not found");
+          const updated = { ...existing, ...data };
+          mocks.segments.set(id, updated);
+          return { ...updated };
+        },
+      ),
+    },
+  },
+}));
+
+vi.mock("@/lib/s3", () => ({
+  getPresignedPutUrl: mocks.getPresignedPutUrl,
+  deleteTrackChunks: mocks.deleteTrackChunks,
+  deleteTrackSegmentChunks: mocks.deleteTrackSegmentChunks,
+  trackPartKey: (sessionId: string, trackId: string, partNumber: number) =>
+    `sessions/${sessionId}/tracks/${trackId}/${partNumber}.webm`,
+  trackRecordingKey: (sessionId: string, trackId: string) =>
+    `sessions/${sessionId}/tracks/${trackId}/recording.webm`,
+  trackSegmentPrefix: (sessionId: string, trackId: string, segmentId: string) =>
+    segmentId === trackId
+      ? `sessions/${sessionId}/tracks/${trackId}/`
+      : `sessions/${sessionId}/tracks/${trackId}/segments/${segmentId}/`,
+  trackSegmentPartKey: (
+    sessionId: string,
+    trackId: string,
+    segmentId: string,
+    partNumber: number,
+  ) =>
+    segmentId === trackId
+      ? `sessions/${sessionId}/tracks/${trackId}/${partNumber}.webm`
+      : `sessions/${sessionId}/tracks/${trackId}/segments/${segmentId}/${partNumber}.webm`,
+  trackSegmentRecordingKey: (
+    sessionId: string,
+    trackId: string,
+    segmentId: string,
+  ) =>
+    segmentId === trackId
+      ? `sessions/${sessionId}/tracks/${trackId}/recording.webm`
+      : `sessions/${sessionId}/tracks/${trackId}/segments/${segmentId}/recording.webm`,
+}));
+
+vi.mock("@/lib/auth", async () => {
+  const actual = await vi.importActual<typeof import("@/lib/auth")>(
+    "@/lib/auth",
+  );
+  return {
+    ...actual,
+    resolvePrincipal: mocks.resolvePrincipal,
+  };
+});
+
+import { NextRequest } from "next/server";
+import { POST as presignUpload } from "@/app/api/upload/presign/route";
+import { POST as completeUpload } from "@/app/api/upload/complete/route";
+import { issueRecordingUploadToken } from "@/lib/auth";
+
+function postJson(
+  path: string,
+  body: Record<string, unknown>,
+  headers: Record<string, string> = {},
+): NextRequest {
+  return new NextRequest(`http://localhost:3001${path}`, {
+    method: "POST",
+    headers: {
+      "content-type": "application/json",
+      ...headers,
+    },
+    body: JSON.stringify(body),
+  });
+}
+
+beforeEach(() => {
+  vi.stubEnv("AUTH_SECRET", "test-secret-for-recording-upload-token-123456");
+  mocks.sessions.clear();
+  mocks.recordingTakes.clear();
+  mocks.tracks.clear();
+  mocks.segments.clear();
+  mocks.sessions.add("s1");
+  vi.clearAllMocks();
+  mocks.resolvePrincipal.mockResolvedValue(null);
+});
+
+afterEach(() => {
+  vi.unstubAllEnvs();
+});
+
+describe("logical track segments", () => {
+  it("creates the first physical segment under the new logical track", async () => {
+    mocks.recordingTakes.set("take-1", {
+      id: "take-1",
+      sessionId: "s1",
+      startedAt: new Date("2026-06-11T00:00:00.000Z"),
+      stoppedAt: null,
+    });
+    mocks.resolvePrincipal.mockResolvedValue({
+      kind: "guest",
+      sessionId: "s1",
+      name: "Cookie Alice",
+      participantId: "guest_alice",
+    });
+
+    const res = await presignUpload(
+      postJson("/api/upload/presign", {
+        sessionId: "s1",
+        trackId: "track-1",
+        partNumber: 0,
+        participantName: "Renamed Alice",
+      }),
+    );
+
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as {
+      key: string;
+      segmentId: string;
+      trackId: string;
+    };
+    expect(body.trackId).toBe("track-1");
+    expect(body.segmentId).toBe("track-1");
+    expect(body.key).toBe("sessions/s1/tracks/track-1/0.webm");
+    expect(mocks.tracks.get("track-1")).toMatchObject({
+      takeId: "take-1",
+      participantId: "guest_alice",
+    });
+    expect(mocks.segments.get("track-1")).toMatchObject({
+      trackId: "track-1",
+      segmentIndex: 0,
+      s3Prefix: "sessions/s1/tracks/track-1/",
+      status: "recording",
+    });
+  });
+
+  it("reuses one logical track per participant and take for a later segment", async () => {
+    mocks.recordingTakes.set("take-1", {
+      id: "take-1",
+      sessionId: "s1",
+      startedAt: new Date("2026-06-11T00:00:00.000Z"),
+      stoppedAt: null,
+    });
+    mocks.tracks.set("logical-track", {
+      id: "logical-track",
+      sessionId: "s1",
+      takeId: "take-1",
+      participantName: "Alice",
+      participantId: "guest_alice",
+      s3Key: "sessions/s1/tracks/logical-track/recording.webm",
+      status: "recording",
+      durationMs: null,
+    });
+    mocks.segments.set("logical-track", {
+      id: "logical-track",
+      trackId: "logical-track",
+      segmentIndex: 0,
+      s3Prefix: "sessions/s1/tracks/logical-track/",
+      status: "recording",
+      durationMs: null,
+    });
+    mocks.resolvePrincipal.mockResolvedValue({
+      kind: "guest",
+      sessionId: "s1",
+      name: "Cookie Alice",
+      participantId: "guest_alice",
+    });
+
+    const res = await presignUpload(
+      postJson("/api/upload/presign", {
+        sessionId: "s1",
+        trackId: "new-browser-segment",
+        partNumber: 0,
+        participantName: "Alice Again",
+      }),
+    );
+
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as {
+      key: string;
+      segmentId: string;
+      trackId: string;
+    };
+    expect(body.trackId).toBe("logical-track");
+    expect(body.segmentId).toBe("new-browser-segment");
+    expect(body.key).toBe(
+      "sessions/s1/tracks/logical-track/segments/new-browser-segment/0.webm",
+    );
+    expect(mocks.tracks.has("new-browser-segment")).toBe(false);
+    expect(mocks.segments.get("new-browser-segment")).toMatchObject({
+      trackId: "logical-track",
+      segmentIndex: 1,
+      s3Prefix:
+        "sessions/s1/tracks/logical-track/segments/new-browser-segment/",
+      status: "recording",
+    });
+  });
+
+  it("marks the addressed segment complete when the upload completes", async () => {
+    mocks.tracks.set("track-1", {
+      id: "track-1",
+      sessionId: "s1",
+      participantName: "Alice",
+      participantId: "guest_alice",
+      s3Key: "sessions/s1/tracks/track-1/recording.webm",
+      status: "recording",
+      durationMs: null,
+    });
+    mocks.segments.set("track-1", {
+      id: "track-1",
+      trackId: "track-1",
+      segmentIndex: 0,
+      s3Prefix: "sessions/s1/tracks/track-1/",
+      status: "recording",
+      durationMs: null,
+    });
+    const recordingToken = await issueRecordingUploadToken("s1", "track-1");
+
+    const res = await completeUpload(
+      postJson(
+        "/api/upload/complete",
+        { sessionId: "s1", trackId: "track-1", segmentId: "track-1", durationMs: 12345 },
+        { "x-cozytrack-recording-token": recordingToken },
+      ),
+    );
+
+    expect(res.status).toBe(200);
+    expect(mocks.segments.get("track-1")).toMatchObject({
+      status: "complete",
+      durationMs: 12345,
+    });
+    expect(mocks.tracks.get("track-1")).toMatchObject({
+      status: "complete",
+      durationMs: 12345,
+    });
+    expect(mocks.deleteTrackSegmentChunks).toHaveBeenCalledWith(
+      "s1",
+      "track-1",
+      "track-1",
+    );
+  });
+});

--- a/tests/logical-track-segments.test.ts
+++ b/tests/logical-track-segments.test.ts
@@ -588,6 +588,87 @@ describe("logical track segments", () => {
     });
   });
 
+  it("rejects a chunk presign for a segment belonging to another track", async () => {
+    mocks.tracks.set("track-a", {
+      id: "track-a",
+      sessionId: "s1",
+      participantName: "Alice",
+      participantId: "guest_alice",
+      s3Key: "sessions/s1/tracks/track-a/recording.webm",
+      status: "recording",
+      durationMs: null,
+    });
+    mocks.tracks.set("track-b", {
+      id: "track-b",
+      sessionId: "s1",
+      participantName: "Bob",
+      participantId: "guest_bob",
+      s3Key: "sessions/s1/tracks/track-b/recording.webm",
+      status: "recording",
+      durationMs: null,
+    });
+    mocks.segments.set("track-a", {
+      id: "track-a",
+      trackId: "track-a",
+      segmentIndex: 0,
+      s3Prefix: "sessions/s1/tracks/track-a/",
+      status: "recording",
+      durationMs: null,
+    });
+    mocks.segments.set("seg-b", {
+      id: "seg-b",
+      trackId: "track-b",
+      segmentIndex: 1,
+      s3Prefix: "sessions/s1/tracks/track-b/segments/seg-b/",
+      status: "recording",
+      durationMs: null,
+    });
+    const recordingToken = await issueRecordingUploadToken("s1", "track-a");
+
+    // A track-scoped token must not mint writable URLs for another track's
+    // segment objects.
+    const res = await presignUpload(
+      postJson(
+        "/api/upload/presign",
+        { sessionId: "s1", trackId: "track-a", partNumber: 5, segmentId: "seg-b" },
+        { "x-cozytrack-recording-token": recordingToken },
+      ),
+    );
+
+    expect(res.status).toBe(403);
+  });
+
+  it("rejects a chunk presign for an unknown segment", async () => {
+    mocks.tracks.set("track-a", {
+      id: "track-a",
+      sessionId: "s1",
+      participantName: "Alice",
+      participantId: "guest_alice",
+      s3Key: "sessions/s1/tracks/track-a/recording.webm",
+      status: "recording",
+      durationMs: null,
+    });
+    mocks.segments.set("track-a", {
+      id: "track-a",
+      trackId: "track-a",
+      segmentIndex: 0,
+      s3Prefix: "sessions/s1/tracks/track-a/",
+      status: "recording",
+      durationMs: null,
+    });
+    const recordingToken = await issueRecordingUploadToken("s1", "track-a");
+
+    const res = await presignUpload(
+      postJson(
+        "/api/upload/presign",
+        { sessionId: "s1", trackId: "track-a", partNumber: 5, segmentId: "ghost" },
+        { "x-cozytrack-recording-token": recordingToken },
+      ),
+    );
+
+    expect(res.status).toBe(404);
+  });
+
   it("retries segment creation when a concurrent start claims the index", async () => {
     mocks.recordingTakes.set("take-1", {
       id: "take-1",

--- a/tests/recording-backup.test.ts
+++ b/tests/recording-backup.test.ts
@@ -124,7 +124,7 @@ describe("recording backup store", () => {
       "track-1",
       9999,
       undefined,
-      undefined,
+      { segmentId: "track-1" },
       "recording-token",
     );
     expect(uploadChunk).toHaveBeenCalledWith(
@@ -138,11 +138,112 @@ describe("recording backup store", () => {
       "track-1",
       undefined,
       "recording-token",
+      "track-1",
     );
     expect(retried.state).toBe("available");
     await expect(store.buildRecordingBlob(manifest.id)).resolves.toBeInstanceOf(
       Blob,
     );
+  });
+
+  it("retries a non-default segment upload to that segment, not the default key", async () => {
+    const store = new RecordingBackupStore(
+      new MemoryRecordingBackupBackend(true),
+    );
+    const manifest = await store.startBackup({
+      sessionId: "session-1",
+      trackId: "logical-track",
+      segmentId: "seg-2",
+      participantName: "Alice",
+      recordingToken: "recording-token",
+    });
+
+    expect(manifest).toMatchObject({
+      id: "session-1:seg-2",
+      trackId: "logical-track",
+      segmentId: "seg-2",
+    });
+
+    await store.saveChunk({
+      sessionId: "session-1",
+      trackId: "logical-track",
+      segmentId: "seg-2",
+      chunkIndex: 0,
+      chunk: blob("second-take"),
+    });
+    const failed = await store.markBackupFailed(
+      manifest.id,
+      new Error("final upload failed"),
+    );
+
+    const getPresignedUploadUrl = vi
+      .fn()
+      .mockResolvedValue("https://s3.example/final");
+    const uploadChunk = vi.fn().mockResolvedValue(undefined);
+    const completeUpload = vi.fn().mockResolvedValue(undefined);
+
+    await retryLocalRecordingBackupUpload(failed, {
+      backupStore: store,
+      getPresignedUploadUrl,
+      uploadChunk,
+      completeUpload,
+    });
+
+    expect(getPresignedUploadUrl).toHaveBeenCalledWith(
+      "session-1",
+      "logical-track",
+      9999,
+      undefined,
+      { segmentId: "seg-2" },
+      "recording-token",
+    );
+    expect(completeUpload).toHaveBeenCalledWith(
+      "session-1",
+      "logical-track",
+      undefined,
+      "recording-token",
+      "seg-2",
+    );
+  });
+
+  it("keeps per-segment backups separate for the same logical track", async () => {
+    const store = new RecordingBackupStore(
+      new MemoryRecordingBackupBackend(true),
+    );
+
+    const firstTake = await store.startBackup({
+      sessionId: "session-1",
+      trackId: "logical-track",
+      participantName: "Alice",
+    });
+    await store.saveChunk({
+      sessionId: "session-1",
+      trackId: "logical-track",
+      chunkIndex: 0,
+      chunk: blob("take-one"),
+    });
+
+    const secondTake = await store.startBackup({
+      sessionId: "session-1",
+      trackId: "logical-track",
+      segmentId: "seg-2",
+      participantName: "Alice",
+    });
+    await store.saveChunk({
+      sessionId: "session-1",
+      trackId: "logical-track",
+      segmentId: "seg-2",
+      chunkIndex: 0,
+      chunk: blob("take-two"),
+    });
+
+    // Re-recording the same logical track must not clobber the previous
+    // attempt's local backup — it may still be pending a retry.
+    expect(secondTake.id).not.toBe(firstTake.id);
+    const firstBlob = await store.buildRecordingBlob(firstTake.id);
+    expect(await firstBlob.text()).toBe("take-one");
+    const secondBlob = await store.buildRecordingBlob(secondTake.id);
+    expect(await secondBlob.text()).toBe("take-two");
   });
 
   it("clears local chunks only for explicit user or verified-upload cleanup", async () => {

--- a/tests/recovery.test.ts
+++ b/tests/recovery.test.ts
@@ -15,6 +15,7 @@ type TrackSegment = {
   status: string;
   durationMs: number | null;
   completedAt?: Date | null;
+  createdAt: Date;
 };
 
 const trackStore = new Map<string, Track>();
@@ -126,6 +127,36 @@ vi.mock("@/lib/s3", () => ({
           : `sessions/${sessionId}/tracks/${trackId}/segments/${segmentId}/recording.webm`
       )
   ),
+  listTrackSegmentChunkParts: vi.fn(
+    async (sessionId: string, trackId: string, segmentId: string) => {
+      const prefix =
+        segmentId === trackId
+          ? `sessions/${sessionId}/tracks/${trackId}/`
+          : `sessions/${sessionId}/tracks/${trackId}/segments/${segmentId}/`;
+      const pattern = /^(\d+)\.webm$/;
+      const parts: {
+        partNumber: number;
+        key: string;
+        size: number;
+        lastModified?: Date;
+      }[] = [];
+      for (const key of s3Objects.keys()) {
+        if (!key.startsWith(prefix)) continue;
+        const m = pattern.exec(key.slice(prefix.length));
+        if (!m) continue;
+        const partNumber = Number(m[1]);
+        if (partNumber === 9999) continue;
+        parts.push({
+          partNumber,
+          key,
+          size: s3Objects.get(key)?.byteLength ?? 0,
+          lastModified: s3Timestamps.get(key),
+        });
+      }
+      parts.sort((a, b) => a.partNumber - b.partNumber);
+      return parts;
+    }
+  ),
   listTrackChunkParts: vi.fn(async (sessionId: string, trackId: string) => {
     const prefix = `sessions/${sessionId}/tracks/${trackId}/`;
     const pattern = /^(\d+)\.webm$/;
@@ -194,6 +225,7 @@ function seedSegment(overrides: Partial<TrackSegment> = {}): TrackSegment {
     segmentIndex: 0,
     status: "recording",
     durationMs: null,
+    createdAt: new Date(0),
     ...overrides,
   };
   segmentStore.set(s.id, s);
@@ -437,6 +469,100 @@ describe("recoverTrack", () => {
     // The segment row must agree with the track, otherwise a later segment
     // completion would see this one as forever-pending.
     expect(segmentStore.get("t1")?.status).toBe("complete");
+  });
+
+  it("stays pending while the newest segment is a fresh in-flight attempt", async () => {
+    seedTrack({ status: "uploading" });
+    seedSegment({ id: "t1", segmentIndex: 0, status: "complete" });
+    // A re-record just started: row created moments ago, no final blob yet.
+    seedSegment({
+      id: "seg-2",
+      segmentIndex: 1,
+      status: "recording",
+      createdAt: new Date(),
+    });
+    s3Objects.set(
+      "sessions/s1/tracks/t1/recording.webm",
+      new Uint8Array([1, 2, 3])
+    );
+
+    const result = await recoverTrack("t1", { chunkStitchMinAgeMs: 30_000 });
+
+    // Completing from the older segment here would finalize the session with
+    // stale audio while the participant is still recording.
+    expect(result.outcome).toBe("skipped_active");
+    expect(trackStore.get("t1")?.status).toBe("uploading");
+    expect(putCalls).toHaveLength(0);
+  });
+
+  it("stays pending while the newest segment has fresh chunk uploads", async () => {
+    seedTrack({ status: "uploading" });
+    seedSegment({ id: "t1", segmentIndex: 0, status: "complete" });
+    seedSegment({ id: "seg-2", segmentIndex: 1, status: "recording" });
+    s3Objects.set(
+      "sessions/s1/tracks/t1/recording.webm",
+      new Uint8Array([1, 2, 3])
+    );
+    putS3(
+      "sessions/s1/tracks/t1/segments/seg-2/0.webm",
+      new Uint8Array([0xaa]),
+      new Date(Date.now() - 5_000)
+    );
+
+    const result = await recoverTrack("t1", { chunkStitchMinAgeMs: 30_000 });
+
+    expect(result.outcome).toBe("skipped_active");
+    expect(trackStore.get("t1")?.status).toBe("uploading");
+  });
+
+  it("falls back to an older complete segment only once the newest is stale, flagging partial", async () => {
+    seedTrack({ status: "uploading" });
+    seedSegment({ id: "t1", segmentIndex: 0, status: "complete" });
+    // The re-record died long ago without producing a final blob.
+    seedSegment({
+      id: "seg-2",
+      segmentIndex: 1,
+      status: "recording",
+      createdAt: new Date(Date.now() - 600_000),
+    });
+    s3Objects.set(
+      "sessions/s1/tracks/t1/recording.webm",
+      new Uint8Array([1, 2, 3])
+    );
+
+    const result = await recoverTrack("t1", { chunkStitchMinAgeMs: 30_000 });
+
+    expect(result.outcome).toBe("recovered_from_recording");
+    expect(result.partial).toBe(true);
+    // The newest attempt's audio is missing, so the recovered track must be
+    // flagged partial rather than silently passing off the older recording.
+    expect(trackStore.get("t1")).toMatchObject({
+      status: "complete",
+      s3Key: "sessions/s1/tracks/t1/recording.webm",
+      partial: true,
+    });
+  });
+
+  it("flags partial when stitching default chunks under a dead newer segment", async () => {
+    seedTrack({ status: "uploading" });
+    seedSegment({ id: "t1", segmentIndex: 0, status: "recording" });
+    seedSegment({
+      id: "seg-2",
+      segmentIndex: 1,
+      status: "recording",
+      createdAt: new Date(Date.now() - 600_000),
+    });
+    putS3("sessions/s1/tracks/t1/0.webm", new Uint8Array([0xaa]), new Date(0));
+    putS3("sessions/s1/tracks/t1/1.webm", new Uint8Array([0xbb]), new Date(0));
+
+    const result = await recoverTrack("t1", { chunkStitchMinAgeMs: 30_000 });
+
+    expect(result.outcome).toBe("recovered_partial");
+    expect(result.partial).toBe(true);
+    expect(trackStore.get("t1")).toMatchObject({
+      status: "complete",
+      partial: true,
+    });
   });
 
   it("marks failed_too_large when chunk bytes exceed the configured cap", async () => {

--- a/tests/recovery.test.ts
+++ b/tests/recovery.test.ts
@@ -543,6 +543,81 @@ describe("recoverTrack", () => {
     });
   });
 
+  it("stitches the newest segment's chunks when its final blob is missing", async () => {
+    seedTrack({ status: "uploading" });
+    seedSegment({ id: "t1", segmentIndex: 0, status: "complete" });
+    // The re-record died after uploading chunks but before the final blob.
+    seedSegment({
+      id: "seg-2",
+      segmentIndex: 1,
+      status: "recording",
+      createdAt: new Date(Date.now() - 600_000),
+    });
+    s3Objects.set(
+      "sessions/s1/tracks/t1/recording.webm",
+      new Uint8Array([1, 2, 3])
+    );
+    putS3(
+      "sessions/s1/tracks/t1/segments/seg-2/0.webm",
+      new Uint8Array([0xaa, 0xaa]),
+      new Date(Date.now() - 600_000)
+    );
+    putS3(
+      "sessions/s1/tracks/t1/segments/seg-2/1.webm",
+      new Uint8Array([0xbb, 0xbb]),
+      new Date(Date.now() - 600_000)
+    );
+
+    const result = await recoverTrack("t1", { chunkStitchMinAgeMs: 30_000 });
+
+    // The chunks are the newest attempt's audio — falling back to the older
+    // segment would discard a recoverable recording.
+    expect(result.outcome).toBe("recovered_from_chunks");
+    expect(result.partial).toBe(false);
+    expect(
+      s3Objects.get("sessions/s1/tracks/t1/segments/seg-2/recording.webm")
+    ).toEqual(new Uint8Array([0xaa, 0xaa, 0xbb, 0xbb]));
+    expect(segmentStore.get("seg-2")?.status).toBe("complete");
+    expect(trackStore.get("t1")).toMatchObject({
+      status: "complete",
+      s3Key: "sessions/s1/tracks/t1/segments/seg-2/recording.webm",
+      partial: false,
+    });
+  });
+
+  it("flags partial when the newest segment stitch has gaps", async () => {
+    seedTrack({ status: "uploading" });
+    seedSegment({ id: "t1", segmentIndex: 0, status: "recording" });
+    seedSegment({
+      id: "seg-2",
+      segmentIndex: 1,
+      status: "recording",
+      createdAt: new Date(Date.now() - 600_000),
+    });
+    putS3(
+      "sessions/s1/tracks/t1/segments/seg-2/0.webm",
+      new Uint8Array([0xaa]),
+      new Date(Date.now() - 600_000)
+    );
+    // Chunk 1 never landed.
+    putS3(
+      "sessions/s1/tracks/t1/segments/seg-2/2.webm",
+      new Uint8Array([0xcc]),
+      new Date(Date.now() - 600_000)
+    );
+
+    const result = await recoverTrack("t1", { chunkStitchMinAgeMs: 30_000 });
+
+    expect(result.outcome).toBe("recovered_partial");
+    expect(result.partial).toBe(true);
+    expect(result.missingPartNumbers).toEqual([1]);
+    expect(trackStore.get("t1")).toMatchObject({
+      status: "complete",
+      s3Key: "sessions/s1/tracks/t1/segments/seg-2/recording.webm",
+      partial: true,
+    });
+  });
+
   it("flags partial when stitching default chunks under a dead newer segment", async () => {
     seedTrack({ status: "uploading" });
     seedSegment({ id: "t1", segmentIndex: 0, status: "recording" });

--- a/tests/recovery.test.ts
+++ b/tests/recovery.test.ts
@@ -8,7 +8,17 @@ type Track = {
   partial: boolean;
 };
 
+type TrackSegment = {
+  id: string;
+  trackId: string;
+  segmentIndex: number;
+  status: string;
+  durationMs: number | null;
+  completedAt?: Date | null;
+};
+
 const trackStore = new Map<string, Track>();
+const segmentStore = new Map<string, TrackSegment>();
 const s3Objects = new Map<string, Uint8Array>();
 const s3Timestamps = new Map<string, Date>();
 const putCalls: { key: string; bytes: Uint8Array }[] = [];
@@ -55,6 +65,38 @@ vi.mock("@/lib/db", () => ({
         }
       ),
     },
+    trackSegment: {
+      findMany: vi.fn(
+        async ({
+          where: { trackId },
+          orderBy,
+        }: {
+          where: { trackId: string };
+          orderBy?: { segmentIndex: "asc" | "desc" };
+        }) => {
+          const list = Array.from(segmentStore.values())
+            .filter((segment) => segment.trackId === trackId)
+            .sort((a, b) => a.segmentIndex - b.segmentIndex)
+            .map((segment) => structuredClone(segment));
+          if (orderBy?.segmentIndex === "desc") list.reverse();
+          return list;
+        }
+      ),
+      updateMany: vi.fn(
+        async ({
+          where: { id },
+          data,
+        }: {
+          where: { id: string };
+          data: Partial<TrackSegment>;
+        }) => {
+          const existing = segmentStore.get(id);
+          if (!existing) return { count: 0 };
+          segmentStore.set(id, { ...existing, ...data });
+          return { count: 1 };
+        }
+      ),
+    },
   },
 }));
 
@@ -67,6 +109,22 @@ vi.mock("@/lib/s3", () => ({
     s3Objects.has(
       `sessions/${sessionId}/tracks/${trackId}/recording.webm`
     )
+  ),
+  trackSegmentRecordingKey: (
+    sessionId: string,
+    trackId: string,
+    segmentId: string
+  ) =>
+    segmentId === trackId
+      ? `sessions/${sessionId}/tracks/${trackId}/recording.webm`
+      : `sessions/${sessionId}/tracks/${trackId}/segments/${segmentId}/recording.webm`,
+  trackSegmentRecordingExists: vi.fn(
+    async (sessionId: string, trackId: string, segmentId: string) =>
+      s3Objects.has(
+        segmentId === trackId
+          ? `sessions/${sessionId}/tracks/${trackId}/recording.webm`
+          : `sessions/${sessionId}/tracks/${trackId}/segments/${segmentId}/recording.webm`
+      )
   ),
   listTrackChunkParts: vi.fn(async (sessionId: string, trackId: string) => {
     const prefix = `sessions/${sessionId}/tracks/${trackId}/`;
@@ -109,6 +167,7 @@ import { recoverTrack } from "@/lib/recovery";
 
 beforeEach(() => {
   trackStore.clear();
+  segmentStore.clear();
   s3Objects.clear();
   s3Timestamps.clear();
   putCalls.length = 0;
@@ -126,6 +185,19 @@ function seedTrack(overrides: Partial<Track> = {}): Track {
   };
   trackStore.set(t.id, t);
   return t;
+}
+
+function seedSegment(overrides: Partial<TrackSegment> = {}): TrackSegment {
+  const s: TrackSegment = {
+    id: "t1",
+    trackId: "t1",
+    segmentIndex: 0,
+    status: "recording",
+    durationMs: null,
+    ...overrides,
+  };
+  segmentStore.set(s.id, s);
+  return s;
 }
 
 describe("recoverTrack", () => {
@@ -304,6 +376,67 @@ describe("recoverTrack", () => {
 
     expect(result.outcome).toBe("recovered_from_recording");
     expect(trackStore.get("t1")?.status).toBe("complete");
+  });
+
+  it("recovers a stuck multi-segment track to the latest complete segment", async () => {
+    seedTrack({ status: "uploading" });
+    seedSegment({ id: "t1", segmentIndex: 0, status: "complete" });
+    seedSegment({ id: "seg-2", segmentIndex: 1, status: "complete", durationMs: 5000 });
+    s3Objects.set(
+      "sessions/s1/tracks/t1/recording.webm",
+      new Uint8Array([1, 2, 3])
+    );
+    s3Objects.set(
+      "sessions/s1/tracks/t1/segments/seg-2/recording.webm",
+      new Uint8Array([4, 5, 6])
+    );
+
+    const result = await recoverTrack("t1");
+
+    expect(result.outcome).toBe("recovered_from_recording");
+    // Latest-wins: the newest segment's audio is the authoritative artifact,
+    // not the default segment's older recording.
+    expect(trackStore.get("t1")).toMatchObject({
+      status: "complete",
+      s3Key: "sessions/s1/tracks/t1/segments/seg-2/recording.webm",
+    });
+    expect(putCalls).toHaveLength(0);
+  });
+
+  it("completes from a non-default segment recording when only it exists", async () => {
+    seedTrack({ status: "uploading" });
+    seedSegment({ id: "t1", segmentIndex: 0, status: "recording" });
+    seedSegment({ id: "seg-2", segmentIndex: 1, status: "uploading" });
+    // The client uploaded the segment blob but died before calling complete.
+    s3Objects.set(
+      "sessions/s1/tracks/t1/segments/seg-2/recording.webm",
+      new Uint8Array([4, 5, 6])
+    );
+
+    const result = await recoverTrack("t1");
+
+    expect(result.outcome).toBe("recovered_from_recording");
+    expect(trackStore.get("t1")).toMatchObject({
+      status: "complete",
+      s3Key: "sessions/s1/tracks/t1/segments/seg-2/recording.webm",
+    });
+    expect(segmentStore.get("seg-2")?.status).toBe("complete");
+    expect(putCalls).toHaveLength(0);
+  });
+
+  it("marks the default segment complete when stitching default chunks", async () => {
+    seedTrack();
+    seedSegment({ id: "t1", segmentIndex: 0, status: "recording" });
+    s3Objects.set("sessions/s1/tracks/t1/0.webm", new Uint8Array([0xaa]));
+    s3Objects.set("sessions/s1/tracks/t1/1.webm", new Uint8Array([0xbb]));
+
+    const result = await recoverTrack("t1");
+
+    expect(result.outcome).toBe("recovered_from_chunks");
+    expect(trackStore.get("t1")?.status).toBe("complete");
+    // The segment row must agree with the track, otherwise a later segment
+    // completion would see this one as forever-pending.
+    expect(segmentStore.get("t1")?.status).toBe("complete");
   });
 
   it("marks failed_too_large when chunk bytes exceed the configured cap", async () => {

--- a/tests/upload-auth.test.ts
+++ b/tests/upload-auth.test.ts
@@ -3,6 +3,7 @@ import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 type Track = {
   id: string;
   sessionId: string;
+  takeId?: string | null;
   participantName: string;
   participantId?: string | null;
   s3Key: string;
@@ -10,11 +11,22 @@ type Track = {
   durationMs: number | null;
 };
 
+type TrackSegment = {
+  id: string;
+  trackId: string;
+  segmentIndex: number;
+  s3Prefix: string;
+  status: string;
+  durationMs: number | null;
+  completedAt?: Date | null;
+};
+
 const mocks = vi.hoisted(() => ({
   sessions: new Set<string>(),
   tracks: new Map<string, Track>(),
+  segments: new Map<string, TrackSegment>(),
   getPresignedPutUrl: vi.fn(async (key: string) => `https://s3.example/${key}`),
-  deleteTrackChunks: vi.fn(async () => undefined),
+  deleteTrackSegmentChunks: vi.fn(async () => undefined),
   resolvePrincipal: vi.fn(),
 }));
 
@@ -25,11 +37,34 @@ vi.mock("@/lib/db", () => ({
         mocks.sessions.has(id) ? { id } : null,
       ),
     },
+    recordingTake: {
+      findFirst: vi.fn(async () => null),
+    },
     track: {
       findUnique: vi.fn(
         async ({ where: { id } }: { where: { id: string } }) => {
           const track = mocks.tracks.get(id);
           return track ? { ...track } : null;
+        },
+      ),
+      findFirst: vi.fn(
+        async ({
+          where: { sessionId, takeId, participantId },
+        }: {
+          where: {
+            sessionId: string;
+            takeId?: string | null;
+            participantId?: string | null;
+          };
+        }) => {
+          return (
+            Array.from(mocks.tracks.values()).find(
+              (track) =>
+                track.sessionId === sessionId &&
+                track.takeId === takeId &&
+                track.participantId === participantId,
+            ) ?? null
+          );
         },
       ),
       create: vi.fn(async ({ data }: { data: Track }) => {
@@ -53,16 +88,69 @@ vi.mock("@/lib/db", () => ({
         },
       ),
     },
+    trackSegment: {
+      count: vi.fn(
+        async ({ where: { trackId } }: { where: { trackId: string } }) =>
+          Array.from(mocks.segments.values()).filter(
+            (segment) => segment.trackId === trackId,
+          ).length,
+      ),
+      findUnique: vi.fn(
+        async ({ where: { id } }: { where: { id: string } }) => {
+          const segment = mocks.segments.get(id);
+          return segment ? { ...segment } : null;
+        },
+      ),
+      create: vi.fn(async ({ data }: { data: TrackSegment }) => {
+        const segment = { ...data, status: "recording", durationMs: null };
+        mocks.segments.set(segment.id, segment);
+        return { ...segment };
+      }),
+      update: vi.fn(
+        async ({
+          where: { id },
+          data,
+        }: {
+          where: { id: string };
+          data: Partial<TrackSegment>;
+        }) => {
+          const existing = mocks.segments.get(id);
+          if (!existing) throw new Error("segment not found");
+          const updated = { ...existing, ...data };
+          mocks.segments.set(id, updated);
+          return { ...updated };
+        },
+      ),
+    },
   },
 }));
 
 vi.mock("@/lib/s3", () => ({
   getPresignedPutUrl: mocks.getPresignedPutUrl,
-  deleteTrackChunks: mocks.deleteTrackChunks,
-  trackPartKey: (sessionId: string, trackId: string, partNumber: number) =>
-    `sessions/${sessionId}/tracks/${trackId}/${partNumber}.webm`,
+  deleteTrackSegmentChunks: mocks.deleteTrackSegmentChunks,
   trackRecordingKey: (sessionId: string, trackId: string) =>
     `sessions/${sessionId}/tracks/${trackId}/recording.webm`,
+  trackSegmentPrefix: (sessionId: string, trackId: string, segmentId: string) =>
+    segmentId === trackId
+      ? `sessions/${sessionId}/tracks/${trackId}/`
+      : `sessions/${sessionId}/tracks/${trackId}/segments/${segmentId}/`,
+  trackSegmentPartKey: (
+    sessionId: string,
+    trackId: string,
+    segmentId: string,
+    partNumber: number,
+  ) =>
+    segmentId === trackId
+      ? `sessions/${sessionId}/tracks/${trackId}/${partNumber}.webm`
+      : `sessions/${sessionId}/tracks/${trackId}/segments/${segmentId}/${partNumber}.webm`,
+  trackSegmentRecordingKey: (
+    sessionId: string,
+    trackId: string,
+    segmentId: string,
+  ) =>
+    segmentId === trackId
+      ? `sessions/${sessionId}/tracks/${trackId}/recording.webm`
+      : `sessions/${sessionId}/tracks/${trackId}/segments/${segmentId}/recording.webm`,
 }));
 
 vi.mock("@/lib/auth", async () => {
@@ -99,6 +187,7 @@ beforeEach(() => {
   vi.stubEnv("AUTH_SECRET", "test-secret-for-recording-upload-token-123456");
   mocks.sessions.clear();
   mocks.tracks.clear();
+  mocks.segments.clear();
   mocks.sessions.add("s1");
   vi.clearAllMocks();
   mocks.resolvePrincipal.mockResolvedValue(null);
@@ -285,6 +374,14 @@ describe("recording upload auth", () => {
       status: "recording",
       durationMs: null,
     });
+    mocks.segments.set("t1", {
+      id: "t1",
+      trackId: "t1",
+      segmentIndex: 0,
+      s3Prefix: "sessions/s1/tracks/t1/",
+      status: "recording",
+      durationMs: null,
+    });
     const recordingToken = await issueRecordingUploadToken("s1", "t1");
 
     const res = await completeUpload(
@@ -300,7 +397,7 @@ describe("recording upload auth", () => {
       status: "complete",
       durationMs: 12345,
     });
-    expect(mocks.deleteTrackChunks).toHaveBeenCalledWith("s1", "t1");
+    expect(mocks.deleteTrackSegmentChunks).toHaveBeenCalledWith("s1", "t1", "t1");
   });
 
   it("forbids completing a track outside the requested session", async () => {
@@ -309,6 +406,14 @@ describe("recording upload auth", () => {
       sessionId: "other-session",
       participantName: "Alice",
       s3Key: "sessions/other-session/tracks/t1/recording.webm",
+      status: "recording",
+      durationMs: null,
+    });
+    mocks.segments.set("t1", {
+      id: "t1",
+      trackId: "t1",
+      segmentIndex: 0,
+      s3Prefix: "sessions/other-session/tracks/t1/",
       status: "recording",
       durationMs: null,
     });

--- a/tests/upload-auth.test.ts
+++ b/tests/upload-auth.test.ts
@@ -87,6 +87,44 @@ vi.mock("@/lib/db", () => ({
           return { ...updated };
         },
       ),
+      updateMany: vi.fn(
+        async ({
+          where,
+          data,
+        }: {
+          where: {
+            id: string;
+            status?: { not?: string; in?: string[] };
+            segments?: { none: { segmentIndex: { gt: number } } };
+          };
+          data: Partial<Track>;
+        }) => {
+          const existing = mocks.tracks.get(where.id);
+          if (!existing) return { count: 0 };
+          if (
+            where.status?.not !== undefined &&
+            existing.status === where.status.not
+          ) {
+            return { count: 0 };
+          }
+          if (
+            where.status?.in !== undefined &&
+            !where.status.in.includes(existing.status)
+          ) {
+            return { count: 0 };
+          }
+          const noneGt = where.segments?.none?.segmentIndex?.gt;
+          if (noneGt !== undefined) {
+            const hasNewer = Array.from(mocks.segments.values()).some(
+              (segment) =>
+                segment.trackId === where.id && segment.segmentIndex > noneGt,
+            );
+            if (hasNewer) return { count: 0 };
+          }
+          mocks.tracks.set(where.id, { ...existing, ...data });
+          return { count: 1 };
+        },
+      ),
     },
     trackSegment: {
       count: vi.fn(

--- a/tests/upload-auth.test.ts
+++ b/tests/upload-auth.test.ts
@@ -101,6 +101,22 @@ vi.mock("@/lib/db", () => ({
           return segment ? { ...segment } : null;
         },
       ),
+      findMany: vi.fn(
+        async ({
+          where: { trackId },
+          orderBy,
+        }: {
+          where: { trackId: string };
+          orderBy?: { segmentIndex: "asc" | "desc" };
+        }) => {
+          const list = Array.from(mocks.segments.values())
+            .filter((segment) => segment.trackId === trackId)
+            .sort((a, b) => a.segmentIndex - b.segmentIndex)
+            .map((segment) => ({ ...segment }));
+          if (orderBy?.segmentIndex === "desc") list.reverse();
+          return list;
+        },
+      ),
       create: vi.fn(async ({ data }: { data: TrackSegment }) => {
         const segment = { ...data, status: "recording", durationMs: null };
         mocks.segments.set(segment.id, segment);

--- a/tests/upload-client.test.ts
+++ b/tests/upload-client.test.ts
@@ -29,6 +29,8 @@ describe("upload client auth", () => {
       jsonResponse({
         url: "https://s3.example/chunk-0",
         recordingToken: "recording-token",
+        trackId: "logical-track",
+        segmentId: "segment-1",
       }),
     );
 
@@ -42,6 +44,8 @@ describe("upload client auth", () => {
     expect(target).toEqual({
       url: "https://s3.example/chunk-0",
       recordingToken: "recording-token",
+      trackId: "logical-track",
+      segmentId: "segment-1",
     });
   });
 


### PR DESCRIPTION
## Summary

- Add Track.takeId and internal TrackSegment rows with a migration/backfill for existing single-segment tracks.
- Make upload presign reuse one logical track per participant per active take while storing new browser-created blobs as physical segments.
- Return logical track and segment ids through the upload client and keep the studio chunk/final uploads scoped to the resolved segment.
- Mark addressed segments complete on upload completion while keeping session/detail/downstream APIs track-oriented.

## Scope

Closes #120.
Refs #111.
Unblocks later reconnect/resume work in #75.

This does not add media stitching/materialization or reconnect auto-resume.

## Verification

- npm run db:generate
- npm test -- tests/logical-track-segments.test.ts tests/upload-auth.test.ts tests/upload-client.test.ts
- npm run typecheck
- npm test
- npm run lint
- npm run build
- COZYTRACK_INTEGRATION_TEST=1 with safe local Postgres/MinIO overrides, npm run test:integration
- npm run test:browser