### PR TITLE
Reconcile roadmap with open issue #148

### DIFF
--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -1,6 +1,6 @@
 # Cozytrack Roadmap
 
-This roadmap was reconciled against every GitHub issue that was open on June 23, 2026 (44 open issues).
+This roadmap was reconciled against every GitHub issue that was open on June 25, 2026 (45 open issues).
 
 - Every currently open issue appears exactly once as a primary roadmap entry below.
 - No open issues are explicitly excluded right now.
@@ -55,6 +55,7 @@ This roadmap was reconciled against every GitHub issue that was open on June 23,
 - #117 Finalize/recovery/completion race integration tests: add a small real-service race suite as another `#108` follow-up for the highest-risk lifecycle ordering cases.
 - #63 Deferred multi-participant browser E2E harness: promote this after the narrower integration coverage and reconnect stack stabilize, or sooner if a real LiveKit/multi-participant regression demands it.
 - #109 Simplify recording and recovery code after the recent safety work: do this after the current safety path and its coverage work stabilize so cleanup is guided by proven invariants instead of guesswork.
+- #148 Durable `RecordingTake` terminal state and stop retry flow: land this before more reconnect auto-resume work, because `#111`, `#134`, and later reconnect follow-ons need a server-authoritative stopped-vs-recording lifecycle instead of inference from missing stop writes.
 - #140 Generate aligned stem artifacts for recording takes: do this after `#7` settles the alignment metadata strategy and after the existing logical-track materialization path, because aligned stems need authoritative marker offsets and a stable cross-track export step.
 - #141 Serve aligned stems by default while preserving raw downloads: land this after `#140`, because the UI and download routes need aligned derived artifacts before they can switch user-facing defaults safely.
 - #142 Optional drift analysis and correction for long takes: keep this after `#140`, because the first aligned-export path should ship with fixed-offset alignment before drift measurement and time-stretch logic add more moving parts.
@@ -68,5 +69,5 @@ This roadmap was reconciled against every GitHub issue that was open on June 23,
 - #7 Cross-track conversation latency design: clarify which timing metadata is authoritative, where alignment logic should live, and what sync quality threshold is acceptable for MVP versus later export polish.
 - #68 Transcript-driven in-browser audio editor: keep this future-facing until recording reliability, session browsing, and export basics are stable enough to support an editor roadmap.
 - #72 Role-aware guest and cohost studio view: decide whether cohosts ever get dashboard access from inside an active session, or whether non-host participants should always stay inside a simplified studio shell.
-- #111 Reconnect-safe recording architecture plan: settle the remaining architecture choices around participant identity semantics, materialization timing, and how reconnect gaps should be represented before extending the stack further.
+- #111 Reconnect-safe recording architecture plan: settle the remaining architecture choices around participant identity semantics, materialization timing, and how reconnect gaps should be represented after the `#148` lifecycle hardening removes the current stop-state inference gap.
 - #135 Local multichannel recording alongside a remote participant: clarify whether local tracks should appear as separate local participants, host-owned track slots, or a multi-channel capture mode, and how that choice should interact with `#111`, `#72`, and `#75`.


### PR DESCRIPTION
## Summary
- update `docs/FEATURES.md` for the June 25, 2026 open-issue audit
- add issue #148 to the sequenced reconnect/materialization work
- refresh the #111 note to reflect the new lifecycle-hardening prerequisite

## Verification
- audited open issues vs roadmap entries: 45 issue numbers, 45 roadmap entries
- confirmed no missing, extra, or duplicate primary roadmap entries