### PR TITLE
[codex] Reconcile roadmap for issue 134

### DIFF
--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -56,6 +56,7 @@ This roadmap was reconciled against every GitHub issue that was open on June 13,
 - #63 Deferred multi-participant browser E2E harness: promote this after the narrower integration coverage and reconnect stack stabilize, or sooner if a real LiveKit/multi-participant regression demands it.
 - #109 Simplify recording and recovery code after the recent safety work: do this after the current safety path and its coverage work stabilize so cleanup is guided by proven invariants instead of guesswork.
 - #131 Media stitching/materialization for logical track segments: continue the reconnect-safe recording stack after `#120`/`#126` by producing one downstream-facing artifact per logical track from one or more internal segments.
+- #134 Automated release-readiness gate for live reconnect recording: run this after the active reconnect/materialization work is ready to validate, and before merging or shipping that stack, so recording, reconnect, upload, recovery, and materialization all pass in one repeatable command and CI path.
 - #75 Participant reconnect and resume: pursue this after `#131`, so reconnect behavior builds on a safe materialized-track boundary instead of exposing physical browser blobs downstream.
 
 ## Needs Clarification


### PR DESCRIPTION
## Summary

- add issue `#134` to `docs/FEATURES.md` under `Sequenced Work`
- keep the roadmap at exact one-to-one coverage with the current open issue set
- preserve the existing parallel/sequenced/clarification structure

## Verification

- exact coverage audit: 41 open issues, 41 roadmap entries, no duplicates, no extras
- `./node_modules/.bin/prettier --check docs/FEATURES.md` not run because Prettier is not installed in this worktree
