### PR TITLE
[codex] Refresh roadmap reconciliation audit

### DIFF
--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -1,6 +1,6 @@
 # Cozytrack Roadmap
 
-This roadmap was reconciled against every GitHub issue that was open on June 18, 2026.
+This roadmap was reconciled against every GitHub issue that was open on June 23, 2026 (44 open issues).
 
 - Every currently open issue appears exactly once as a primary roadmap entry below.
 - No open issues are explicitly excluded right now.


### PR DESCRIPTION
## Summary
- refresh the roadmap audit stamp to the June 23, 2026 open-issue snapshot
- record that `docs/FEATURES.md` still matches all 44 open GitHub issues exactly

## Verification
- exact issue-number audit against the live `gh issue list` snapshot: 44 issues, 44 roadmap entries, no missing, extra, or duplicate issue numbers