### PR TITLE
Fix flaky studio-page test: stub AudioContext in test harness

### DIFF
--- a/tests/helpers/studio-page.ts
+++ b/tests/helpers/studio-page.ts
@@ -1,6 +1,6 @@
 import React, { type ReactNode } from "react";
 import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
-import { afterEach, beforeEach, vi } from "vitest";
+import { afterEach, beforeEach, expect, vi } from "vitest";
 import StudioPage from "@/app/studio/[id]/page";
 
 type AuthMeResponse =
@@ -17,6 +17,7 @@ const studioPageHarness = vi.hoisted(() => ({
   getUserMedia: vi.fn(),
   enumerateDevices: vi.fn(),
   listBackups: vi.fn(async () => []),
+  audioContexts: [] as unknown[],
 }));
 
 vi.mock("next/navigation", () => ({
@@ -109,6 +110,28 @@ function mediaStream(): MediaStream {
   } as unknown as MediaStream;
 }
 
+// happy-dom has no Web Audio API, but the studio page's local level monitor
+// constructs an AudioContext once the recording stream resolves after join.
+// getByteTimeDomainData fills with 128 (silence) so the meter reads 0.
+class FakeAudioContext {
+  constructor() {
+    studioPageHarness.audioContexts.push(this);
+  }
+  createMediaStreamSource() {
+    return { connect: vi.fn(), disconnect: vi.fn() };
+  }
+  createAnalyser() {
+    return {
+      fftSize: 2048,
+      smoothingTimeConstant: 0,
+      getByteTimeDomainData(data: Uint8Array) {
+        data.fill(128);
+      },
+    };
+  }
+  async close() {}
+}
+
 function audioInput(deviceId: string, label: string): MediaDeviceInfo {
   return {
     deviceId,
@@ -131,7 +154,9 @@ beforeEach(() => {
     .mockReset()
     .mockResolvedValue([audioInput("usb-mic", "Shure MV7")]);
   studioPageHarness.listBackups.mockClear();
+  studioPageHarness.audioContexts.length = 0;
 
+  vi.stubGlobal("AudioContext", FakeAudioContext);
   vi.stubGlobal(
     "fetch",
     vi.fn(async () => Response.json(studioPageHarness.authMeResponse)),
@@ -177,6 +202,13 @@ export function renderGuestStudioPage({
 
       fireEvent.click(screen.getByRole("button", { name: "Join Studio" }));
       await screen.findByTestId("livekit-room");
+
+      // The recording stream resolves asynchronously after the room mounts and
+      // spins up the local level monitor. Wait for it so assertions see the
+      // settled UI instead of racing the effect against test teardown.
+      await waitFor(() => {
+        expect(studioPageHarness.audioContexts.length).toBeGreaterThan(0);
+      });
     },
     screen,
   };


### PR DESCRIPTION
## Problem

`tests/studio-page.test.ts` failed intermittently during full `npm test` runs but passed in isolation.

## Root cause

After joining, the studio page resolves the recording stream (`getUserMedia` → `setRecordingStream`) and a passive effect then constructs an `AudioContext` for the local audio-level monitor (`src/app/studio/[id]/page.tsx:1080`). happy-dom has no Web Audio API, so that effect throws `ReferenceError: AudioContext is not defined`.

The test's `join()` helper returned as soon as the LiveKit room rendered, so the effect flush raced `afterEach` cleanup/unmount:

- unmount wins → effect never runs → test passes
- effect wins → throw → test fails

Under parallel full-suite load the scheduler interleaving flipped often enough to surface the failure. Reproduced within 1–2 runs of `vitest run --sequence.shuffle`.

## Fix

- Stub a minimal `AudioContext` in the test harness (`vi.stubGlobal`, restored by the existing `vi.unstubAllGlobals()`), following the mock-constructor pattern already used in `tests/audio-downmix.test.ts`. `getByteTimeDomainData` fills with 128 (silence) so the level meter reads 0.
- Make `join()` wait until the level monitor has spun up (an `AudioContext` was constructed), so assertions always run against the same settled UI instead of racing teardown.

## Verification

- Pre-fix: shuffled full-suite run failed within 1–2 attempts with the `AudioContext` ReferenceError.
- Post-fix: 20 consecutive `vitest run --sequence.shuffle` full-suite runs pass; single-file run passes; `tsc --noEmit` and eslint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)