### PR TITLE
Harden RecordingTake lifecycle: authoritative status + durable stop

### DIFF
--- a/prisma/migrations/20260625000000_recording_take_status/migration.sql
+++ b/prisma/migrations/20260625000000_recording_take_status/migration.sql
@@ -1,0 +1,21 @@
+-- Make the take lifecycle authoritative: "recording" while in progress,
+-- "stopped" once terminally stopped. Previously "active" was inferred from
+-- stoppedAt IS NULL, which conflated "recording in progress" with "no stop
+-- write has landed yet". status removes that ambiguity.
+ALTER TABLE "RecordingTake"
+    ADD COLUMN "status" TEXT NOT NULL DEFAULT 'recording';
+
+-- Backfill: any take that already has a stop timestamp is terminally stopped.
+UPDATE "RecordingTake"
+    SET "status" = 'stopped'
+    WHERE "stoppedAt" IS NOT NULL;
+
+-- Re-key the one-active-take-per-session guard on status instead of stoppedAt.
+DROP INDEX "RecordingTake_sessionId_active_unique";
+
+CREATE UNIQUE INDEX "RecordingTake_sessionId_active_unique"
+    ON "RecordingTake"("sessionId")
+    WHERE "status" = 'recording';
+
+CREATE INDEX "RecordingTake_sessionId_status_idx"
+    ON "RecordingTake"("sessionId", "status");

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -29,12 +29,17 @@ model RecordingTake {
   session             Session                          @relation(fields: [sessionId], references: [id])
   startedAt           DateTime
   stoppedAt           DateTime?
+  // Authoritative lifecycle state: "recording" while in progress, "stopped"
+  // once the host has terminally stopped it. A stopped take is never resumable.
+  // stoppedAt stays as the timestamp; status is the source of truth for "active".
+  status              String                           @default("recording") // recording | stopped
   createdAt           DateTime                         @default(now())
   updatedAt           DateTime                         @updatedAt
   participantStatuses RecordingTakeParticipantStatus[]
   tracks              Track[]
 
   @@index([sessionId, stoppedAt])
+  @@index([sessionId, status])
 }
 
 model RecordingTakeParticipantStatus {

--- a/src/app/api/sessions/[id]/recording-state/route.ts
+++ b/src/app/api/sessions/[id]/recording-state/route.ts
@@ -11,6 +11,7 @@ type RecordingTakeWithStatuses = {
   sessionId: string;
   startedAt: Date;
   stoppedAt: Date | null;
+  status: string;
   participantStatuses?: Array<{
     participantId: string;
     participantName: string | null;
@@ -78,11 +79,13 @@ async function requireSession(sessionId: string) {
   });
 }
 
+// "Active" is now authoritative on status, not on stoppedAt IS NULL. A take is
+// resumable/active only while its status is "recording".
 async function findActiveTake(
   sessionId: string,
 ): Promise<RecordingTakeWithStatuses | null> {
   return await db.recordingTake.findFirst({
-    where: { sessionId, stoppedAt: null },
+    where: { sessionId, status: "recording" },
     orderBy: { startedAt: "desc" },
     include: {
       participantStatuses: { orderBy: { participantName: "asc" } },
@@ -97,6 +100,7 @@ function serializeTake(take: RecordingTakeWithStatuses | null) {
     sessionId: take.sessionId,
     startedAt: take.startedAt.toISOString(),
     stoppedAt: take.stoppedAt?.toISOString() ?? null,
+    status: take.status,
     participantStatuses: (take.participantStatuses ?? []).map((status) => ({
       participantId: status.participantId,
       participantName: status.participantName,
@@ -226,6 +230,9 @@ export async function POST(
       }
     }
 
+    // Stop is idempotent: if there's no recording take (already stopped, or a
+    // retry after the first stop landed), report inactive instead of erroring,
+    // so a retrying client converges.
     const current = await findActiveTake(id);
     if (!current) {
       return NextResponse.json(serializeRecordingState(null, false));
@@ -233,7 +240,7 @@ export async function POST(
 
     const stopped = await db.recordingTake.update({
       where: { id: current.id },
-      data: { stoppedAt: new Date() },
+      data: { stoppedAt: new Date(), status: "stopped" },
       include: {
         participantStatuses: { orderBy: { participantName: "asc" } },
       },

--- a/src/app/api/upload/presign/route.ts
+++ b/src/app/api/upload/presign/route.ts
@@ -77,7 +77,7 @@ function isUniqueConstraintError(error: unknown): boolean {
 
 async function findActiveTake(sessionId: string): Promise<{ id: string } | null> {
   return await db.recordingTake.findFirst({
-    where: { sessionId, stoppedAt: null },
+    where: { sessionId, status: "recording" },
     orderBy: { startedAt: "desc" },
     select: { id: true },
   });

--- a/src/app/studio/[id]/page.tsx
+++ b/src/app/studio/[id]/page.tsx
@@ -1891,6 +1891,7 @@ function RoomContent({
       } catch (err) {
         console.error("Failed to close recording take:", err);
         showNotification("Couldn't update recording state");
+        return;
       }
       try {
         await transport.sendControlMessage({ type: "recording_stop" });

--- a/src/app/studio/[id]/page.tsx
+++ b/src/app/studio/[id]/page.tsx
@@ -1884,6 +1884,9 @@ function RoomContent({
     stoppingRef.current = true;
     try {
       try {
+        // stopRecordingTake retries transient failures internally, so reaching
+        // this catch means the stop genuinely could not be persisted after
+        // several attempts (not just a single blip).
         await stopRecordingTake(sessionId);
       } catch (err) {
         console.error("Failed to close recording take:", err);

--- a/src/lib/recording-state.ts
+++ b/src/lib/recording-state.ts
@@ -16,8 +16,20 @@ export type RecordingTakeState = {
     sessionId: string;
     startedAt: string;
     stoppedAt: string | null;
+    status: string;
   } | null;
 };
+
+// Carries the HTTP status so callers can decide whether a failure is worth
+// retrying (5xx and network errors are; 4xx are not).
+export class RecordingStateError extends Error {
+  readonly status?: number;
+  constructor(message: string, status?: number) {
+    super(message);
+    this.name = "RecordingStateError";
+    this.status = status;
+  }
+}
 
 async function parseError(res: Response): Promise<string> {
   try {
@@ -41,10 +53,25 @@ async function jsonRequest<T>(
   });
 
   if (!res.ok) {
-    throw new Error(await parseError(res));
+    throw new RecordingStateError(await parseError(res), res.status);
   }
 
   return (await res.json()) as T;
+}
+
+const STOP_MAX_ATTEMPTS = 5;
+const STOP_RETRY_BASE_MS = 300;
+
+function isRetryableStopError(error: unknown): boolean {
+  // Network/fetch rejections have no HTTP status — always worth retrying.
+  if (!(error instanceof RecordingStateError)) return true;
+  if (error.status === undefined) return true;
+  // Server errors are transient; client errors (403/404/400) are not.
+  return error.status >= 500;
+}
+
+function delay(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
 }
 
 export async function startRecordingTake(
@@ -58,14 +85,34 @@ export async function startRecordingTake(
   );
 }
 
+// Stopping must be durable: a transient failure here previously left the room's
+// take active server-side, which let returning/new participants resume a
+// recording the host had already ended. The stop endpoint is idempotent, so we
+// retry transient failures until the stop is confirmed (or attempts run out).
 export async function stopRecordingTake(
   sessionId: string,
+  options: { maxAttempts?: number; retryDelayMs?: number } = {},
 ): Promise<RecordingTakeState> {
-  return await jsonRequest<RecordingTakeState>(
-    `/api/sessions/${encodeURIComponent(sessionId)}/recording-state`,
-    "POST",
-    { active: false },
-  );
+  const maxAttempts = Math.max(1, options.maxAttempts ?? STOP_MAX_ATTEMPTS);
+  const path = `/api/sessions/${encodeURIComponent(sessionId)}/recording-state`;
+
+  let lastError: unknown;
+  for (let attempt = 1; attempt <= maxAttempts; attempt += 1) {
+    try {
+      return await jsonRequest<RecordingTakeState>(path, "POST", {
+        active: false,
+      });
+    } catch (error) {
+      lastError = error;
+      if (attempt >= maxAttempts || !isRetryableStopError(error)) {
+        throw error;
+      }
+      const baseDelay = options.retryDelayMs ?? STOP_RETRY_BASE_MS;
+      await delay(baseDelay * attempt);
+    }
+  }
+
+  throw lastError;
 }
 
 export async function reportRecordingTakeParticipantStatus(

--- a/tests/helpers/studio-page.ts
+++ b/tests/helpers/studio-page.ts
@@ -13,11 +13,29 @@ const studioPageHarness = vi.hoisted(() => ({
     sessionId: "session-guest",
   },
   getToken: vi.fn(async () => "livekit-token"),
+  sendControlMessage: vi.fn(async () => undefined),
+  onControlMessage: vi.fn(() => vi.fn()),
   republishAllTracks: vi.fn(async () => undefined),
   getUserMedia: vi.fn(),
   enumerateDevices: vi.fn(),
   listBackups: vi.fn(async () => []),
   audioContexts: [] as unknown[],
+  startRecordingTake: vi.fn(),
+  stopRecordingTake: vi.fn(),
+  reportRecordingTakeParticipantStatus: vi.fn(async () => undefined),
+  getPresignedUploadTarget: vi.fn(),
+  getPresignedUploadUrl: vi.fn(async () => "https://s3.example/recording.webm"),
+  uploadChunk: vi.fn(async () => undefined),
+  completeUpload: vi.fn(async () => undefined),
+  recorderOnChunk: vi.fn(),
+  recorderStart: vi.fn(async () => undefined),
+  recorderStop: vi.fn(),
+  recorderChunkHandler: undefined as
+    | ((chunk: Blob, index: number) => void)
+    | undefined,
+  syncMarkerPrepare: vi.fn(async () => undefined),
+  syncMarkerPlay: vi.fn(async () => undefined),
+  syncMarkerDispose: vi.fn(),
 }));
 
 vi.mock("next/navigation", () => ({
@@ -44,11 +62,45 @@ vi.mock("@/lib/livekit", () => ({
 
 vi.mock("@/lib/transport", () => ({
   useTransport: () => ({
-    sendControlMessage: vi.fn(async () => undefined),
-    onControlMessage: vi.fn(() => vi.fn()),
+    sendControlMessage: studioPageHarness.sendControlMessage,
+    onControlMessage: studioPageHarness.onControlMessage,
   }),
   isHostSender: () => false,
   parseParticipantMetadata: () => null,
+}));
+
+vi.mock("@/lib/recording-state", () => ({
+  startRecordingTake: studioPageHarness.startRecordingTake,
+  stopRecordingTake: studioPageHarness.stopRecordingTake,
+  reportRecordingTakeParticipantStatus:
+    studioPageHarness.reportRecordingTakeParticipantStatus,
+}));
+
+vi.mock("@/lib/upload", () => ({
+  getPresignedUploadTarget: studioPageHarness.getPresignedUploadTarget,
+  getPresignedUploadUrl: studioPageHarness.getPresignedUploadUrl,
+  uploadChunk: studioPageHarness.uploadChunk,
+  completeUpload: studioPageHarness.completeUpload,
+}));
+
+vi.mock("@/lib/recorder", () => ({
+  CozyRecorder: vi.fn().mockImplementation(function () {
+    return {
+      onChunk: studioPageHarness.recorderOnChunk,
+      start: studioPageHarness.recorderStart,
+      stop: studioPageHarness.recorderStop,
+    };
+  }),
+}));
+
+vi.mock("@/lib/recording-sync-marker", () => ({
+  createSyncMarkerRecordingStream: (stream: MediaStream) => ({
+    stream,
+    marker: undefined,
+    prepare: studioPageHarness.syncMarkerPrepare,
+    playSyncMarker: studioPageHarness.syncMarkerPlay,
+    dispose: studioPageHarness.syncMarkerDispose,
+  }),
 }));
 
 vi.mock("@/lib/audio-downmix", () => ({
@@ -148,6 +200,8 @@ beforeEach(() => {
   studioPageHarness.authMeResponse = { role: "guest", name: "Guest Alice" };
   studioPageHarness.route.sessionId = "session-guest";
   studioPageHarness.getToken.mockClear();
+  studioPageHarness.sendControlMessage.mockReset().mockResolvedValue(undefined);
+  studioPageHarness.onControlMessage.mockReset().mockReturnValue(vi.fn());
   studioPageHarness.republishAllTracks.mockClear();
   studioPageHarness.getUserMedia.mockReset().mockResolvedValue(mediaStream());
   studioPageHarness.enumerateDevices
@@ -155,6 +209,52 @@ beforeEach(() => {
     .mockResolvedValue([audioInput("usb-mic", "Shure MV7")]);
   studioPageHarness.listBackups.mockClear();
   studioPageHarness.audioContexts.length = 0;
+  studioPageHarness.startRecordingTake.mockReset().mockResolvedValue({
+    active: true,
+    sessionStartedAt: "2026-06-27T12:00:00.000Z",
+    take: {
+      id: "take-1",
+      sessionId: "session-host",
+      startedAt: "2026-06-27T12:00:00.000Z",
+      stoppedAt: null,
+    },
+  });
+  studioPageHarness.stopRecordingTake.mockReset().mockResolvedValue({
+    active: false,
+    sessionStartedAt: null,
+    take: {
+      id: "take-1",
+      sessionId: "session-host",
+      startedAt: "2026-06-27T12:00:00.000Z",
+      stoppedAt: "2026-06-27T12:01:00.000Z",
+    },
+  });
+  studioPageHarness.reportRecordingTakeParticipantStatus
+    .mockReset()
+    .mockResolvedValue(undefined);
+  studioPageHarness.getPresignedUploadTarget.mockReset().mockResolvedValue({
+    url: "https://s3.example/0.webm",
+    key: "sessions/session-host/tracks/track-1/0.webm",
+    recordingToken: "recording-token",
+    trackId: "track-1",
+    segmentId: "segment-1",
+  });
+  studioPageHarness.getPresignedUploadUrl
+    .mockReset()
+    .mockResolvedValue("https://s3.example/recording.webm");
+  studioPageHarness.uploadChunk.mockReset().mockResolvedValue(undefined);
+  studioPageHarness.completeUpload.mockReset().mockResolvedValue(undefined);
+  studioPageHarness.recorderOnChunk.mockReset().mockImplementation((handler) => {
+    studioPageHarness.recorderChunkHandler = handler;
+  });
+  studioPageHarness.recorderStart.mockReset().mockResolvedValue(undefined);
+  studioPageHarness.recorderStop
+    .mockReset()
+    .mockResolvedValue(new Blob(["recording"], { type: "audio/webm" }));
+  studioPageHarness.recorderChunkHandler = undefined;
+  studioPageHarness.syncMarkerPrepare.mockReset().mockResolvedValue(undefined);
+  studioPageHarness.syncMarkerPlay.mockReset().mockResolvedValue(undefined);
+  studioPageHarness.syncMarkerDispose.mockReset();
 
   vi.stubGlobal("AudioContext", FakeAudioContext);
   vi.stubGlobal(
@@ -211,5 +311,34 @@ export function renderGuestStudioPage({
       });
     },
     screen,
+  };
+}
+
+export function renderHostStudioPage({
+  name = "Pasha",
+  sessionId = "session-host",
+}: {
+  name?: string;
+  sessionId?: string;
+} = {}) {
+  studioPageHarness.authMeResponse = { role: "host" };
+  studioPageHarness.route.sessionId = sessionId;
+
+  render(React.createElement(StudioPage));
+
+  return {
+    async join() {
+      const nameInput = await screen.findByPlaceholderText("Enter your name");
+      fireEvent.change(nameInput, { target: { value: name } });
+
+      fireEvent.click(screen.getByRole("button", { name: "Join Studio" }));
+      await screen.findByTestId("livekit-room");
+
+      await waitFor(() => {
+        expect(studioPageHarness.audioContexts.length).toBeGreaterThan(0);
+      });
+    },
+    screen,
+    harness: studioPageHarness,
   };
 }

--- a/tests/helpers/studio-page.ts
+++ b/tests/helpers/studio-page.ts
@@ -13,7 +13,7 @@ const studioPageHarness = vi.hoisted(() => ({
     sessionId: "session-guest",
   },
   getToken: vi.fn(async () => "livekit-token"),
-  sendControlMessage: vi.fn(async () => undefined),
+  sendControlMessage: vi.fn(async (_message: { type: string }) => undefined),
   onControlMessage: vi.fn(() => vi.fn()),
   republishAllTracks: vi.fn(async () => undefined),
   getUserMedia: vi.fn(),

--- a/tests/logical-track-segments.test.ts
+++ b/tests/logical-track-segments.test.ts
@@ -9,6 +9,7 @@ type RecordingTake = {
   sessionId: string;
   startedAt: Date;
   stoppedAt: Date | null;
+  status: string;
 };
 
 type Track = {
@@ -61,14 +62,15 @@ vi.mock("@/lib/db", () => ({
       ),
       findFirst: vi.fn(
         async ({
-          where: { sessionId, stoppedAt },
+          where: { sessionId, status },
         }: {
-          where: { sessionId: string; stoppedAt: null };
+          where: { sessionId: string; status?: string };
         }) => {
           return (
             Array.from(mocks.recordingTakes.values()).find(
               (take) =>
-                take.sessionId === sessionId && take.stoppedAt === stoppedAt,
+                take.sessionId === sessionId &&
+                (status === undefined || take.status === status),
             ) ?? null
           );
         },
@@ -339,6 +341,7 @@ describe("logical track segments", () => {
       sessionId: "s1",
       startedAt: new Date("2026-06-11T00:00:00.000Z"),
       stoppedAt: null,
+      status: "recording",
     });
     mocks.resolvePrincipal.mockResolvedValue({
       kind: "guest",
@@ -383,6 +386,7 @@ describe("logical track segments", () => {
       sessionId: "s1",
       startedAt: new Date("2026-06-11T00:00:00.000Z"),
       stoppedAt: null,
+      status: "recording",
     });
     mocks.tracks.set("logical-track", {
       id: "logical-track",
@@ -445,6 +449,7 @@ describe("logical track segments", () => {
       sessionId: "s1",
       startedAt: new Date("2026-06-11T00:00:00.000Z"),
       stoppedAt: null,
+      status: "recording",
     });
     mocks.tracks.set("logical-track", {
       id: "logical-track",
@@ -830,12 +835,14 @@ describe("logical track segments", () => {
       sessionId: "s1",
       startedAt: new Date("2026-06-11T00:00:00.000Z"),
       stoppedAt: new Date("2026-06-11T00:05:00.000Z"),
+      status: "stopped",
     });
     mocks.recordingTakes.set("take-b", {
       id: "take-b",
       sessionId: "s1",
       startedAt: new Date("2026-06-11T00:06:00.000Z"),
       stoppedAt: null,
+      status: "recording",
     });
     mocks.resolvePrincipal.mockResolvedValue({
       kind: "guest",
@@ -866,6 +873,7 @@ describe("logical track segments", () => {
       sessionId: "s2",
       startedAt: new Date("2026-06-11T00:00:00.000Z"),
       stoppedAt: null,
+      status: "recording",
     });
     mocks.resolvePrincipal.mockResolvedValue({
       kind: "guest",
@@ -975,6 +983,7 @@ describe("logical track segments", () => {
       sessionId: "s1",
       startedAt: new Date("2026-06-11T00:00:00.000Z"),
       stoppedAt: null,
+      status: "recording",
     });
     mocks.tracks.set("logical-track", {
       id: "logical-track",

--- a/tests/recording-state-client.test.ts
+++ b/tests/recording-state-client.test.ts
@@ -1,0 +1,73 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  RecordingStateError,
+  stopRecordingTake,
+} from "@/lib/recording-state";
+
+function jsonResponse(body: unknown, status = 200): Response {
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    statusText: `status ${status}`,
+    json: async () => body,
+  } as unknown as Response;
+}
+
+const inactiveState = {
+  active: false,
+  sessionStartedAt: null,
+  take: null,
+};
+
+let fetchMock: ReturnType<typeof vi.fn>;
+
+beforeEach(() => {
+  fetchMock = vi.fn();
+  vi.stubGlobal("fetch", fetchMock);
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe("stopRecordingTake durability", () => {
+  it("retries a 5xx failure until the stop is confirmed", async () => {
+    fetchMock
+      .mockResolvedValueOnce(jsonResponse({ error: "boom" }, 503))
+      .mockResolvedValueOnce(jsonResponse(inactiveState, 200));
+
+    const result = await stopRecordingTake("s1", { retryDelayMs: 0 });
+
+    expect(result).toEqual(inactiveState);
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
+  it("retries a network/fetch rejection", async () => {
+    fetchMock
+      .mockRejectedValueOnce(new TypeError("network down"))
+      .mockResolvedValueOnce(jsonResponse(inactiveState, 200));
+
+    const result = await stopRecordingTake("s1", { retryDelayMs: 0 });
+
+    expect(result).toEqual(inactiveState);
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
+  it("does not retry a 4xx client error", async () => {
+    fetchMock.mockResolvedValueOnce(jsonResponse({ error: "forbidden" }, 403));
+
+    await expect(
+      stopRecordingTake("s1", { retryDelayMs: 0 }),
+    ).rejects.toBeInstanceOf(RecordingStateError);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("gives up after exhausting attempts and throws the last error", async () => {
+    fetchMock.mockResolvedValue(jsonResponse({ error: "still down" }, 500));
+
+    await expect(
+      stopRecordingTake("s1", { maxAttempts: 3, retryDelayMs: 0 }),
+    ).rejects.toBeInstanceOf(RecordingStateError);
+    expect(fetchMock).toHaveBeenCalledTimes(3);
+  });
+});

--- a/tests/recording-take.test.ts
+++ b/tests/recording-take.test.ts
@@ -5,6 +5,7 @@ type RecordingTake = {
   sessionId: string;
   startedAt: Date;
   stoppedAt: Date | null;
+  status: string;
   participantStatuses?: RecordingTakeParticipantStatus[];
 };
 
@@ -38,7 +39,7 @@ function cloneTake(take: RecordingTake): RecordingTake {
 function activeTakeFor(sessionId: string): RecordingTake | null {
   return (
     Array.from(mocks.takes.values()).find(
-      (take) => take.sessionId === sessionId && take.stoppedAt === null,
+      (take) => take.sessionId === sessionId && take.status === "recording",
     ) ?? null
   );
 }
@@ -55,10 +56,10 @@ vi.mock("@/lib/db", () => ({
         async ({
           where,
         }: {
-          where: { sessionId: string; stoppedAt?: null };
+          where: { sessionId: string; status?: string; stoppedAt?: null };
         }) => {
           let take: RecordingTake | null = null;
-          if (where.stoppedAt === null) {
+          if (where.status === "recording" || where.stoppedAt === null) {
             take = activeTakeFor(where.sessionId);
           } else {
             take =
@@ -79,13 +80,14 @@ vi.mock("@/lib/db", () => ({
         async ({
           data,
         }: {
-          data: { sessionId: string; startedAt: Date };
+          data: { sessionId: string; startedAt: Date; status?: string };
         }) => {
           const take: RecordingTake = {
             id: `take-${mocks.nextTakeId++}`,
             sessionId: data.sessionId,
             startedAt: data.startedAt,
             stoppedAt: null,
+            status: data.status ?? "recording",
           };
           mocks.takes.set(take.id, take);
           return cloneTake(take);
@@ -97,7 +99,7 @@ vi.mock("@/lib/db", () => ({
           data,
         }: {
           where: { id: string };
-          data: { stoppedAt?: Date | null };
+          data: { stoppedAt?: Date | null; status?: string };
         }) => {
           const take = mocks.takes.get(id);
           if (!take) throw new Error("take not found");
@@ -277,6 +279,7 @@ describe("/api/sessions/[id]/recording-state", () => {
       sessionId: "s1",
       startedAt: new Date("2026-06-01T12:00:00.000Z"),
       stoppedAt: null,
+      status: "recording",
     });
     mocks.resolvePrincipal.mockResolvedValue({
       kind: "guest",
@@ -321,6 +324,7 @@ describe("/api/sessions/[id]/recording-state", () => {
       sessionId: "s1",
       startedAt: new Date("2026-06-01T12:00:00.000Z"),
       stoppedAt: null,
+      status: "recording",
     });
 
     const res = await reportRecordingState(
@@ -333,5 +337,101 @@ describe("/api/sessions/[id]/recording-state", () => {
     );
 
     expect(res.status).toBe(400);
+  });
+
+  it("marks the take stopped (status + timestamp) on host stop", async () => {
+    await setRecordingState(
+      request("POST", {
+        active: true,
+        sessionStartedAt: "2026-06-01T12:00:00.000Z",
+      }),
+      params(),
+    );
+
+    const stop = await setRecordingState(
+      request("POST", { active: false }),
+      params(),
+    );
+    expect(stop.status).toBe(200);
+
+    const stored = mocks.takes.get("take-1");
+    expect(stored?.status).toBe("stopped");
+    expect(stored?.stoppedAt).toEqual(expect.any(Date));
+  });
+
+  it("treats status, not stoppedAt, as the active signal", async () => {
+    // A take whose stop write landed (status stopped) must never read as active,
+    // even though a returning participant might still hold a stale reference.
+    mocks.takes.set("take-done", {
+      id: "take-done",
+      sessionId: "s1",
+      startedAt: new Date("2026-06-01T12:00:00.000Z"),
+      stoppedAt: new Date("2026-06-01T12:05:00.000Z"),
+      status: "stopped",
+    });
+
+    const read = await getRecordingState(request("GET"), params());
+    expect(read.status).toBe(200);
+    await expect(read.json()).resolves.toMatchObject({
+      active: false,
+      sessionStartedAt: null,
+      take: null,
+    });
+  });
+
+  it("is idempotent when stop is retried after it already landed", async () => {
+    await setRecordingState(
+      request("POST", {
+        active: true,
+        sessionStartedAt: "2026-06-01T12:00:00.000Z",
+      }),
+      params(),
+    );
+
+    const first = await setRecordingState(
+      request("POST", { active: false }),
+      params(),
+    );
+    const second = await setRecordingState(
+      request("POST", { active: false }),
+      params(),
+    );
+
+    expect(first.status).toBe(200);
+    expect(second.status).toBe(200);
+    await expect(second.json()).resolves.toMatchObject({
+      active: false,
+      take: null,
+    });
+    // The already-stopped take is untouched; no second take is created.
+    expect(mocks.takes).toHaveLength(1);
+    expect(mocks.takes.get("take-1")?.status).toBe("stopped");
+  });
+
+  it("starts a fresh take after the previous one was stopped", async () => {
+    await setRecordingState(
+      request("POST", {
+        active: true,
+        sessionStartedAt: "2026-06-01T12:00:00.000Z",
+      }),
+      params(),
+    );
+    await setRecordingState(request("POST", { active: false }), params());
+
+    const restart = await setRecordingState(
+      request("POST", {
+        active: true,
+        sessionStartedAt: "2026-06-01T12:10:00.000Z",
+      }),
+      params(),
+    );
+
+    expect(restart.status).toBe(200);
+    await expect(restart.json()).resolves.toMatchObject({
+      active: true,
+      sessionStartedAt: "2026-06-01T12:10:00.000Z",
+      take: { id: "take-2", status: "recording" },
+    });
+    expect(mocks.takes).toHaveLength(2);
   });
 });

--- a/tests/studio-page.test.ts
+++ b/tests/studio-page.test.ts
@@ -1,5 +1,6 @@
+import { fireEvent, waitFor } from "@testing-library/react";
 import { describe, expect, it } from "vitest";
-import { renderGuestStudioPage } from "./helpers/studio-page";
+import { renderGuestStudioPage, renderHostStudioPage } from "./helpers/studio-page";
 
 describe("StudioPage participant role labels", () => {
   it("does not label the local participant as host when a guest joins", async () => {
@@ -9,5 +10,37 @@ describe("StudioPage participant role labels", () => {
 
     expect(studio.screen.getByText("Guest Alice")).toBeTruthy();
     expect(studio.screen.queryByText("host")).toBeNull();
+  });
+
+  it("does not broadcast or stop locally when the authoritative stop fails", async () => {
+    const studio = renderHostStudioPage();
+
+    await studio.join();
+
+    fireEvent.click(studio.screen.getByRole("button", { name: "Start recording" }));
+    await studio.screen.findByRole("button", { name: "Stop recording" });
+
+    studio.harness.sendControlMessage.mockClear();
+    studio.harness.recorderStop.mockClear();
+    studio.harness.stopRecordingTake.mockRejectedValueOnce(
+      new Error("stop exhausted retries"),
+    );
+
+    fireEvent.click(studio.screen.getByRole("button", { name: "Stop recording" }));
+
+    await waitFor(() => {
+      expect(studio.harness.stopRecordingTake).toHaveBeenCalledWith("session-host");
+    });
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    expect(
+      studio.harness.sendControlMessage.mock.calls.some(
+        ([message]) => message.type === "recording_stop",
+      ),
+    ).toBe(false);
+    expect(studio.harness.recorderStop).not.toHaveBeenCalled();
+    expect(
+      studio.screen.getByRole("button", { name: "Stop recording" }),
+    ).toBeTruthy();
   });
 });


### PR DESCRIPTION
Closes #148. Foundation for the reconnect auto-resume (#134 / #137), which will be re-derived on top of this.

## Why

Building reconnect auto-resume on the existing take model produced a steady stream of P1/P2 review findings that were all the *same* defect: "active" was inferred from `stoppedAt IS NULL`, which means **"no stop write has landed yet"** — not "recording is genuinely ongoing." A failed/transient stop left the take active server-side, so returning or new participants could resume a recording the host had already ended.

## What

1. **Authoritative `RecordingTake.status`** (`recording` | `stopped`) — `stoppedAt` stays the timestamp; `status` is the source of truth for "active." Migration backfills stopped takes and re-keys the one-active-take-per-session unique index on `status = 'recording'`.
2. **Active-take queries key on status** in both the recording-state and presign routes. Host stop sets `status = 'stopped'`; a stopped take never reads as active. Stop is idempotent — a retry after the first stop landed converges to inactive `200`.
3. **Durable stop** — `stopRecordingTake` retries transient failures (5xx + network errors) with backoff until confirmed; 4xx are not retried. This removes the log-and-continue path that was the original source of resurrection.

## Scope

**Out of scope (follow-up reconnect PR, stack 5):** the catch-up effect, the heartbeat liveness lease, and the returning-host/guest browser smoke tests. The `host_stopped_room` marker inference does not exist on `main` (it lives only in the unmerged #137) — with `status` authoritative, that re-derivation won't need it.

## Tests

- `npm test` — 27 files, 201 tests passed.
- `npm run typecheck`, `npm run lint`, `npx prisma validate` — all passed.
- New: status-is-the-active-signal; stop sets status + timestamp; idempotent retried stop; fresh take after stop; client retry-on-5xx / retry-on-network / no-retry-on-4xx / give-up-after-max-attempts.
- Existing recording-take / logical-track-segments assertions unchanged; only their mock DB harnesses learned the new column.

🤖 Generated with [Claude Code](https://claude.com/claude-code)