### PR TITLE
[codex] Add recording sync marker capture

### DIFF
--- a/prisma/migrations/20260613000000_track_segment_sync_marker/migration.sql
+++ b/prisma/migrations/20260613000000_track_segment_sync_marker/migration.sql
@@ -1,0 +1,4 @@
+ALTER TABLE "TrackSegment"
+ADD COLUMN "syncMarkerVersion" TEXT,
+ADD COLUMN "syncMarkerOffsetMs" INTEGER,
+ADD COLUMN "syncMarkerDurationMs" INTEGER;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -88,17 +88,20 @@ model Track {
 }
 
 model TrackSegment {
-  id           String    @id @default(uuid())
-  trackId      String
-  track        Track     @relation(fields: [trackId], references: [id], onDelete: Cascade)
-  segmentIndex Int
-  s3Prefix     String
-  status       String    @default("recording") // recording | uploading | complete | failed
-  durationMs   Int?
-  startedAt    DateTime  @default(now())
-  completedAt  DateTime?
-  createdAt    DateTime  @default(now())
-  updatedAt    DateTime  @updatedAt
+  id                   String    @id @default(uuid())
+  trackId              String
+  track                Track     @relation(fields: [trackId], references: [id], onDelete: Cascade)
+  segmentIndex         Int
+  s3Prefix             String
+  status               String    @default("recording") // recording | uploading | complete | failed
+  durationMs           Int?
+  syncMarkerVersion    String?
+  syncMarkerOffsetMs   Int?
+  syncMarkerDurationMs Int?
+  startedAt            DateTime  @default(now())
+  completedAt          DateTime?
+  createdAt            DateTime  @default(now())
+  updatedAt            DateTime  @updatedAt
 
   @@unique([trackId, segmentIndex])
   @@index([trackId, status])

--- a/src/app/api/upload/presign/route.ts
+++ b/src/app/api/upload/presign/route.ts
@@ -14,6 +14,12 @@ import {
   type Principal,
   verifyRecordingUploadToken,
 } from "@/lib/auth";
+import {
+  SYNC_MARKER_DURATION_MS,
+  SYNC_MARKER_OFFSET_MS,
+  SYNC_MARKER_VERSION,
+  type SyncMarkerMetadata,
+} from "@/lib/sync-marker";
 
 function getUploadErrorMessage(error: unknown): string {
   if (!(error instanceof Error)) {
@@ -32,6 +38,32 @@ function getUploadErrorMessage(error: unknown): string {
 
 function cleanNonEmptyString(value: unknown): string | null {
   return typeof value === "string" && value.length > 0 ? value : null;
+}
+
+function cleanSyncMarker(value: unknown): SyncMarkerMetadata | undefined {
+  if (value === undefined || value === null) return undefined;
+  if (typeof value !== "object") {
+    throw new Error("SYNC_MARKER_INVALID");
+  }
+
+  const marker = value as {
+    version?: unknown;
+    offsetMs?: unknown;
+    durationMs?: unknown;
+  };
+  if (
+    marker.version !== SYNC_MARKER_VERSION ||
+    marker.offsetMs !== SYNC_MARKER_OFFSET_MS ||
+    marker.durationMs !== SYNC_MARKER_DURATION_MS
+  ) {
+    throw new Error("SYNC_MARKER_INVALID");
+  }
+
+  return {
+    version: SYNC_MARKER_VERSION,
+    offsetMs: SYNC_MARKER_OFFSET_MS,
+    durationMs: SYNC_MARKER_DURATION_MS,
+  };
 }
 
 function isUniqueConstraintError(error: unknown): boolean {
@@ -62,6 +94,7 @@ async function ensureLogicalTrackAndSegment(input: {
   deviceId: unknown;
   isBuiltInMic: unknown;
   sessionStartedAt: unknown;
+  syncMarker?: SyncMarkerMetadata;
 }) {
   const {
     sessionId,
@@ -74,6 +107,7 @@ async function ensureLogicalTrackAndSegment(input: {
     deviceId,
     isBuiltInMic,
     sessionStartedAt,
+    syncMarker,
   } = input;
   const participantId = principalParticipantId(principal);
   // Prefer the take the client was actually recording for. A delayed start
@@ -198,6 +232,9 @@ async function ensureLogicalTrackAndSegment(input: {
               track.id,
               requestedSegmentId,
             ),
+            syncMarkerVersion: syncMarker?.version,
+            syncMarkerOffsetMs: syncMarker?.offsetMs,
+            syncMarkerDurationMs: syncMarker?.durationMs,
           },
         });
       } catch (error) {
@@ -266,6 +303,22 @@ export async function POST(req: NextRequest) {
     let logicalTrackId = trackId;
     let segmentId = cleanNonEmptyString(body?.segmentId) ?? trackId;
     if (isRecordingStart) {
+      let syncMarker: SyncMarkerMetadata | undefined;
+      try {
+        syncMarker = cleanSyncMarker(body?.syncMarker);
+      } catch (error) {
+        if (
+          error instanceof Error &&
+          error.message === "SYNC_MARKER_INVALID"
+        ) {
+          return NextResponse.json(
+            { error: "syncMarker is invalid" },
+            { status: 400 },
+          );
+        }
+        throw error;
+      }
+
       // Starting a recording still requires normal host/guest auth. The
       // returned recording token is scoped to this session+track so later
       // chunks can keep uploading if the login cookie expires mid-take.
@@ -301,6 +354,7 @@ export async function POST(req: NextRequest) {
           deviceId,
           isBuiltInMic,
           sessionStartedAt,
+          syncMarker,
         });
         logicalTrackId = track.id;
         segmentId = segment.id;

--- a/src/app/studio/[id]/page.tsx
+++ b/src/app/studio/[id]/page.tsx
@@ -1298,8 +1298,11 @@ function RoomContent({
       let syncMarkerRecording: SyncMarkerRecordingStream | null = null;
       try {
         syncMarkerRecording = createSyncMarkerRecordingStream(streamRef.current);
+        await syncMarkerRecording.prepare();
       } catch (err) {
         console.error("Recording: sync marker unavailable; recording raw stream.", err);
+        syncMarkerRecording?.dispose();
+        syncMarkerRecording = null;
         showNotification("Sync marker unavailable - recording raw audio");
       }
 

--- a/src/app/studio/[id]/page.tsx
+++ b/src/app/studio/[id]/page.tsx
@@ -29,6 +29,10 @@ import { v4 as uuidv4 } from "uuid";
 import { CozyRecorder } from "@/lib/recorder";
 import { forceMonoStream, getTrackChannelCount } from "@/lib/audio-downmix";
 import {
+  createSyncMarkerRecordingStream,
+  type SyncMarkerRecordingStream,
+} from "@/lib/recording-sync-marker";
+import {
   getPresignedUploadTarget,
   getPresignedUploadUrl,
   uploadChunk,
@@ -724,6 +728,7 @@ function RoomContent({
   // `getUserMedia` constraints.
   const streamRef = useRef<MediaStream | null>(null);
   const downmixDisposeRef = useRef<(() => void) | null>(null);
+  const syncMarkerRecordingDisposeRef = useRef<(() => void) | null>(null);
   const [recordingStream, setRecordingStream] = useState<MediaStream | null>(null);
   // Mirror of studioState so callbacks invoked from transport subscriptions
   // (which close over the value at subscription time) can check current state
@@ -1290,6 +1295,13 @@ function RoomContent({
       let trackId = requestedTrackId;
       let segmentId = requestedTrackId;
       recordingUploadTokenRef.current = undefined;
+      let syncMarkerRecording: SyncMarkerRecordingStream | null = null;
+      try {
+        syncMarkerRecording = createSyncMarkerRecordingStream(streamRef.current);
+      } catch (err) {
+        console.error("Recording: sync marker unavailable; recording raw stream.", err);
+        showNotification("Sync marker unavailable - recording raw audio");
+      }
 
       try {
         const initialUpload = await getPresignedUploadTarget(
@@ -1305,6 +1317,7 @@ function RoomContent({
             },
             sessionStartedAt: sessionStartedAtIso,
             takeId: effectiveTakeId ?? undefined,
+            syncMarker: syncMarkerRecording?.marker,
           },
         );
         trackId = initialUpload.trackId ?? requestedTrackId;
@@ -1330,6 +1343,7 @@ function RoomContent({
         }
       } catch (err) {
         console.error("Failed to initialize upload:", err);
+        syncMarkerRecording?.dispose();
         clearRecordingConfirmationState();
         void broadcastRecordingStatus(
           "failed",
@@ -1342,7 +1356,7 @@ function RoomContent({
 
       trackerReset();
 
-      const recorder = new CozyRecorder(streamRef.current);
+      const recorder = new CozyRecorder(syncMarkerRecording?.stream ?? streamRef.current);
 
       recorder.onChunk((chunk, index) => {
         const byteLength = chunk.size;
@@ -1432,6 +1446,7 @@ function RoomContent({
       });
 
       recorderRef.current = recorder;
+      syncMarkerRecordingDisposeRef.current = syncMarkerRecording?.dispose ?? null;
       recordingStartRef.current = Date.now();
 
       if (timingDebug) {
@@ -1444,15 +1459,26 @@ function RoomContent({
             sessionStartedAt: sessionStartedAtIso,
             trackId,
             participant: participantName,
+            syncMarker: syncMarkerRecording?.marker,
           }),
         );
       }
 
+      let recorderStarted = false;
       try {
         await recorder.start(5000);
+        recorderStarted = true;
+        await syncMarkerRecording?.playSyncMarker();
       } catch (err) {
         console.error("Failed to start recorder:", err);
+        if (recorderStarted) {
+          await recorder.stop().catch((stopErr) => {
+            console.error("Failed to stop recorder after sync marker error:", stopErr);
+          });
+        }
         recorderRef.current = null;
+        syncMarkerRecordingDisposeRef.current = null;
+        syncMarkerRecording?.dispose();
         clearRecordingConfirmationState();
         void broadcastRecordingStatus(
           "failed",
@@ -1513,6 +1539,8 @@ function RoomContent({
     clearRecordingConfirmationState(false);
 
     if (!recorderRef.current) {
+      syncMarkerRecordingDisposeRef.current?.();
+      syncMarkerRecordingDisposeRef.current = null;
       setRecordingSessionStartedAtSync(null);
       recordingTakeIdRef.current = null;
       void broadcastRecordingStatus(
@@ -1545,6 +1573,8 @@ function RoomContent({
 
     try {
       const blob = await recorder.stop();
+      syncMarkerRecordingDisposeRef.current?.();
+      syncMarkerRecordingDisposeRef.current = null;
       const durationMs = Date.now() - startedAt;
 
       if (timingDebug) {
@@ -1636,6 +1666,8 @@ function RoomContent({
       }
     } finally {
       recorderRef.current = null;
+      syncMarkerRecordingDisposeRef.current?.();
+      syncMarkerRecordingDisposeRef.current = null;
       segmentIdRef.current = "";
       recordingUploadTokenRef.current = undefined;
       // Hard invariant from issue #61: do not leave `finalizing` until the
@@ -1959,6 +1991,8 @@ function RoomContent({
 
   useEffect(() => {
     return () => {
+      syncMarkerRecordingDisposeRef.current?.();
+      syncMarkerRecordingDisposeRef.current = null;
       downmixDisposeRef.current?.();
       downmixDisposeRef.current = null;
       const rawStream = rawStreamRef.current;

--- a/src/lib/recording-sync-marker.ts
+++ b/src/lib/recording-sync-marker.ts
@@ -25,6 +25,7 @@ export const SYNC_MARKER_GAIN = 0.12;
 export type SyncMarkerRecordingStream = {
   stream: MediaStream;
   marker: SyncMarkerMetadata;
+  prepare: () => Promise<SyncMarkerMetadata>;
   playSyncMarker: () => Promise<SyncMarkerMetadata>;
   dispose: () => void;
 };
@@ -63,15 +64,37 @@ export function createSyncMarkerRecordingStream(
 
   let disposed = false;
 
+  async function ensureAudioContextRunning(): Promise<SyncMarkerMetadata> {
+    if (disposed) {
+      throw new Error("Sync marker audio graph is disposed");
+    }
+
+    if (ctx.state === "suspended") {
+      try {
+        await ctx.resume();
+      } catch (error) {
+        const detail = error instanceof Error ? `: ${error.message}` : "";
+        throw new Error(`AudioContext failed to resume for sync marker${detail}`);
+      }
+    }
+
+    if (ctx.state === "suspended") {
+      throw new Error("AudioContext stayed suspended for sync marker");
+    }
+
+    if (ctx.state !== "running") {
+      throw new Error(`AudioContext is ${ctx.state} for sync marker`);
+    }
+
+    return syncMarkerMetadata();
+  }
+
   return {
     stream: destination.stream,
     marker: syncMarkerMetadata(),
+    prepare: ensureAudioContextRunning,
     playSyncMarker: async () => {
-      if (disposed) return syncMarkerMetadata();
-
-      if (ctx.state === "suspended") {
-        await ctx.resume().catch(() => undefined);
-      }
+      const marker = await ensureAudioContextRunning();
 
       const startAt = ctx.currentTime + SYNC_MARKER_OFFSET_MS / 1000;
       const endAt = startAt + SYNC_MARKER_DURATION_MS / 1000;
@@ -100,7 +123,7 @@ export function createSyncMarkerRecordingStream(
         }
       };
 
-      return syncMarkerMetadata();
+      return marker;
     },
     dispose: () => {
       if (disposed) return;

--- a/src/lib/recording-sync-marker.ts
+++ b/src/lib/recording-sync-marker.ts
@@ -1,0 +1,133 @@
+"use client";
+
+import {
+  SYNC_MARKER_DURATION_MS,
+  SYNC_MARKER_OFFSET_MS,
+  SYNC_MARKER_VERSION,
+  syncMarkerMetadata,
+  type SyncMarkerMetadata,
+} from "@/lib/sync-marker";
+
+export {
+  SYNC_MARKER_DURATION_MS,
+  SYNC_MARKER_OFFSET_MS,
+  SYNC_MARKER_VERSION,
+  syncMarkerMetadata,
+};
+export type { SyncMarkerMetadata };
+
+export type AudioContextCtor = new (options?: AudioContextOptions) => AudioContext;
+
+export const SYNC_MARKER_START_FREQUENCY_HZ = 1200;
+export const SYNC_MARKER_END_FREQUENCY_HZ = 3200;
+export const SYNC_MARKER_GAIN = 0.12;
+
+export type SyncMarkerRecordingStream = {
+  stream: MediaStream;
+  marker: SyncMarkerMetadata;
+  playSyncMarker: () => Promise<SyncMarkerMetadata>;
+  dispose: () => void;
+};
+
+function getAudioContextCtor(AudioCtxCtor?: AudioContextCtor): AudioContextCtor | undefined {
+  return (
+    AudioCtxCtor ??
+    (typeof window !== "undefined"
+      ? (window.AudioContext ??
+        (window as unknown as { webkitAudioContext?: AudioContextCtor })
+          .webkitAudioContext)
+      : undefined)
+  );
+}
+
+export function createSyncMarkerRecordingStream(
+  source: MediaStream,
+  AudioCtxCtor?: AudioContextCtor,
+): SyncMarkerRecordingStream {
+  const Ctor = getAudioContextCtor(AudioCtxCtor);
+  if (!Ctor) {
+    throw new Error("createSyncMarkerRecordingStream: no AudioContext available");
+  }
+
+  const ctx = new Ctor({ sampleRate: 48000 });
+  const sourceNode = ctx.createMediaStreamSource(source);
+  const micGain = ctx.createGain();
+  const markerGain = ctx.createGain();
+  markerGain.gain.value = 0;
+
+  const destination = new MediaStreamAudioDestinationNode(ctx, { channelCount: 1 });
+
+  sourceNode.connect(micGain);
+  micGain.connect(destination);
+  markerGain.connect(destination);
+
+  let disposed = false;
+
+  return {
+    stream: destination.stream,
+    marker: syncMarkerMetadata(),
+    playSyncMarker: async () => {
+      if (disposed) return syncMarkerMetadata();
+
+      if (ctx.state === "suspended") {
+        await ctx.resume().catch(() => undefined);
+      }
+
+      const startAt = ctx.currentTime + SYNC_MARKER_OFFSET_MS / 1000;
+      const endAt = startAt + SYNC_MARKER_DURATION_MS / 1000;
+      const oscillator = ctx.createOscillator();
+      oscillator.type = "sine";
+      oscillator.frequency.setValueAtTime(SYNC_MARKER_START_FREQUENCY_HZ, startAt);
+      oscillator.frequency.linearRampToValueAtTime(
+        SYNC_MARKER_END_FREQUENCY_HZ,
+        endAt,
+      );
+
+      markerGain.gain.cancelScheduledValues(startAt);
+      markerGain.gain.setValueAtTime(0, startAt);
+      markerGain.gain.linearRampToValueAtTime(SYNC_MARKER_GAIN, startAt + 0.01);
+      markerGain.gain.setValueAtTime(SYNC_MARKER_GAIN, endAt - 0.02);
+      markerGain.gain.linearRampToValueAtTime(0, endAt);
+
+      oscillator.connect(markerGain);
+      oscillator.start(startAt);
+      oscillator.stop(endAt);
+      oscillator.onended = () => {
+        try {
+          oscillator.disconnect();
+        } catch {
+          // Already disconnected; ignore.
+        }
+      };
+
+      return syncMarkerMetadata();
+    },
+    dispose: () => {
+      if (disposed) return;
+      disposed = true;
+      try {
+        sourceNode.disconnect();
+      } catch {
+        // Already disconnected; ignore.
+      }
+      try {
+        micGain.disconnect();
+      } catch {
+        // Already disconnected; ignore.
+      }
+      try {
+        markerGain.disconnect();
+      } catch {
+        // Already disconnected; ignore.
+      }
+      for (const track of destination.stream.getTracks()) {
+        try {
+          track.stop();
+        } catch {
+          // Already stopped; ignore.
+        }
+      }
+      void ctx.close().catch(() => undefined);
+    },
+  };
+}

--- a/src/lib/sync-marker.ts
+++ b/src/lib/sync-marker.ts
@@ -1,0 +1,17 @@
+export const SYNC_MARKER_VERSION = "chirp-v1";
+export const SYNC_MARKER_OFFSET_MS = 100;
+export const SYNC_MARKER_DURATION_MS = 300;
+
+export type SyncMarkerMetadata = {
+  version: typeof SYNC_MARKER_VERSION;
+  offsetMs: typeof SYNC_MARKER_OFFSET_MS;
+  durationMs: typeof SYNC_MARKER_DURATION_MS;
+};
+
+export function syncMarkerMetadata(): SyncMarkerMetadata {
+  return {
+    version: SYNC_MARKER_VERSION,
+    offsetMs: SYNC_MARKER_OFFSET_MS,
+    durationMs: SYNC_MARKER_DURATION_MS,
+  };
+}

--- a/src/lib/upload.ts
+++ b/src/lib/upload.ts
@@ -1,5 +1,7 @@
 "use client";
 
+import type { SyncMarkerMetadata } from "@/lib/sync-marker";
+
 export interface DeviceInfo {
   deviceLabel: string | undefined;
   deviceId: string;
@@ -15,6 +17,7 @@ export interface TrackInitInfo {
   // The take this recording was broadcast for. Binds a delayed start to its
   // original take instead of whatever take is active when presign arrives.
   takeId?: string;
+  syncMarker?: SyncMarkerMetadata;
 }
 
 export interface PresignedUploadTarget {
@@ -50,6 +53,7 @@ export async function getPresignedUploadTarget(
       sessionStartedAt: trackInit?.sessionStartedAt,
       segmentId: trackInit?.segmentId,
       takeId: trackInit?.takeId,
+      syncMarker: trackInit?.syncMarker,
     }),
   });
 

--- a/tests/recording-sync-marker.test.ts
+++ b/tests/recording-sync-marker.test.ts
@@ -1,0 +1,231 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  SYNC_MARKER_DURATION_MS,
+  SYNC_MARKER_OFFSET_MS,
+  SYNC_MARKER_VERSION,
+  createSyncMarkerRecordingStream,
+} from "@/lib/recording-sync-marker";
+
+type MockNode = {
+  connect: ReturnType<typeof vi.fn>;
+  disconnect: ReturnType<typeof vi.fn>;
+};
+
+type MockAudioParam = {
+  value: number;
+  cancelScheduledValues: ReturnType<typeof vi.fn>;
+  setValueAtTime: ReturnType<typeof vi.fn>;
+  linearRampToValueAtTime: ReturnType<typeof vi.fn>;
+};
+
+function makeNode(): MockNode {
+  return {
+    connect: vi.fn(),
+    disconnect: vi.fn(),
+  };
+}
+
+function makeAudioParam(): MockAudioParam {
+  return {
+    value: 1,
+    cancelScheduledValues: vi.fn(),
+    setValueAtTime: vi.fn(),
+    linearRampToValueAtTime: vi.fn(),
+  };
+}
+
+class MockMediaStream {
+  readonly _kind = "marker-stream" as const;
+  getTracks(): MediaStreamTrack[] {
+    return [];
+  }
+}
+
+class MockDestinationNode {
+  channelCount: number;
+  stream = new MockMediaStream() as unknown as MediaStream;
+
+  constructor(_ctx: unknown, opts?: { channelCount?: number }) {
+    this.channelCount = opts?.channelCount ?? 2;
+  }
+}
+
+function makeMockAudioContextCtor() {
+  const sourceNode = makeNode();
+  const micGain = makeNode() as MockNode & { gain: MockAudioParam };
+  micGain.gain = makeAudioParam();
+  const markerGain = makeNode() as MockNode & { gain: MockAudioParam };
+  markerGain.gain = makeAudioParam();
+  const oscillator = makeNode() as MockNode & {
+    type: OscillatorType;
+    frequency: MockAudioParam;
+    start: ReturnType<typeof vi.fn>;
+    stop: ReturnType<typeof vi.fn>;
+    onended: (() => void) | null;
+  };
+  oscillator.type = "sine";
+  oscillator.frequency = makeAudioParam();
+  oscillator.start = vi.fn();
+  oscillator.stop = vi.fn();
+  oscillator.onended = null;
+
+  const destinationCalls: Array<{
+    args: unknown[];
+    instance: MockDestinationNode;
+  }> = [];
+  const instances: Array<{
+    currentTime: number;
+    state: AudioContextState;
+    createMediaStreamSource: ReturnType<typeof vi.fn>;
+    createGain: ReturnType<typeof vi.fn>;
+    createOscillator: ReturnType<typeof vi.fn>;
+    resume: ReturnType<typeof vi.fn>;
+    close: ReturnType<typeof vi.fn>;
+  }> = [];
+
+  function DestinationCtorImpl(
+    this: MockDestinationNode,
+    ctx: unknown,
+    opts?: { channelCount?: number },
+  ) {
+    const inst = new MockDestinationNode(ctx, opts);
+    destinationCalls.push({ args: [ctx, opts], instance: inst });
+    return inst;
+  }
+
+  const DestinationCtor = DestinationCtorImpl as unknown as new (
+    ctx: unknown,
+    opts?: { channelCount?: number },
+  ) => MockDestinationNode;
+
+  class MockAudioContext {
+    currentTime = 10;
+    state: AudioContextState = "suspended";
+    createMediaStreamSource = vi.fn().mockReturnValue(sourceNode);
+    createGain = vi
+      .fn()
+      .mockReturnValueOnce(micGain)
+      .mockReturnValueOnce(markerGain);
+    createOscillator = vi.fn().mockReturnValue(oscillator);
+    resume = vi.fn().mockResolvedValue(undefined);
+    close = vi.fn().mockResolvedValue(undefined);
+
+    constructor() {
+      instances.push(this);
+    }
+  }
+
+  return {
+    Ctor: MockAudioContext as unknown as typeof AudioContext,
+    sourceNode,
+    micGain,
+    markerGain,
+    oscillator,
+    DestinationCtor,
+    destinationCalls,
+    instances,
+  };
+}
+
+describe("createSyncMarkerRecordingStream", () => {
+  let originalDestinationCtor: unknown;
+  let captured: ReturnType<typeof makeMockAudioContextCtor>;
+
+  beforeEach(() => {
+    captured = makeMockAudioContextCtor();
+    originalDestinationCtor = (
+      globalThis as { MediaStreamAudioDestinationNode?: unknown }
+    ).MediaStreamAudioDestinationNode;
+    (
+      globalThis as { MediaStreamAudioDestinationNode: unknown }
+    ).MediaStreamAudioDestinationNode = captured.DestinationCtor;
+  });
+
+  afterEach(() => {
+    (
+      globalThis as { MediaStreamAudioDestinationNode?: unknown }
+    ).MediaStreamAudioDestinationNode = originalDestinationCtor;
+  });
+
+  it("mixes the microphone and marker into a mono destination stream", () => {
+    const fakeStream = {} as MediaStream;
+    const graph = createSyncMarkerRecordingStream(fakeStream, captured.Ctor);
+
+    expect(captured.destinationCalls).toHaveLength(1);
+    expect(captured.destinationCalls[0].args[1]).toEqual({ channelCount: 1 });
+    expect(captured.sourceNode.connect).toHaveBeenCalledWith(captured.micGain);
+    expect(captured.micGain.connect).toHaveBeenCalledWith(
+      captured.destinationCalls[0].instance,
+    );
+    expect(captured.markerGain.connect).toHaveBeenCalledWith(
+      captured.destinationCalls[0].instance,
+    );
+    expect((graph.stream as unknown as { _kind?: string })._kind).toBe(
+      "marker-stream",
+    );
+  });
+
+  it("schedules a clipping-safe chirp marker after the recorder pre-roll offset", async () => {
+    const fakeStream = {} as MediaStream;
+    const graph = createSyncMarkerRecordingStream(fakeStream, captured.Ctor);
+    const marker = await graph.playSyncMarker();
+
+    const startAt = 10 + SYNC_MARKER_OFFSET_MS / 1000;
+    const endAt = startAt + SYNC_MARKER_DURATION_MS / 1000;
+
+    expect(marker).toMatchObject({
+      version: SYNC_MARKER_VERSION,
+      offsetMs: SYNC_MARKER_OFFSET_MS,
+      durationMs: SYNC_MARKER_DURATION_MS,
+    });
+    expect(captured.instances[0].resume).toHaveBeenCalledTimes(1);
+    expect(captured.oscillator.frequency.setValueAtTime).toHaveBeenCalledWith(
+      expect.any(Number),
+      startAt,
+    );
+    expect(
+      captured.oscillator.frequency.linearRampToValueAtTime,
+    ).toHaveBeenCalledWith(expect.any(Number), endAt);
+    expect(captured.markerGain.gain.setValueAtTime).toHaveBeenCalledWith(
+      0,
+      startAt,
+    );
+    expect(captured.markerGain.gain.linearRampToValueAtTime).toHaveBeenCalledWith(
+      expect.any(Number),
+      startAt + 0.01,
+    );
+    expect(captured.markerGain.gain.linearRampToValueAtTime).toHaveBeenCalledWith(
+      0,
+      endAt,
+    );
+    expect(captured.oscillator.connect).toHaveBeenCalledWith(
+      captured.markerGain,
+    );
+    expect(captured.oscillator.start).toHaveBeenCalledWith(startAt);
+    expect(captured.oscillator.stop).toHaveBeenCalledWith(endAt);
+  });
+
+  it("dispose disconnects nodes, stops destination tracks, and closes once", () => {
+    const stop = vi.fn();
+    const fakeTrack = { stop } as unknown as MediaStreamTrack;
+    const graph = createSyncMarkerRecordingStream({} as MediaStream, captured.Ctor);
+    const dest = captured.destinationCalls[0].instance;
+    (dest.stream as unknown as { getTracks: () => MediaStreamTrack[] }).getTracks =
+      () => [fakeTrack];
+
+    graph.dispose();
+    graph.dispose();
+
+    expect(captured.sourceNode.disconnect).toHaveBeenCalledTimes(1);
+    expect(captured.micGain.disconnect).toHaveBeenCalledTimes(1);
+    expect(captured.markerGain.disconnect).toHaveBeenCalledTimes(1);
+    expect(stop).toHaveBeenCalledTimes(1);
+    expect(captured.instances[0].close).toHaveBeenCalledTimes(1);
+  });
+
+  it("throws when no AudioContext is available", () => {
+    expect(() =>
+      createSyncMarkerRecordingStream({} as MediaStream, undefined),
+    ).toThrowError(/no AudioContext/);
+  });
+});

--- a/tests/recording-sync-marker.test.ts
+++ b/tests/recording-sync-marker.test.ts
@@ -107,7 +107,9 @@ function makeMockAudioContextCtor() {
       .mockReturnValueOnce(micGain)
       .mockReturnValueOnce(markerGain);
     createOscillator = vi.fn().mockReturnValue(oscillator);
-    resume = vi.fn().mockResolvedValue(undefined);
+    resume = vi.fn().mockImplementation(async () => {
+      this.state = "running";
+    });
     close = vi.fn().mockResolvedValue(undefined);
 
     constructor() {
@@ -162,6 +164,42 @@ describe("createSyncMarkerRecordingStream", () => {
     );
     expect((graph.stream as unknown as { _kind?: string })._kind).toBe(
       "marker-stream",
+    );
+  });
+
+  it("prepares the marker stream only after the AudioContext is running", async () => {
+    const fakeStream = {} as MediaStream;
+    const graph = createSyncMarkerRecordingStream(fakeStream, captured.Ctor);
+
+    await expect(graph.prepare()).resolves.toMatchObject({
+      version: SYNC_MARKER_VERSION,
+      offsetMs: SYNC_MARKER_OFFSET_MS,
+      durationMs: SYNC_MARKER_DURATION_MS,
+    });
+
+    expect(captured.instances[0].resume).toHaveBeenCalledTimes(1);
+    expect(captured.instances[0].state).toBe("running");
+  });
+
+  it("rejects prepare when the AudioContext cannot resume", async () => {
+    const fakeStream = {} as MediaStream;
+    const graph = createSyncMarkerRecordingStream(fakeStream, captured.Ctor);
+    captured.instances[0].resume.mockRejectedValueOnce(
+      new Error("activation blocked"),
+    );
+
+    await expect(graph.prepare()).rejects.toThrowError(
+      /AudioContext failed to resume/,
+    );
+  });
+
+  it("rejects prepare when the AudioContext remains suspended", async () => {
+    const fakeStream = {} as MediaStream;
+    const graph = createSyncMarkerRecordingStream(fakeStream, captured.Ctor);
+    captured.instances[0].resume.mockImplementationOnce(async () => undefined);
+
+    await expect(graph.prepare()).rejects.toThrowError(
+      /AudioContext stayed suspended/,
     );
   });
 

--- a/tests/upload-auth.test.ts
+++ b/tests/upload-auth.test.ts
@@ -19,6 +19,9 @@ type TrackSegment = {
   status: string;
   durationMs: number | null;
   completedAt?: Date | null;
+  syncMarkerVersion?: string | null;
+  syncMarkerOffsetMs?: number | null;
+  syncMarkerDurationMs?: number | null;
 };
 
 const mocks = vi.hoisted(() => ({
@@ -221,6 +224,11 @@ import { NextRequest } from "next/server";
 import { POST as presignUpload } from "@/app/api/upload/presign/route";
 import { POST as completeUpload } from "@/app/api/upload/complete/route";
 import { issueRecordingUploadToken } from "@/lib/auth";
+import {
+  SYNC_MARKER_DURATION_MS,
+  SYNC_MARKER_OFFSET_MS,
+  SYNC_MARKER_VERSION,
+} from "@/lib/sync-marker";
 
 function postJson(
   path: string,
@@ -277,6 +285,62 @@ describe("recording upload auth", () => {
     expect(body.url).toBe("https://s3.example/sessions/s1/tracks/t1/0.webm");
     expect(body.recordingToken).toEqual(expect.any(String));
     expect(mocks.tracks.get("t1")?.participantName).toBe("Alice");
+  });
+
+  it("stores sync marker metadata on the created track segment", async () => {
+    mocks.resolvePrincipal.mockResolvedValue({ kind: "host" });
+
+    const res = await presignUpload(
+      postJson(
+        "/api/upload/presign",
+        {
+          sessionId: "s1",
+          trackId: "t1",
+          segmentId: "seg-1",
+          partNumber: 0,
+          participantName: "Alice",
+          syncMarker: {
+            version: SYNC_MARKER_VERSION,
+            offsetMs: SYNC_MARKER_OFFSET_MS,
+            durationMs: SYNC_MARKER_DURATION_MS,
+          },
+        },
+      ),
+    );
+
+    expect(res.status).toBe(200);
+    expect(mocks.segments.get("seg-1")).toMatchObject({
+      syncMarkerVersion: SYNC_MARKER_VERSION,
+      syncMarkerOffsetMs: SYNC_MARKER_OFFSET_MS,
+      syncMarkerDurationMs: SYNC_MARKER_DURATION_MS,
+    });
+  });
+
+  it("rejects malformed sync marker metadata", async () => {
+    mocks.resolvePrincipal.mockResolvedValue({ kind: "host" });
+
+    const res = await presignUpload(
+      postJson(
+        "/api/upload/presign",
+        {
+          sessionId: "s1",
+          trackId: "t1",
+          partNumber: 0,
+          participantName: "Alice",
+          syncMarker: {
+            version: "unknown-marker",
+            offsetMs: SYNC_MARKER_OFFSET_MS,
+            durationMs: SYNC_MARKER_DURATION_MS,
+          },
+        },
+      ),
+    );
+
+    expect(res.status).toBe(400);
+    expect(await res.json()).toEqual({
+      error: "syncMarker is invalid",
+    });
+    expect(mocks.segments.size).toBe(0);
   });
 
   it("stores the guest participant id from the authenticated principal", async () => {

--- a/tests/upload-client.test.ts
+++ b/tests/upload-client.test.ts
@@ -4,6 +4,11 @@ import {
   getPresignedUploadTarget,
   getPresignedUploadUrl,
 } from "@/lib/upload";
+import {
+  SYNC_MARKER_DURATION_MS,
+  SYNC_MARKER_OFFSET_MS,
+  SYNC_MARKER_VERSION,
+} from "@/lib/sync-marker";
 
 const fetchMock = vi.fn();
 
@@ -72,6 +77,33 @@ describe("upload client auth", () => {
         },
       }),
     );
+  });
+
+  it("sends sync marker metadata when starting a recording", async () => {
+    fetchMock.mockResolvedValueOnce(
+      jsonResponse({ url: "https://s3.example/chunk-0" }),
+    );
+
+    await getPresignedUploadTarget("session-1", "track-1", 0, "Alice", {
+      syncMarker: {
+        version: SYNC_MARKER_VERSION,
+        offsetMs: SYNC_MARKER_OFFSET_MS,
+        durationMs: SYNC_MARKER_DURATION_MS,
+      },
+    });
+
+    const [, init] = fetchMock.mock.calls[0];
+    expect(JSON.parse(init.body as string)).toMatchObject({
+      sessionId: "session-1",
+      trackId: "track-1",
+      partNumber: 0,
+      participantName: "Alice",
+      syncMarker: {
+        version: SYNC_MARKER_VERSION,
+        offsetMs: SYNC_MARKER_OFFSET_MS,
+        durationMs: SYNC_MARKER_DURATION_MS,
+      },
+    });
   });
 
   it("sends the recording token when completing the upload", async () => {


### PR DESCRIPTION
## Summary

- Add a recorder-only Web Audio mix that embeds a short chirp sync marker in local recordings without affecting LiveKit preview or monitoring.
- Send sync marker metadata during initial presign and persist it on `TrackSegment`.
- Add the Prisma migration plus unit, client, and API coverage for marker creation and validation.

Closes #138

## Validation

- `npm test`
- `npm run typecheck`
