### PR TITLE
[codex] Restore path-gated Codex reviews

### DIFF
--- a/.github/workflows/codex-review.yml
+++ b/.github/workflows/codex-review.yml
@@ -1,6 +1,12 @@
 name: Codex review
 
 on:
+  pull_request:
+    types: [opened, synchronize, ready_for_review, reopened]
+    paths-ignore:
+      - "*.md"
+      - "**/*.md"
+      - "docs/**"
   issue_comment:
     types: [created]
 
@@ -8,9 +14,17 @@ jobs:
   codex:
     if: >-
       ${{
-        github.event.issue.pull_request &&
-        startsWith(github.event.comment.body, '/codex review') &&
-        contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.comment.author_association)
+        (
+          github.event_name == 'pull_request' &&
+          github.event.pull_request.draft == false &&
+          github.event.pull_request.user.type != 'Bot'
+        ) ||
+        (
+          github.event_name == 'issue_comment' &&
+          github.event.issue.pull_request &&
+          startsWith(github.event.comment.body, '/codex review') &&
+          contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.comment.author_association)
+        )
       }}
     runs-on: ubuntu-latest
     permissions:
@@ -24,13 +38,17 @@ jobs:
         uses: actions/github-script@v7
         with:
           script: |
-            const prNumber = context.payload.issue.number;
+            const prNumber = context.eventName === "pull_request"
+              ? context.payload.pull_request.number
+              : context.payload.issue.number;
 
-            const pr = (await github.rest.pulls.get({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              pull_number: prNumber,
-            })).data;
+            const pr = context.eventName === "pull_request"
+              ? context.payload.pull_request
+              : (await github.rest.pulls.get({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  pull_number: prNumber,
+                })).data;
 
             core.setOutput("number", String(pr.number));
             core.setOutput("base_ref", pr.base.ref);

--- a/.github/workflows/codex-review.yml
+++ b/.github/workflows/codex-review.yml
@@ -7,6 +7,23 @@ on:
       - "*.md"
       - "**/*.md"
       - "docs/**"
+      - ".gitignore"
+      - ".gitattributes"
+      - ".editorconfig"
+      - ".github/ISSUE_TEMPLATE/**"
+      - ".github/PULL_REQUEST_TEMPLATE.md"
+      - "*.png"
+      - "**/*.png"
+      - "*.jpg"
+      - "**/*.jpg"
+      - "*.jpeg"
+      - "**/*.jpeg"
+      - "*.gif"
+      - "**/*.gif"
+      - "*.webp"
+      - "**/*.webp"
+      - "*.avif"
+      - "**/*.avif"
   issue_comment:
     types: [created]
 

--- a/.github/workflows/pr-gate.yml
+++ b/.github/workflows/pr-gate.yml
@@ -68,8 +68,20 @@ jobs:
 
             const docsOnly = names.length > 0 && names.every(isDocsOnlyFile);
             const baseline = !docsOnly;
-            const automaticCodexReview =
+            const codexReviewPathEligible =
               names.length > 0 && !names.every(isAutomaticCodexReviewIgnoredFile);
+            const codexReviewReady =
+              context.payload.pull_request.draft === false &&
+              context.payload.pull_request.user?.type !== "Bot";
+            const automaticCodexReview =
+              codexReviewPathEligible && codexReviewReady;
+            const codexReviewSummary = automaticCodexReview
+              ? "runs automatically; manual via `/codex review`"
+              : !codexReviewPathEligible
+                ? "skipped for docs/metadata/assets-only changes; manual via `/codex review`"
+                : context.payload.pull_request.draft
+                  ? "skipped for draft PRs; manual via `/codex review`"
+                  : "skipped for bot-authored PRs; manual via `/codex review`";
             const serviceIntegration = names.some(touchesServiceIntegration);
             const browserSmoke = names.some(touchesBrowserSmoke);
             const tier = docsOnly
@@ -92,7 +104,7 @@ jobs:
               `| Baseline validation | ${baseline ? "runs" : "skipped for docs-only changes"} |`,
               `| Browser recording smoke | ${browserSmoke ? "runs" : "skipped"} |`,
               `| Prisma and storage integration | ${serviceIntegration ? "runs" : "skipped"} |`,
-              `| Codex review | ${automaticCodexReview ? "runs automatically; manual via `/codex review`" : "skipped for docs/metadata/assets-only changes; manual via `/codex review`"} |`,
+              `| Codex review | ${codexReviewSummary} |`,
               "",
               "<details>",
               "<summary>Changed files</summary>",

--- a/.github/workflows/pr-gate.yml
+++ b/.github/workflows/pr-gate.yml
@@ -29,6 +29,12 @@ jobs:
             const isDocsOnlyFile = (name) =>
               name.endsWith(".md") ||
               name.startsWith("docs/");
+            const isAutomaticCodexReviewIgnoredFile = (name) =>
+              isDocsOnlyFile(name) ||
+              [".gitignore", ".gitattributes", ".editorconfig"].includes(name) ||
+              name.startsWith(".github/ISSUE_TEMPLATE/") ||
+              name === ".github/PULL_REQUEST_TEMPLATE.md" ||
+              /\.(png|jpe?g|gif|webp|avif)$/i.test(name);
 
             const touchesServiceIntegration = (name) =>
               name === ".github/workflows/service-integration.yml" ||
@@ -62,6 +68,8 @@ jobs:
 
             const docsOnly = names.length > 0 && names.every(isDocsOnlyFile);
             const baseline = !docsOnly;
+            const automaticCodexReview =
+              names.length > 0 && !names.every(isAutomaticCodexReviewIgnoredFile);
             const serviceIntegration = names.some(touchesServiceIntegration);
             const browserSmoke = names.some(touchesBrowserSmoke);
             const tier = docsOnly
@@ -84,7 +92,7 @@ jobs:
               `| Baseline validation | ${baseline ? "runs" : "skipped for docs-only changes"} |`,
               `| Browser recording smoke | ${browserSmoke ? "runs" : "skipped"} |`,
               `| Prisma and storage integration | ${serviceIntegration ? "runs" : "skipped"} |`,
-              `| Codex review | ${baseline ? "runs automatically; manual via `/codex review`" : "skipped for docs-only changes; manual via `/codex review`"} |`,
+              `| Codex review | ${automaticCodexReview ? "runs automatically; manual via `/codex review`" : "skipped for docs/metadata/assets-only changes; manual via `/codex review`"} |`,
               "",
               "<details>",
               "<summary>Changed files</summary>",

--- a/.github/workflows/pr-gate.yml
+++ b/.github/workflows/pr-gate.yml
@@ -84,7 +84,7 @@ jobs:
               `| Baseline validation | ${baseline ? "runs" : "skipped for docs-only changes"} |`,
               `| Browser recording smoke | ${browserSmoke ? "runs" : "skipped"} |`,
               `| Prisma and storage integration | ${serviceIntegration ? "runs" : "skipped"} |`,
-              "| Codex review | manual via `/codex review` |",
+              `| Codex review | ${baseline ? "runs automatically; manual via `/codex review`" : "skipped for docs-only changes; manual via `/codex review`"} |`,
               "",
               "<details>",
               "<summary>Changed files</summary>",


### PR DESCRIPTION
## Summary

- Restore automatic Codex review for PRs that touch review-worthy paths.
- Skip automatic Codex review for docs-only, inert repository metadata, PR/issue templates, and common raster asset changes.
- Preserve manual `/codex review` as an override for skipped PRs.
- Update the PR gate summary so it reports the same Codex review expectation as the workflow trigger.

## Verification

- Workflow YAML parse for all `.github/workflows/*.yml` files.
- `git diff --check`