### PR TITLE
[codex] Report fork Codex review skips

### DIFF
--- a/.github/workflows/pr-gate.yml
+++ b/.github/workflows/pr-gate.yml
@@ -70,18 +70,28 @@ jobs:
             const baseline = !docsOnly;
             const codexReviewPathEligible =
               names.length > 0 && !names.every(isAutomaticCodexReviewIgnoredFile);
+            const codexReviewSameRepo =
+              context.payload.pull_request.head.repo?.full_name ===
+              `${context.repo.owner}/${context.repo.repo}`;
             const codexReviewReady =
               context.payload.pull_request.draft === false &&
               context.payload.pull_request.user?.type !== "Bot";
             const automaticCodexReview =
-              codexReviewPathEligible && codexReviewReady;
-            const codexReviewSummary = automaticCodexReview
-              ? "runs automatically; manual via `/codex review`"
-              : !codexReviewPathEligible
-                ? "skipped for docs/metadata/assets-only changes; manual via `/codex review`"
-                : context.payload.pull_request.draft
-                  ? "skipped for draft PRs; manual via `/codex review`"
-                  : "skipped for bot-authored PRs; manual via `/codex review`";
+              codexReviewPathEligible && codexReviewSameRepo && codexReviewReady;
+            let codexReviewSummary;
+            if (automaticCodexReview) {
+              codexReviewSummary = "runs automatically; manual via `/codex review`";
+            } else if (!codexReviewSameRepo) {
+              codexReviewSummary = "skipped for fork PRs";
+            } else if (!codexReviewPathEligible) {
+              codexReviewSummary =
+                "skipped for docs/metadata/assets-only changes; manual via `/codex review`";
+            } else if (context.payload.pull_request.draft) {
+              codexReviewSummary = "skipped for draft PRs; manual via `/codex review`";
+            } else {
+              codexReviewSummary =
+                "skipped for bot-authored PRs; manual via `/codex review`";
+            }
             const serviceIntegration = names.some(touchesServiceIntegration);
             const browserSmoke = names.some(touchesBrowserSmoke);
             const tier = docsOnly


### PR DESCRIPTION
## Summary

- Follow up on PR #127 after its Codex review noted one more summary mismatch.
- Include the same-repo/fork gate in the PR gate Codex review summary.
- Avoid advertising manual `/codex review` for fork PRs, since the Codex workflow skips fork review steps.

## Verification

- Workflow YAML parse for all `.github/workflows/*.yml` files.
- `git diff --check`