### PR TITLE
[codex] Detect and persist sync marker metadata

### DIFF
--- a/prisma/migrations/20260613010000_track_segment_sync_marker_detection/migration.sql
+++ b/prisma/migrations/20260613010000_track_segment_sync_marker_detection/migration.sql
@@ -1,0 +1,6 @@
+ALTER TABLE "TrackSegment"
+ADD COLUMN "syncMarkerDetectedAtMs" DOUBLE PRECISION,
+ADD COLUMN "syncMarkerDetectedAtSamples" INTEGER,
+ADD COLUMN "syncMarkerConfidence" DOUBLE PRECISION,
+ADD COLUMN "syncMarkerDetectionStatus" TEXT,
+ADD COLUMN "syncMarkerAnalyzedAt" TIMESTAMP(3);

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -98,6 +98,11 @@ model TrackSegment {
   syncMarkerVersion    String?
   syncMarkerOffsetMs   Int?
   syncMarkerDurationMs Int?
+  syncMarkerDetectedAtMs      Float?
+  syncMarkerDetectedAtSamples Int?
+  syncMarkerConfidence        Float?
+  syncMarkerDetectionStatus   String?
+  syncMarkerAnalyzedAt        DateTime?
   startedAt            DateTime  @default(now())
   completedAt          DateTime?
   createdAt            DateTime  @default(now())

--- a/src/lib/recording-sync-marker.ts
+++ b/src/lib/recording-sync-marker.ts
@@ -2,7 +2,10 @@
 
 import {
   SYNC_MARKER_DURATION_MS,
+  SYNC_MARKER_END_FREQUENCY_HZ,
+  SYNC_MARKER_GAIN,
   SYNC_MARKER_OFFSET_MS,
+  SYNC_MARKER_START_FREQUENCY_HZ,
   SYNC_MARKER_VERSION,
   syncMarkerMetadata,
   type SyncMarkerMetadata,
@@ -10,17 +13,16 @@ import {
 
 export {
   SYNC_MARKER_DURATION_MS,
+  SYNC_MARKER_END_FREQUENCY_HZ,
+  SYNC_MARKER_GAIN,
   SYNC_MARKER_OFFSET_MS,
+  SYNC_MARKER_START_FREQUENCY_HZ,
   SYNC_MARKER_VERSION,
   syncMarkerMetadata,
 };
 export type { SyncMarkerMetadata };
 
 export type AudioContextCtor = new (options?: AudioContextOptions) => AudioContext;
-
-export const SYNC_MARKER_START_FREQUENCY_HZ = 1200;
-export const SYNC_MARKER_END_FREQUENCY_HZ = 3200;
-export const SYNC_MARKER_GAIN = 0.12;
 
 export type SyncMarkerRecordingStream = {
   stream: MediaStream;

--- a/src/lib/s3.ts
+++ b/src/lib/s3.ts
@@ -262,6 +262,29 @@ export async function getObjectBytes(key: string): Promise<Uint8Array> {
   return await body.transformToByteArray();
 }
 
+/**
+ * Reads at most the first `maxBytes` of an object via an HTTP Range request.
+ * Used to inspect the start of an upload (e.g. sync-marker detection) without
+ * downloading or buffering an arbitrarily large object.
+ */
+export async function getObjectBytesRange(
+  key: string,
+  maxBytes: number
+): Promise<Uint8Array> {
+  const response = await s3.send(
+    new GetObjectCommand({
+      Bucket: bucket,
+      Key: key,
+      Range: `bytes=0-${Math.max(0, maxBytes - 1)}`,
+    })
+  );
+  const body = response.Body;
+  if (!body) {
+    throw new Error(`S3 object ${key} returned empty body`);
+  }
+  return await body.transformToByteArray();
+}
+
 export async function putObjectBytes(
   key: string,
   bytes: Uint8Array

--- a/src/lib/sync-marker-detection.ts
+++ b/src/lib/sync-marker-detection.ts
@@ -16,6 +16,9 @@ const execFileAsync = promisify(execFile);
 const DEFAULT_DECODE_SAMPLE_RATE = 48000;
 const DEFAULT_ANALYSIS_SAMPLE_RATE = 8000;
 const DEFAULT_MAX_SEARCH_MS = 5000;
+// Decoding the bounded window is sub-second in practice; this only exists to
+// bound a pathological/malformed input that makes ffmpeg hang instead of fail.
+const DECODE_TIMEOUT_MS = 15000;
 // Normalized-correlation thresholds tuned empirically against the WebM/Opus
 // round-trip fixture (clears ~0.55); >= DETECTED_CONFIDENCE counts as a match,
 // the band down to LOW_CONFIDENCE is reported as "low_confidence", and below
@@ -257,6 +260,9 @@ export async function decodeWebmToPcm(
         "f32le",
         outputPath,
       ],
+      // Hard-kill a hung/malformed decode so it can't tie up the caller. The
+      // rejection is surfaced to detection and recorded as a failed decode.
+      { timeout: DECODE_TIMEOUT_MS, killSignal: "SIGKILL" },
     );
     const output = await readFile(outputPath);
     const arrayBuffer = output.buffer.slice(

--- a/src/lib/sync-marker-detection.ts
+++ b/src/lib/sync-marker-detection.ts
@@ -1,0 +1,253 @@
+import { execFile } from "node:child_process";
+import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { promisify } from "node:util";
+import ffmpegStaticPath from "ffmpeg-static";
+import {
+  SYNC_MARKER_DURATION_MS,
+  SYNC_MARKER_END_FREQUENCY_HZ,
+  SYNC_MARKER_GAIN,
+  SYNC_MARKER_START_FREQUENCY_HZ,
+} from "@/lib/sync-marker";
+
+const execFileAsync = promisify(execFile);
+
+const DEFAULT_DECODE_SAMPLE_RATE = 48000;
+const DEFAULT_ANALYSIS_SAMPLE_RATE = 8000;
+const DEFAULT_MAX_SEARCH_MS = 5000;
+const DETECTED_CONFIDENCE = 0.45;
+const LOW_CONFIDENCE = 0.35;
+
+export type SyncMarkerDetectionStatus =
+  | "detected"
+  | "low_confidence"
+  | "missing"
+  | "decode_failed"
+  | "source_missing";
+
+export type SyncMarkerDetectionResult = {
+  status: SyncMarkerDetectionStatus;
+  detectedAtMs: number | null;
+  detectedAtSamples: number | null;
+  confidence: number;
+  marker: {
+    durationMs: typeof SYNC_MARKER_DURATION_MS;
+    startFrequencyHz: typeof SYNC_MARKER_START_FREQUENCY_HZ;
+    endFrequencyHz: typeof SYNC_MARKER_END_FREQUENCY_HZ;
+    gain: typeof SYNC_MARKER_GAIN;
+  };
+};
+
+export type DetectSyncMarkerOptions = {
+  analysisSampleRate?: number;
+  maxSearchMs?: number;
+  detectedConfidence?: number;
+  lowConfidence?: number;
+};
+
+function markerInfo(): SyncMarkerDetectionResult["marker"] {
+  return {
+    durationMs: SYNC_MARKER_DURATION_MS,
+    startFrequencyHz: SYNC_MARKER_START_FREQUENCY_HZ,
+    endFrequencyHz: SYNC_MARKER_END_FREQUENCY_HZ,
+    gain: SYNC_MARKER_GAIN,
+  };
+}
+
+export function generateSyncMarkerTemplate(sampleRate: number): Float32Array {
+  const durationSeconds = SYNC_MARKER_DURATION_MS / 1000;
+  const length = Math.round(durationSeconds * sampleRate);
+  const template = new Float32Array(length);
+  const frequencyDelta =
+    SYNC_MARKER_END_FREQUENCY_HZ - SYNC_MARKER_START_FREQUENCY_HZ;
+  const fadeInSeconds = 0.01;
+  const fadeOutSeconds = 0.02;
+
+  for (let i = 0; i < length; i++) {
+    const t = i / sampleRate;
+    const phase =
+      2 *
+      Math.PI *
+      (SYNC_MARKER_START_FREQUENCY_HZ * t +
+        (0.5 * frequencyDelta * t * t) / durationSeconds);
+    let envelope = SYNC_MARKER_GAIN;
+    if (t < fadeInSeconds) {
+      envelope *= t / fadeInSeconds;
+    } else if (durationSeconds - t < fadeOutSeconds) {
+      envelope *= Math.max(0, (durationSeconds - t) / fadeOutSeconds);
+    }
+    template[i] = Math.sin(phase) * envelope;
+  }
+
+  return template;
+}
+
+function resampleLinear(
+  samples: Float32Array,
+  sampleRate: number,
+  targetSampleRate: number,
+): Float32Array {
+  if (sampleRate === targetSampleRate) return samples;
+
+  const length = Math.max(0, Math.floor((samples.length * targetSampleRate) / sampleRate));
+  const output = new Float32Array(length);
+  for (let i = 0; i < length; i++) {
+    const sourcePosition = (i * sampleRate) / targetSampleRate;
+    const left = Math.floor(sourcePosition);
+    const right = Math.min(samples.length - 1, left + 1);
+    const fraction = sourcePosition - left;
+    output[i] = samples[left] * (1 - fraction) + samples[right] * fraction;
+  }
+  return output;
+}
+
+function energy(samples: Float32Array): number {
+  let total = 0;
+  for (let i = 0; i < samples.length; i++) {
+    total += samples[i] * samples[i];
+  }
+  return total;
+}
+
+function normalizedCorrelationAt(
+  samples: Float32Array,
+  template: Float32Array,
+  templateEnergy: number,
+  offset: number,
+): number {
+  let dot = 0;
+  let sampleEnergy = 0;
+  for (let i = 0; i < template.length; i++) {
+    const sample = samples[offset + i];
+    dot += sample * template[i];
+    sampleEnergy += sample * sample;
+  }
+  if (sampleEnergy === 0 || templateEnergy === 0) return 0;
+  return dot / Math.sqrt(sampleEnergy * templateEnergy);
+}
+
+function emptyResult(status: SyncMarkerDetectionStatus, confidence = 0): SyncMarkerDetectionResult {
+  return {
+    status,
+    detectedAtMs: null,
+    detectedAtSamples: null,
+    confidence,
+    marker: markerInfo(),
+  };
+}
+
+export function detectSyncMarkerInPcm(
+  samples: Float32Array,
+  sampleRate: number,
+  options: DetectSyncMarkerOptions = {},
+): SyncMarkerDetectionResult {
+  const analysisSampleRate =
+    options.analysisSampleRate ?? DEFAULT_ANALYSIS_SAMPLE_RATE;
+  const maxSearchMs = options.maxSearchMs ?? DEFAULT_MAX_SEARCH_MS;
+  const detectedConfidence =
+    options.detectedConfidence ?? DETECTED_CONFIDENCE;
+  const lowConfidence = options.lowConfidence ?? LOW_CONFIDENCE;
+
+  const analysisSamples = resampleLinear(samples, sampleRate, analysisSampleRate);
+  const template = generateSyncMarkerTemplate(analysisSampleRate);
+  if (analysisSamples.length < template.length) return emptyResult("missing");
+
+  const latestOffset = Math.min(
+    analysisSamples.length - template.length,
+    Math.max(0, Math.floor((maxSearchMs / 1000) * analysisSampleRate)),
+  );
+  const templateEnergy = energy(template);
+  const coarseStep = Math.max(1, Math.round(0.004 * analysisSampleRate));
+  let bestOffset = 0;
+  let bestConfidence = -1;
+
+  for (let offset = 0; offset <= latestOffset; offset += coarseStep) {
+    const confidence = normalizedCorrelationAt(
+      analysisSamples,
+      template,
+      templateEnergy,
+      offset,
+    );
+    if (confidence > bestConfidence) {
+      bestConfidence = confidence;
+      bestOffset = offset;
+    }
+  }
+
+  const refineStart = Math.max(0, bestOffset - coarseStep);
+  const refineEnd = Math.min(latestOffset, bestOffset + coarseStep);
+  for (let offset = refineStart; offset <= refineEnd; offset++) {
+    const confidence = normalizedCorrelationAt(
+      analysisSamples,
+      template,
+      templateEnergy,
+      offset,
+    );
+    if (confidence > bestConfidence) {
+      bestConfidence = confidence;
+      bestOffset = offset;
+    }
+  }
+
+  const confidence = Math.max(0, bestConfidence);
+  if (confidence < lowConfidence) return emptyResult("missing", confidence);
+  if (confidence < detectedConfidence) {
+    return emptyResult("low_confidence", confidence);
+  }
+
+  const detectedAtMs = (bestOffset / analysisSampleRate) * 1000;
+  return {
+    status: "detected",
+    detectedAtMs,
+    detectedAtSamples: Math.round((bestOffset / analysisSampleRate) * sampleRate),
+    confidence,
+    marker: markerInfo(),
+  };
+}
+
+export async function decodeWebmToPcm(
+  bytes: Uint8Array,
+  sampleRate = DEFAULT_DECODE_SAMPLE_RATE,
+): Promise<Float32Array> {
+  const dir = await mkdtemp(join(tmpdir(), "cozytrack-marker-decode-"));
+  try {
+    const inputPath = join(dir, "input.webm");
+    const outputPath = join(dir, "output.f32le");
+    await writeFile(inputPath, bytes);
+    await execFileAsync(
+      process.env.FFMPEG_PATH ?? ffmpegStaticPath ?? "ffmpeg",
+      [
+        "-y",
+        "-hide_banner",
+        "-loglevel",
+        "error",
+        "-i",
+        inputPath,
+        "-ac",
+        "1",
+        "-ar",
+        String(sampleRate),
+        "-f",
+        "f32le",
+        outputPath,
+      ],
+    );
+    const output = await readFile(outputPath);
+    const arrayBuffer = output.buffer.slice(
+      output.byteOffset,
+      output.byteOffset + output.byteLength,
+    );
+    return new Float32Array(arrayBuffer);
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+}
+
+export async function detectSyncMarkerInWebmBytes(
+  bytes: Uint8Array,
+  options: DetectSyncMarkerOptions = {},
+): Promise<SyncMarkerDetectionResult> {
+  const samples = await decodeWebmToPcm(bytes, DEFAULT_DECODE_SAMPLE_RATE);
+  return detectSyncMarkerInPcm(samples, DEFAULT_DECODE_SAMPLE_RATE, options);
+}

--- a/src/lib/sync-marker-detection.ts
+++ b/src/lib/sync-marker-detection.ts
@@ -16,6 +16,10 @@ const execFileAsync = promisify(execFile);
 const DEFAULT_DECODE_SAMPLE_RATE = 48000;
 const DEFAULT_ANALYSIS_SAMPLE_RATE = 8000;
 const DEFAULT_MAX_SEARCH_MS = 5000;
+// Normalized-correlation thresholds tuned empirically against the WebM/Opus
+// round-trip fixture (clears ~0.55); >= DETECTED_CONFIDENCE counts as a match,
+// the band down to LOW_CONFIDENCE is reported as "low_confidence", and below
+// that is treated as "missing".
 const DETECTED_CONFIDENCE = 0.45;
 const LOW_CONFIDENCE = 0.35;
 
@@ -46,7 +50,7 @@ export type DetectSyncMarkerOptions = {
   lowConfidence?: number;
 };
 
-function markerInfo(): SyncMarkerDetectionResult["marker"] {
+export function markerInfo(): SyncMarkerDetectionResult["marker"] {
   return {
     durationMs: SYNC_MARKER_DURATION_MS,
     startFrequencyHz: SYNC_MARKER_START_FREQUENCY_HZ,
@@ -149,7 +153,22 @@ export function detectSyncMarkerInPcm(
     options.detectedConfidence ?? DETECTED_CONFIDENCE;
   const lowConfidence = options.lowConfidence ?? LOW_CONFIDENCE;
 
-  const analysisSamples = resampleLinear(samples, sampleRate, analysisSampleRate);
+  // Detection only searches the first `maxSearchMs`, so cap the input to that
+  // window (plus one marker length) before resampling to avoid processing the
+  // entire recording for long tracks.
+  const searchWindowMs = maxSearchMs + SYNC_MARKER_DURATION_MS;
+  const neededSourceSamples =
+    Math.ceil((searchWindowMs / 1000) * sampleRate) + 1;
+  const windowedSamples =
+    samples.length > neededSourceSamples
+      ? samples.subarray(0, neededSourceSamples)
+      : samples;
+
+  const analysisSamples = resampleLinear(
+    windowedSamples,
+    sampleRate,
+    analysisSampleRate,
+  );
   const template = generateSyncMarkerTemplate(analysisSampleRate);
   if (analysisSamples.length < template.length) return emptyResult("missing");
 
@@ -209,12 +228,17 @@ export function detectSyncMarkerInPcm(
 export async function decodeWebmToPcm(
   bytes: Uint8Array,
   sampleRate = DEFAULT_DECODE_SAMPLE_RATE,
+  maxDurationMs?: number,
 ): Promise<Float32Array> {
   const dir = await mkdtemp(join(tmpdir(), "cozytrack-marker-decode-"));
   try {
     const inputPath = join(dir, "input.webm");
     const outputPath = join(dir, "output.f32le");
     await writeFile(inputPath, bytes);
+    const durationArgs =
+      maxDurationMs && maxDurationMs > 0
+        ? ["-t", (maxDurationMs / 1000).toFixed(3)]
+        : [];
     await execFileAsync(
       process.env.FFMPEG_PATH ?? ffmpegStaticPath ?? "ffmpeg",
       [
@@ -224,6 +248,7 @@ export async function decodeWebmToPcm(
         "error",
         "-i",
         inputPath,
+        ...durationArgs,
         "-ac",
         "1",
         "-ar",
@@ -248,6 +273,14 @@ export async function detectSyncMarkerInWebmBytes(
   bytes: Uint8Array,
   options: DetectSyncMarkerOptions = {},
 ): Promise<SyncMarkerDetectionResult> {
-  const samples = await decodeWebmToPcm(bytes, DEFAULT_DECODE_SAMPLE_RATE);
+  const maxSearchMs = options.maxSearchMs ?? DEFAULT_MAX_SEARCH_MS;
+  // Only decode the window detection actually searches (plus one marker length
+  // of slack), so long recordings don't fill /tmp or blow up memory.
+  const maxDecodeMs = maxSearchMs + SYNC_MARKER_DURATION_MS;
+  const samples = await decodeWebmToPcm(
+    bytes,
+    DEFAULT_DECODE_SAMPLE_RATE,
+    maxDecodeMs,
+  );
   return detectSyncMarkerInPcm(samples, DEFAULT_DECODE_SAMPLE_RATE, options);
 }

--- a/src/lib/sync-marker.ts
+++ b/src/lib/sync-marker.ts
@@ -1,6 +1,9 @@
 export const SYNC_MARKER_VERSION = "chirp-v1";
 export const SYNC_MARKER_OFFSET_MS = 100;
 export const SYNC_MARKER_DURATION_MS = 300;
+export const SYNC_MARKER_START_FREQUENCY_HZ = 1200;
+export const SYNC_MARKER_END_FREQUENCY_HZ = 3200;
+export const SYNC_MARKER_GAIN = 0.12;
 
 export type SyncMarkerMetadata = {
   version: typeof SYNC_MARKER_VERSION;

--- a/src/lib/track-materialization.ts
+++ b/src/lib/track-materialization.ts
@@ -6,6 +6,16 @@ import { promisify } from "node:util";
 import ffmpegStaticPath from "ffmpeg-static";
 import { db } from "@/lib/db";
 import {
+  detectSyncMarkerInWebmBytes,
+  type SyncMarkerDetectionResult,
+} from "@/lib/sync-marker-detection";
+import {
+  SYNC_MARKER_DURATION_MS,
+  SYNC_MARKER_END_FREQUENCY_HZ,
+  SYNC_MARKER_GAIN,
+  SYNC_MARKER_START_FREQUENCY_HZ,
+} from "@/lib/sync-marker";
+import {
   getObjectBytes,
   putObjectBytes,
   trackRecordingKey,
@@ -22,6 +32,7 @@ type CompletedSegment = {
   segmentIndex: number;
   status: string;
   durationMs: number | null;
+  syncMarkerVersion: string | null;
 };
 
 export type MaterializationStatus =
@@ -47,9 +58,19 @@ export type MaterializeTrackDeps = {
   readObjectBytes?: (key: string) => Promise<Uint8Array>;
   writeObjectBytes?: (key: string, bytes: Uint8Array) => Promise<void>;
   remuxSegments?: (input: RemuxSegmentsInput) => Promise<void>;
+  detectSyncMarker?: (
+    input: DetectSyncMarkerInput,
+  ) => Promise<SyncMarkerDetectionResult>;
   partial?: boolean;
   allowIncompleteLatest?: boolean;
   skipMissingSegments?: boolean;
+};
+
+export type DetectSyncMarkerInput = {
+  sessionId: string;
+  trackId: string;
+  segmentId: string;
+  sourceKey: string;
 };
 
 async function segmentRecordingKeys(
@@ -146,6 +167,109 @@ async function remuxWebmSegments(
   }
 }
 
+async function detectSegmentSyncMarker(
+  input: DetectSyncMarkerInput,
+  deps: Required<Pick<MaterializeTrackDeps, "readObjectBytes">>,
+): Promise<SyncMarkerDetectionResult> {
+  const bytes = await deps.readObjectBytes(input.sourceKey);
+  return await detectSyncMarkerInWebmBytes(bytes);
+}
+
+async function persistSegmentSyncMarkerDetection(input: {
+  segmentId: string;
+  result: SyncMarkerDetectionResult;
+}) {
+  const { segmentId, result } = input;
+  await db.trackSegment.update({
+    where: { id: segmentId },
+    data: {
+      syncMarkerDetectionStatus: result.status,
+      syncMarkerDetectedAtMs: result.detectedAtMs,
+      syncMarkerDetectedAtSamples: result.detectedAtSamples,
+      syncMarkerConfidence: result.confidence,
+      syncMarkerAnalyzedAt: new Date(),
+    },
+  });
+}
+
+async function markSyncMarkerSourceMissing(segmentId: string) {
+  await persistSegmentSyncMarkerDetection({
+    segmentId,
+    result: {
+      status: "source_missing",
+      detectedAtMs: null,
+      detectedAtSamples: null,
+      confidence: 0,
+      marker: {
+        durationMs: SYNC_MARKER_DURATION_MS,
+        startFrequencyHz: SYNC_MARKER_START_FREQUENCY_HZ,
+        endFrequencyHz: SYNC_MARKER_END_FREQUENCY_HZ,
+        gain: SYNC_MARKER_GAIN,
+      },
+    },
+  });
+}
+
+async function detectAndPersistSyncMarkers(input: {
+  sessionId: string;
+  trackId: string;
+  segments: CompletedSegment[];
+  sourceKeys: string[];
+  deps: MaterializeTrackDeps;
+}) {
+  const { sessionId, trackId, segments, sourceKeys, deps } = input;
+  const markerSegments = segments
+    .map((segment, index) => ({ segment, sourceKey: sourceKeys[index] }))
+    .filter(
+      (entry): entry is { segment: CompletedSegment; sourceKey: string } =>
+        Boolean(entry.segment.syncMarkerVersion && entry.sourceKey),
+    );
+  if (markerSegments.length === 0) return;
+
+  const readObjectBytes = deps.readObjectBytes ?? getObjectBytes;
+  const detectSyncMarker =
+    deps.detectSyncMarker ??
+    ((detectInput: DetectSyncMarkerInput) =>
+      detectSegmentSyncMarker(detectInput, { readObjectBytes }));
+
+  await Promise.all(
+    markerSegments.map(async ({ segment, sourceKey }) => {
+      try {
+        const result = await detectSyncMarker({
+          sessionId,
+          trackId,
+          segmentId: segment.id,
+          sourceKey,
+        });
+        await persistSegmentSyncMarkerDetection({
+          segmentId: segment.id,
+          result,
+        });
+      } catch (error) {
+        console.error(
+          `[sync-marker] segment=${segment.id} detection failed:`,
+          error,
+        );
+        await persistSegmentSyncMarkerDetection({
+          segmentId: segment.id,
+          result: {
+            status: "decode_failed",
+            detectedAtMs: null,
+            detectedAtSamples: null,
+            confidence: 0,
+            marker: {
+              durationMs: SYNC_MARKER_DURATION_MS,
+              startFrequencyHz: SYNC_MARKER_START_FREQUENCY_HZ,
+              endFrequencyHz: SYNC_MARKER_END_FREQUENCY_HZ,
+              gain: SYNC_MARKER_GAIN,
+            },
+          },
+        });
+      }
+    }),
+  );
+}
+
 async function markTrackFailed(input: {
   trackId: string;
   currentS3Key: string;
@@ -225,6 +349,7 @@ export async function materializeTrack(
       status: true,
       durationMs: true,
       segmentIndex: true,
+      syncMarkerVersion: true,
     },
   });
 
@@ -262,6 +387,9 @@ export async function materializeTrack(
         existingSegments.push(segment);
       } else {
         skippedMissingSegment = true;
+        if (segment.syncMarkerVersion) {
+          await markSyncMarkerSourceMissing(segment.id);
+        }
       }
     }
     sourceSegments = existingSegments;
@@ -276,8 +404,8 @@ export async function materializeTrack(
     );
   }
 
+  let sourceKeys: string[] = [];
   try {
-    let sourceKeys: string[];
     if (sourceSegments.length === 1) {
       sourceKeys = [
         trackSegmentRecordingKey(
@@ -353,6 +481,14 @@ export async function materializeTrack(
       durationMs,
     };
   }
+
+  await detectAndPersistSyncMarkers({
+    sessionId: track.sessionId,
+    trackId,
+    segments: sourceSegments,
+    sourceKeys,
+    deps,
+  });
 
   return {
     trackId,

--- a/src/lib/track-materialization.ts
+++ b/src/lib/track-materialization.ts
@@ -58,6 +58,7 @@ export type MaterializeTrackDeps = {
   detectSyncMarker?: (
     input: DetectSyncMarkerInput,
   ) => Promise<SyncMarkerDetectionResult>;
+  detectionTimeoutMs?: number;
   partial?: boolean;
   allowIncompleteLatest?: boolean;
   skipMissingSegments?: boolean;
@@ -216,21 +217,56 @@ async function markSyncMarkerSourceMissing(segmentId: string) {
 // avoid spiking memory and /tmp usage on tracks with many marker segments.
 const SYNC_MARKER_DETECTION_CONCURRENCY = 2;
 
+// Upper bound on a single segment's detection. The ffmpeg decode has its own
+// inner timeout; this is a backstop covering any other hang so detection can't
+// stall the upload-completion request that awaits materializeTrack.
+const SYNC_MARKER_DETECTION_TIMEOUT_MS = 20000;
+
+class SyncMarkerDetectionTimeoutError extends Error {
+  constructor(timeoutMs: number) {
+    super(`sync-marker detection timed out after ${timeoutMs}ms`);
+    this.name = "SyncMarkerDetectionTimeoutError";
+  }
+}
+
+async function withDetectionTimeout<T>(
+  work: Promise<T>,
+  timeoutMs: number,
+): Promise<T> {
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  const timeout = new Promise<never>((_resolve, reject) => {
+    timer = setTimeout(
+      () => reject(new SyncMarkerDetectionTimeoutError(timeoutMs)),
+      timeoutMs,
+    );
+  });
+  try {
+    return await Promise.race([work, timeout]);
+  } finally {
+    if (timer) clearTimeout(timer);
+  }
+}
+
 async function detectAndPersistOneSegment(input: {
   sessionId: string;
   trackId: string;
   segment: CompletedSegment;
   sourceKey: string;
   detectSyncMarker: (input: DetectSyncMarkerInput) => Promise<SyncMarkerDetectionResult>;
+  timeoutMs: number;
 }) {
-  const { sessionId, trackId, segment, sourceKey, detectSyncMarker } = input;
+  const { sessionId, trackId, segment, sourceKey, detectSyncMarker, timeoutMs } =
+    input;
   try {
-    const result = await detectSyncMarker({
-      sessionId,
-      trackId,
-      segmentId: segment.id,
-      sourceKey,
-    });
+    const result = await withDetectionTimeout(
+      detectSyncMarker({
+        sessionId,
+        trackId,
+        segmentId: segment.id,
+        sourceKey,
+      }),
+      timeoutMs,
+    );
     await persistSegmentSyncMarkerDetection({ segmentId: segment.id, result });
   } catch (error) {
     console.error(
@@ -283,6 +319,8 @@ async function detectAndPersistSyncMarkers(input: {
       detectSegmentSyncMarker(detectInput, {
         readObjectBytesRange: deps.readObjectBytesRange ?? getObjectBytesRange,
       }));
+  const timeoutMs =
+    deps.detectionTimeoutMs ?? SYNC_MARKER_DETECTION_TIMEOUT_MS;
 
   for (
     let start = 0;
@@ -301,6 +339,7 @@ async function detectAndPersistSyncMarkers(input: {
           segment,
           sourceKey,
           detectSyncMarker,
+          timeoutMs,
         }),
       ),
     );

--- a/src/lib/track-materialization.ts
+++ b/src/lib/track-materialization.ts
@@ -7,14 +7,9 @@ import ffmpegStaticPath from "ffmpeg-static";
 import { db } from "@/lib/db";
 import {
   detectSyncMarkerInWebmBytes,
+  markerInfo,
   type SyncMarkerDetectionResult,
 } from "@/lib/sync-marker-detection";
-import {
-  SYNC_MARKER_DURATION_MS,
-  SYNC_MARKER_END_FREQUENCY_HZ,
-  SYNC_MARKER_GAIN,
-  SYNC_MARKER_START_FREQUENCY_HZ,
-} from "@/lib/sync-marker";
 import {
   getObjectBytes,
   putObjectBytes,
@@ -200,14 +195,56 @@ async function markSyncMarkerSourceMissing(segmentId: string) {
       detectedAtMs: null,
       detectedAtSamples: null,
       confidence: 0,
-      marker: {
-        durationMs: SYNC_MARKER_DURATION_MS,
-        startFrequencyHz: SYNC_MARKER_START_FREQUENCY_HZ,
-        endFrequencyHz: SYNC_MARKER_END_FREQUENCY_HZ,
-        gain: SYNC_MARKER_GAIN,
-      },
+      marker: markerInfo(),
     },
   });
+}
+
+// Detection decodes each segment with ffmpeg, so bound how many run at once to
+// avoid spiking memory and /tmp usage on tracks with many marker segments.
+const SYNC_MARKER_DETECTION_CONCURRENCY = 2;
+
+async function detectAndPersistOneSegment(input: {
+  sessionId: string;
+  trackId: string;
+  segment: CompletedSegment;
+  sourceKey: string;
+  detectSyncMarker: (input: DetectSyncMarkerInput) => Promise<SyncMarkerDetectionResult>;
+}) {
+  const { sessionId, trackId, segment, sourceKey, detectSyncMarker } = input;
+  try {
+    const result = await detectSyncMarker({
+      sessionId,
+      trackId,
+      segmentId: segment.id,
+      sourceKey,
+    });
+    await persistSegmentSyncMarkerDetection({ segmentId: segment.id, result });
+  } catch (error) {
+    console.error(
+      `[sync-marker] segment=${segment.id} detection failed:`,
+      error,
+    );
+    // Best-effort: record the failure, but never let a metadata write reject
+    // the materialization that already completed successfully.
+    try {
+      await persistSegmentSyncMarkerDetection({
+        segmentId: segment.id,
+        result: {
+          status: "decode_failed",
+          detectedAtMs: null,
+          detectedAtSamples: null,
+          confidence: 0,
+          marker: markerInfo(),
+        },
+      });
+    } catch (persistError) {
+      console.error(
+        `[sync-marker] segment=${segment.id} failed to persist decode_failed status:`,
+        persistError,
+      );
+    }
+  }
 }
 
 async function detectAndPersistSyncMarkers(input: {
@@ -218,6 +255,8 @@ async function detectAndPersistSyncMarkers(input: {
   deps: MaterializeTrackDeps;
 }) {
   const { sessionId, trackId, segments, sourceKeys, deps } = input;
+  // `sourceKeys` is built in lockstep with `segments` (same order/length) by the
+  // caller, so a positional zip is the correct segment -> recording mapping.
   const markerSegments = segments
     .map((segment, index) => ({ segment, sourceKey: sourceKeys[index] }))
     .filter(
@@ -232,42 +271,27 @@ async function detectAndPersistSyncMarkers(input: {
     ((detectInput: DetectSyncMarkerInput) =>
       detectSegmentSyncMarker(detectInput, { readObjectBytes }));
 
-  await Promise.all(
-    markerSegments.map(async ({ segment, sourceKey }) => {
-      try {
-        const result = await detectSyncMarker({
+  for (
+    let start = 0;
+    start < markerSegments.length;
+    start += SYNC_MARKER_DETECTION_CONCURRENCY
+  ) {
+    const batch = markerSegments.slice(
+      start,
+      start + SYNC_MARKER_DETECTION_CONCURRENCY,
+    );
+    await Promise.all(
+      batch.map(({ segment, sourceKey }) =>
+        detectAndPersistOneSegment({
           sessionId,
           trackId,
-          segmentId: segment.id,
+          segment,
           sourceKey,
-        });
-        await persistSegmentSyncMarkerDetection({
-          segmentId: segment.id,
-          result,
-        });
-      } catch (error) {
-        console.error(
-          `[sync-marker] segment=${segment.id} detection failed:`,
-          error,
-        );
-        await persistSegmentSyncMarkerDetection({
-          segmentId: segment.id,
-          result: {
-            status: "decode_failed",
-            detectedAtMs: null,
-            detectedAtSamples: null,
-            confidence: 0,
-            marker: {
-              durationMs: SYNC_MARKER_DURATION_MS,
-              startFrequencyHz: SYNC_MARKER_START_FREQUENCY_HZ,
-              endFrequencyHz: SYNC_MARKER_END_FREQUENCY_HZ,
-              gain: SYNC_MARKER_GAIN,
-            },
-          },
-        });
-      }
-    }),
-  );
+          detectSyncMarker,
+        }),
+      ),
+    );
+  }
 }
 
 async function markTrackFailed(input: {
@@ -482,13 +506,23 @@ export async function materializeTrack(
     };
   }
 
-  await detectAndPersistSyncMarkers({
-    sessionId: track.sessionId,
-    trackId,
-    segments: sourceSegments,
-    sourceKeys,
-    deps,
-  });
+  // Sync-marker detection is secondary metadata. The track is already marked
+  // complete above, so a detection failure must never reject materialization
+  // (which would turn a successful upload into a 500 and skip route cleanup).
+  try {
+    await detectAndPersistSyncMarkers({
+      sessionId: track.sessionId,
+      trackId,
+      segments: sourceSegments,
+      sourceKeys,
+      deps,
+    });
+  } catch (error) {
+    console.error(
+      `[sync-marker] track=${trackId} detection pass failed:`,
+      error,
+    );
+  }
 
   return {
     trackId,

--- a/src/lib/track-materialization.ts
+++ b/src/lib/track-materialization.ts
@@ -12,6 +12,7 @@ import {
 } from "@/lib/sync-marker-detection";
 import {
   getObjectBytes,
+  getObjectBytesRange,
   putObjectBytes,
   trackRecordingKey,
   trackSegmentRecordingExists,
@@ -51,6 +52,7 @@ export type RemuxSegmentsInput = {
 
 export type MaterializeTrackDeps = {
   readObjectBytes?: (key: string) => Promise<Uint8Array>;
+  readObjectBytesRange?: (key: string, maxBytes: number) => Promise<Uint8Array>;
   writeObjectBytes?: (key: string, bytes: Uint8Array) => Promise<void>;
   remuxSegments?: (input: RemuxSegmentsInput) => Promise<void>;
   detectSyncMarker?: (
@@ -162,11 +164,21 @@ async function remuxWebmSegments(
   }
 }
 
+// Detection only inspects the first ~5.3s, and ffmpeg's `-t` cap stops decoding
+// before reaching the end of this slice for any realistic Opus bitrate (Opus
+// tops out near 510kbps; 4 MiB holds >60s at that rate). Reading a bounded
+// range instead of the whole object keeps an arbitrarily large upload from
+// being downloaded and buffered into /tmp just to look at its start.
+const DETECTION_SOURCE_READ_MAX_BYTES = 4 * 1024 * 1024;
+
 async function detectSegmentSyncMarker(
   input: DetectSyncMarkerInput,
-  deps: Required<Pick<MaterializeTrackDeps, "readObjectBytes">>,
+  deps: Required<Pick<MaterializeTrackDeps, "readObjectBytesRange">>,
 ): Promise<SyncMarkerDetectionResult> {
-  const bytes = await deps.readObjectBytes(input.sourceKey);
+  const bytes = await deps.readObjectBytesRange(
+    input.sourceKey,
+    DETECTION_SOURCE_READ_MAX_BYTES,
+  );
   return await detectSyncMarkerInWebmBytes(bytes);
 }
 
@@ -265,11 +277,12 @@ async function detectAndPersistSyncMarkers(input: {
     );
   if (markerSegments.length === 0) return;
 
-  const readObjectBytes = deps.readObjectBytes ?? getObjectBytes;
   const detectSyncMarker =
     deps.detectSyncMarker ??
     ((detectInput: DetectSyncMarkerInput) =>
-      detectSegmentSyncMarker(detectInput, { readObjectBytes }));
+      detectSegmentSyncMarker(detectInput, {
+        readObjectBytesRange: deps.readObjectBytesRange ?? getObjectBytesRange,
+      }));
 
   for (
     let start = 0;

--- a/tests/sync-marker-detection.test.ts
+++ b/tests/sync-marker-detection.test.ts
@@ -1,0 +1,118 @@
+import { execFile } from "node:child_process";
+import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { promisify } from "node:util";
+import ffmpegStaticPath from "ffmpeg-static";
+import { describe, expect, it } from "vitest";
+import {
+  SYNC_MARKER_DURATION_MS,
+  SYNC_MARKER_END_FREQUENCY_HZ,
+  SYNC_MARKER_GAIN,
+  SYNC_MARKER_START_FREQUENCY_HZ,
+} from "@/lib/sync-marker";
+import {
+  detectSyncMarkerInPcm,
+  detectSyncMarkerInWebmBytes,
+  generateSyncMarkerTemplate,
+} from "@/lib/sync-marker-detection";
+
+const execFileAsync = promisify(execFile);
+
+function addMarker(
+  samples: Float32Array,
+  sampleRate: number,
+  startAtMs: number,
+  gain = 1,
+) {
+  const marker = generateSyncMarkerTemplate(sampleRate);
+  const startSample = Math.round((startAtMs / 1000) * sampleRate);
+  for (let i = 0; i < marker.length; i++) {
+    samples[startSample + i] += marker[i] * gain;
+  }
+}
+
+async function encodePcmToWebm(
+  samples: Float32Array,
+  sampleRate: number,
+): Promise<Uint8Array> {
+  const dir = await mkdtemp(join(tmpdir(), "cozytrack-marker-fixture-"));
+  try {
+    const pcmPath = join(dir, "input.f32le");
+    const webmPath = join(dir, "marker.webm");
+    await writeFile(pcmPath, Buffer.from(samples.buffer));
+    await execFileAsync(
+      process.env.FFMPEG_PATH ?? ffmpegStaticPath ?? "ffmpeg",
+      [
+        "-y",
+        "-hide_banner",
+        "-loglevel",
+        "error",
+        "-f",
+        "f32le",
+        "-ar",
+        String(sampleRate),
+        "-ac",
+        "1",
+        "-i",
+        pcmPath,
+        "-c:a",
+        "libopus",
+        "-b:a",
+        "64k",
+        webmPath,
+      ],
+    );
+    return await readFile(webmPath);
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+}
+
+describe("sync marker detection", () => {
+  it("detects the generated chirp marker in PCM within a tight tolerance", () => {
+    const sampleRate = 48000;
+    const markerAtMs = 260;
+    const samples = new Float32Array(sampleRate);
+    addMarker(samples, sampleRate, markerAtMs);
+
+    const result = detectSyncMarkerInPcm(samples, sampleRate);
+
+    expect(result.status).toBe("detected");
+    expect(result.detectedAtMs).toBeGreaterThanOrEqual(markerAtMs - 5);
+    expect(result.detectedAtMs).toBeLessThanOrEqual(markerAtMs + 5);
+    expect(result.confidence).toBeGreaterThan(0.8);
+    expect(result.marker).toMatchObject({
+      durationMs: SYNC_MARKER_DURATION_MS,
+      startFrequencyHz: SYNC_MARKER_START_FREQUENCY_HZ,
+      endFrequencyHz: SYNC_MARKER_END_FREQUENCY_HZ,
+      gain: SYNC_MARKER_GAIN,
+    });
+  });
+
+  it("does not silently mark missing markers as aligned", () => {
+    const sampleRate = 48000;
+    const samples = new Float32Array(sampleRate);
+
+    const result = detectSyncMarkerInPcm(samples, sampleRate);
+
+    expect(result.status).toBe("missing");
+    expect(result.detectedAtMs).toBeNull();
+    expect(result.confidence).toBeLessThan(0.35);
+  });
+
+  it("detects the marker after real WebM/Opus encoding and ffmpeg decode", async () => {
+    const sampleRate = 48000;
+    const markerAtMs = 180;
+    const samples = new Float32Array(sampleRate);
+    addMarker(samples, sampleRate, markerAtMs, 0.9);
+    const webm = await encodePcmToWebm(samples, sampleRate);
+
+    const result = await detectSyncMarkerInWebmBytes(webm);
+
+    expect(result.status).toBe("detected");
+    expect(result.detectedAtMs).toBeGreaterThanOrEqual(markerAtMs - 20);
+    expect(result.detectedAtMs).toBeLessThanOrEqual(markerAtMs + 20);
+    expect(result.confidence).toBeGreaterThan(0.55);
+  });
+});

--- a/tests/track-materialization.test.ts
+++ b/tests/track-materialization.test.ts
@@ -15,6 +15,14 @@ type TrackSegment = {
   segmentIndex: number;
   status: string;
   durationMs: number | null;
+  syncMarkerVersion?: string | null;
+  syncMarkerOffsetMs?: number | null;
+  syncMarkerDurationMs?: number | null;
+  syncMarkerDetectedAtMs?: number | null;
+  syncMarkerDetectedAtSamples?: number | null;
+  syncMarkerConfidence?: number | null;
+  syncMarkerDetectionStatus?: string | null;
+  syncMarkerAnalyzedAt?: Date | null;
 };
 
 const mocks = vi.hoisted(() => ({
@@ -25,6 +33,7 @@ const mocks = vi.hoisted(() => ({
   remuxSegments: vi.fn<
     (input: { sourceKeys: string[]; outputKey: string }) => Promise<void>
   >(),
+  detectSyncMarker: vi.fn(),
   trackSegmentRecordingExists: vi.fn<
     (sessionId: string, trackId: string, segmentId: string) => Promise<boolean>
   >(),
@@ -91,6 +100,21 @@ vi.mock("@/lib/db", () => ({
           return list;
         },
       ),
+      update: vi.fn(
+        async ({
+          where: { id },
+          data,
+        }: {
+          where: { id: string };
+          data: Partial<TrackSegment>;
+        }) => {
+          const existing = mocks.segments.get(id);
+          if (!existing) throw new Error("segment not found");
+          const updated = { ...existing, ...data };
+          mocks.segments.set(id, updated);
+          return { ...updated };
+        },
+      ),
     },
   },
 }));
@@ -150,6 +174,12 @@ beforeEach(() => {
   mocks.readObjectBytes.mockResolvedValue(new Uint8Array([1, 2, 3]));
   mocks.writeObjectBytes.mockResolvedValue(undefined);
   mocks.remuxSegments.mockResolvedValue(undefined);
+  mocks.detectSyncMarker.mockResolvedValue({
+    status: "detected",
+    detectedAtMs: 103,
+    detectedAtSamples: 4944,
+    confidence: 0.92,
+  });
   mocks.trackSegmentRecordingExists.mockResolvedValue(true);
   mocks.trackSegmentSourceRecordingExists.mockResolvedValue(false);
 });
@@ -178,6 +208,104 @@ describe("materializeTrack", () => {
     expect(mocks.readObjectBytes).not.toHaveBeenCalled();
     expect(mocks.writeObjectBytes).not.toHaveBeenCalled();
     expect(mocks.remuxSegments).not.toHaveBeenCalled();
+  });
+
+  it("persists sync marker detection metadata for completed source segments", async () => {
+    seedTrack();
+    seedSegment({
+      id: "track-1",
+      durationMs: 12345,
+      syncMarkerVersion: "chirp-v1",
+      syncMarkerOffsetMs: 100,
+      syncMarkerDurationMs: 300,
+    });
+
+    const result = await materializeTrack("track-1", {
+      readObjectBytes: mocks.readObjectBytes,
+      writeObjectBytes: mocks.writeObjectBytes,
+      remuxSegments: mocks.remuxSegments,
+      detectSyncMarker: mocks.detectSyncMarker,
+    });
+
+    expect(result.status).toBe("complete");
+    expect(mocks.detectSyncMarker).toHaveBeenCalledWith({
+      sessionId: "s1",
+      trackId: "track-1",
+      segmentId: "track-1",
+      sourceKey: "sessions/s1/tracks/track-1/recording.webm",
+    });
+    expect(mocks.segments.get("track-1")).toMatchObject({
+      syncMarkerDetectionStatus: "detected",
+      syncMarkerDetectedAtMs: 103,
+      syncMarkerDetectedAtSamples: 4944,
+      syncMarkerConfidence: 0.92,
+    });
+    expect(mocks.segments.get("track-1")?.syncMarkerAnalyzedAt).toBeInstanceOf(
+      Date,
+    );
+  });
+
+  it("records sync marker decode failures without failing materialization", async () => {
+    seedTrack();
+    seedSegment({
+      id: "track-1",
+      durationMs: 12345,
+      syncMarkerVersion: "chirp-v1",
+      syncMarkerOffsetMs: 100,
+      syncMarkerDurationMs: 300,
+    });
+    mocks.detectSyncMarker.mockRejectedValueOnce(new Error("ffmpeg failed"));
+
+    const result = await materializeTrack("track-1", {
+      readObjectBytes: mocks.readObjectBytes,
+      writeObjectBytes: mocks.writeObjectBytes,
+      remuxSegments: mocks.remuxSegments,
+      detectSyncMarker: mocks.detectSyncMarker,
+    });
+
+    expect(result.status).toBe("complete");
+    expect(mocks.tracks.get("track-1")).toMatchObject({
+      status: "complete",
+    });
+    expect(mocks.segments.get("track-1")).toMatchObject({
+      syncMarkerDetectionStatus: "decode_failed",
+      syncMarkerDetectedAtMs: null,
+      syncMarkerDetectedAtSamples: null,
+      syncMarkerConfidence: 0,
+    });
+  });
+
+  it("marks marker-bearing segments skipped during partial recovery as source_missing", async () => {
+    seedTrack({ status: "uploading" });
+    seedSegment({ id: "track-1", segmentIndex: 0, durationMs: 1000 });
+    seedSegment({
+      id: "segment-2",
+      segmentIndex: 1,
+      durationMs: 5000,
+      syncMarkerVersion: "chirp-v1",
+      syncMarkerOffsetMs: 100,
+      syncMarkerDurationMs: 300,
+    });
+    mocks.trackSegmentRecordingExists.mockImplementation(
+      async (_sessionId, _trackId, segmentId) => segmentId === "track-1",
+    );
+
+    const result = await materializeTrack("track-1", {
+      readObjectBytes: mocks.readObjectBytes,
+      writeObjectBytes: mocks.writeObjectBytes,
+      remuxSegments: mocks.remuxSegments,
+      detectSyncMarker: mocks.detectSyncMarker,
+      skipMissingSegments: true,
+    });
+
+    expect(result.status).toBe("complete");
+    expect(mocks.segments.get("segment-2")).toMatchObject({
+      syncMarkerDetectionStatus: "source_missing",
+      syncMarkerDetectedAtMs: null,
+      syncMarkerDetectedAtSamples: null,
+      syncMarkerConfidence: 0,
+    });
+    expect(mocks.detectSyncMarker).not.toHaveBeenCalled();
   });
 
   it("remuxes multiple completed segments into the logical track artifact", async () => {

--- a/tests/track-materialization.test.ts
+++ b/tests/track-materialization.test.ts
@@ -275,6 +275,38 @@ describe("materializeTrack", () => {
     });
   });
 
+  it("records decode_failed when detection hangs past the timeout without stalling materialization", async () => {
+    seedTrack();
+    seedSegment({
+      id: "track-1",
+      durationMs: 12345,
+      syncMarkerVersion: "chirp-v1",
+      syncMarkerOffsetMs: 100,
+      syncMarkerDurationMs: 300,
+    });
+    // A detector that never resolves would tie up the upload-completion request
+    // if detection were not bounded by a timeout.
+    mocks.detectSyncMarker.mockImplementation(
+      () => new Promise(() => {}),
+    );
+
+    const result = await materializeTrack("track-1", {
+      readObjectBytes: mocks.readObjectBytes,
+      writeObjectBytes: mocks.writeObjectBytes,
+      remuxSegments: mocks.remuxSegments,
+      detectSyncMarker: mocks.detectSyncMarker,
+      detectionTimeoutMs: 10,
+    });
+
+    expect(result.status).toBe("complete");
+    expect(mocks.segments.get("track-1")).toMatchObject({
+      syncMarkerDetectionStatus: "decode_failed",
+      syncMarkerDetectedAtMs: null,
+      syncMarkerDetectedAtSamples: null,
+      syncMarkerConfidence: 0,
+    });
+  });
+
   it("marks marker-bearing segments skipped during partial recovery as source_missing", async () => {
     seedTrack({ status: "uploading" });
     seedSegment({ id: "track-1", segmentIndex: 0, durationMs: 1000 });


### PR DESCRIPTION
## Summary

- Add a deterministic sync-marker detector for the generated chirp, including ffmpeg-backed WebM/Opus decode.
- Persist marker detection status, position, confidence, and analysis timestamp on `TrackSegment`.
- Run detection after track materialization without changing download behavior, and record explicit `decode_failed` / `source_missing` states for recoverable paths.

Closes #139

## Validation

- `npm test -- tests/sync-marker-detection.test.ts tests/track-materialization.test.ts`
- `npm run typecheck`
- `npm test`

`npm run test:integration` was attempted, but the suite is guarded and refused to run without `COZYTRACK_INTEGRATION_TEST=1`.
