### PR TITLE
Reject new recordings on finalized sessions (#151)

### DIFF
--- a/src/app/api/sessions/[id]/finalize/route.ts
+++ b/src/app/api/sessions/[id]/finalize/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest, NextResponse } from "next/server";
 import { db } from "@/lib/db";
+import { withSessionLock } from "@/lib/session-lock";
 import { recoverTrack } from "@/lib/recovery";
 
 export async function POST(
@@ -38,29 +39,39 @@ export async function POST(
         }
       }
 
-      const refreshed = stuck.length
-        ? await db.track.findMany({
-            where: { id: { in: stuck.map((t) => t.id) } },
-            select: { id: true, participantName: true, status: true },
-          })
-        : [];
+      // Decide pending-vs-finalize and flip the status under a per-session
+      // advisory lock (issue #151). Re-reading every track inside the lock —
+      // not just the previously-stuck subset — means a track a concurrent
+      // recording start created is seen here and blocks finalize, instead of
+      // being stranded on a session we've just marked `ready`. The lock also
+      // serializes against the start guards, so a start can't create a track
+      // between our read and our status flip.
+      const decision = await withSessionLock(id, async (tx) => {
+        const tracks = await tx.track.findMany({
+          where: { sessionId: id },
+          select: { id: true, participantName: true, status: true },
+        });
 
-      const pending = refreshed
-        .filter((t) => t.status !== "complete" && t.status !== "failed")
-        .map((t) => ({
-          trackId: t.id,
-          participantName: t.participantName,
-          status: t.status,
-        }));
+        const pending = tracks
+          .filter((t) => t.status !== "complete" && t.status !== "failed")
+          .map((t) => ({
+            trackId: t.id,
+            participantName: t.participantName,
+            status: t.status,
+          }));
 
-      if (pending.length > 0) {
-        return NextResponse.json({ pending }, { status: 409 });
-      }
+        if (pending.length > 0) return { pending };
 
-      await db.session.updateMany({
-        where: { id, status: "recording" },
-        data: { status: "ready", finalizedAt: new Date() },
+        await tx.session.updateMany({
+          where: { id, status: "recording" },
+          data: { status: "ready", finalizedAt: new Date() },
+        });
+        return { pending };
       });
+
+      if (decision.pending.length > 0) {
+        return NextResponse.json({ pending: decision.pending }, { status: 409 });
+      }
     }
 
     const updated = await db.session.findUnique({

--- a/src/app/api/sessions/[id]/finalize/route.ts
+++ b/src/app/api/sessions/[id]/finalize/route.ts
@@ -47,6 +47,17 @@ export async function POST(
       // serializes against the start guards, so a start can't create a track
       // between our read and our status flip.
       const decision = await withSessionLock(id, async (tx) => {
+        // A recording start is two-phase: /recording-state creates the take,
+        // then presign creates the first track. Checking only tracks would let
+        // finalize slip through the window after the take exists but before any
+        // track does — it would mark the session `ready`, then presign 409s and
+        // the in-progress recording is stranded. Block on an active take too so
+        // that whole start is atomic w.r.t. finalize.
+        const activeTake = await tx.recordingTake.findFirst({
+          where: { sessionId: id, status: "recording" },
+          select: { id: true },
+        });
+
         const tracks = await tx.track.findMany({
           where: { sessionId: id },
           select: { id: true, participantName: true, status: true },
@@ -60,16 +71,18 @@ export async function POST(
             status: t.status,
           }));
 
-        if (pending.length > 0) return { pending };
+        if (activeTake || pending.length > 0) {
+          return { blocked: true as const, pending };
+        }
 
         await tx.session.updateMany({
           where: { id, status: "recording" },
           data: { status: "ready", finalizedAt: new Date() },
         });
-        return { pending };
+        return { blocked: false as const, pending };
       });
 
-      if (decision.pending.length > 0) {
+      if (decision.blocked) {
         return NextResponse.json({ pending: decision.pending }, { status: 409 });
       }
     }

--- a/src/app/api/sessions/[id]/finalize/route.ts
+++ b/src/app/api/sessions/[id]/finalize/route.ts
@@ -55,7 +55,8 @@ export async function POST(
         // that whole start is atomic w.r.t. finalize.
         const activeTake = await tx.recordingTake.findFirst({
           where: { sessionId: id, status: "recording" },
-          select: { id: true },
+          orderBy: { startedAt: "desc" },
+          select: { id: true, startedAt: true },
         });
 
         const tracks = await tx.track.findMany({
@@ -71,19 +72,35 @@ export async function POST(
             status: t.status,
           }));
 
-        if (activeTake || pending.length > 0) {
-          return { blocked: true as const, pending };
+        if (pending.length > 0) {
+          return { kind: "pending" as const, pending };
+        }
+
+        if (activeTake) {
+          return { kind: "active_take" as const, activeTake };
         }
 
         await tx.session.updateMany({
           where: { id, status: "recording" },
           data: { status: "ready", finalizedAt: new Date() },
         });
-        return { blocked: false as const, pending };
+        return { kind: "ready" as const };
       });
 
-      if (decision.blocked) {
+      if (decision.kind === "pending") {
         return NextResponse.json({ pending: decision.pending }, { status: 409 });
+      }
+      if (decision.kind === "active_take") {
+        return NextResponse.json(
+          {
+            error: "An unfinished recording take is still active.",
+            activeTake: {
+              id: decision.activeTake.id,
+              startedAt: decision.activeTake.startedAt.toISOString(),
+            },
+          },
+          { status: 409 },
+        );
       }
     }
 

--- a/src/app/api/sessions/[id]/recording-state/route.ts
+++ b/src/app/api/sessions/[id]/recording-state/route.ts
@@ -75,7 +75,7 @@ async function requirePrincipal(req: NextRequest, sessionId: string) {
 async function requireSession(sessionId: string) {
   return await db.session.findUnique({
     where: { id: sessionId },
-    select: { id: true },
+    select: { id: true, status: true },
   });
 }
 
@@ -202,6 +202,20 @@ export async function POST(
     const active = body?.active === true;
 
     if (active) {
+      // A finalized/ready session has already been handed off for ingest.
+      // Starting a new take here would attach fresh audio to an old session
+      // id (issue #151), so the recording never ingests. Reject the start;
+      // the operator must create a new session instead.
+      if (session.status === "ready") {
+        return NextResponse.json(
+          {
+            error:
+              "This session is finalized and can no longer be recorded into. Start a new session.",
+          },
+          { status: 409 },
+        );
+      }
+
       const startedAt = parseStartedAt(body?.sessionStartedAt);
       if (!startedAt) {
         return NextResponse.json(

--- a/src/app/api/sessions/[id]/recording-state/route.ts
+++ b/src/app/api/sessions/[id]/recording-state/route.ts
@@ -248,9 +248,54 @@ export async function POST(
       return NextResponse.json(serializeRecordingState(outcome.take, true));
     }
 
-    // Stop is idempotent: if there's no recording take (already stopped, or a
-    // retry after the first stop landed), report inactive instead of erroring,
-    // so a retrying client converges.
+    const requestedTakeId =
+      typeof body?.takeId === "string" && body.takeId.length > 0
+        ? body.takeId
+        : null;
+
+    if (requestedTakeId) {
+      const target = await db.recordingTake.findUnique({
+        where: { id: requestedTakeId },
+        include: {
+          participantStatuses: { orderBy: { participantName: "asc" } },
+        },
+      });
+      if (target && target.sessionId !== id) {
+        return NextResponse.json({ error: "forbidden" }, { status: 403 });
+      }
+
+      // Recovery stops only the take finalize reported. A delayed confirmation
+      // must never stop a newer active take that appeared in the meantime.
+      if (target?.status === "recording") {
+        await db.recordingTake.updateMany({
+          where: { id: requestedTakeId, sessionId: id, status: "recording" },
+          data: { stoppedAt: new Date(), status: "stopped" },
+        });
+      }
+
+      const remainingActive = await findActiveTake(id);
+      if (remainingActive) {
+        return NextResponse.json(
+          serializeRecordingState(remainingActive, true),
+        );
+      }
+
+      const stoppedTarget = target
+        ? await db.recordingTake.findUnique({
+            where: { id: requestedTakeId },
+            include: {
+              participantStatuses: { orderBy: { participantName: "asc" } },
+            },
+          })
+        : null;
+      return NextResponse.json(
+        serializeRecordingState(stoppedTarget, false),
+      );
+    }
+
+    // Untargeted stop keeps its existing idempotent behavior: if there's no
+    // active take (already stopped, or a retry after the first stop landed),
+    // report inactive so a retrying client converges.
     const current = await findActiveTake(id);
     if (!current) {
       return NextResponse.json(serializeRecordingState(null, false));

--- a/src/app/api/sessions/[id]/recording-state/route.ts
+++ b/src/app/api/sessions/[id]/recording-state/route.ts
@@ -312,21 +312,32 @@ export async function POST(
       );
     }
 
-    // Untargeted stop keeps its existing idempotent behavior: if there's no
-    // active take (already stopped, or a retry after the first stop landed),
-    // report inactive so a retrying client converges.
-    const current = await findActiveTake(id);
-    if (!current) {
+    // Serialize the legacy untargeted stop with starts, recovery stops, and
+    // initial presigns. Otherwise a delayed presign can validate the active
+    // take, lose the race to this stop, and create writable artifacts for a
+    // take that is already stopped.
+    const stopped = await withSessionLock(id, async (tx) => {
+      const current = await tx.recordingTake.findFirst({
+        where: { sessionId: id, status: "recording" },
+        orderBy: { startedAt: "desc" },
+      });
+      if (!current) return null;
+
+      return await tx.recordingTake.update({
+        where: { id: current.id },
+        data: { stoppedAt: new Date(), status: "stopped" },
+        include: {
+          participantStatuses: { orderBy: { participantName: "asc" } },
+        },
+      });
+    });
+
+    // Keep the existing idempotent behavior: if there's no active take
+    // (already stopped, or a retry after the first stop landed), report
+    // inactive so a retrying client converges.
+    if (!stopped) {
       return NextResponse.json(serializeRecordingState(null, false));
     }
-
-    const stopped = await db.recordingTake.update({
-      where: { id: current.id },
-      data: { stoppedAt: new Date(), status: "stopped" },
-      include: {
-        participantStatuses: { orderBy: { participantName: "asc" } },
-      },
-    });
     return NextResponse.json(serializeRecordingState(stopped, false));
   } catch (error) {
     console.error("Failed to update recording state:", error);

--- a/src/app/api/sessions/[id]/recording-state/route.ts
+++ b/src/app/api/sessions/[id]/recording-state/route.ts
@@ -254,42 +254,61 @@ export async function POST(
         : null;
 
     if (requestedTakeId) {
-      const target = await db.recordingTake.findUnique({
-        where: { id: requestedTakeId },
-        include: {
-          participantStatuses: { orderBy: { participantName: "asc" } },
-        },
+      const outcome = await withSessionLock(id, async (tx) => {
+        const target = await tx.recordingTake.findUnique({
+          where: { id: requestedTakeId },
+          include: {
+            participantStatuses: { orderBy: { participantName: "asc" } },
+          },
+        });
+        if (target && target.sessionId !== id) {
+          return { kind: "forbidden" as const };
+        }
+
+        // Recovery stops only the take finalize reported. A delayed
+        // confirmation must never stop a newer active take that appeared in
+        // the meantime. Sharing the session advisory lock with initial presign
+        // also prevents stop from landing between its take-status read and its
+        // track/segment creation.
+        if (target?.status === "recording") {
+          await tx.recordingTake.updateMany({
+            where: { id: requestedTakeId, sessionId: id, status: "recording" },
+            data: { stoppedAt: new Date(), status: "stopped" },
+          });
+        }
+
+        const remainingActive = await tx.recordingTake.findFirst({
+          where: { sessionId: id, status: "recording" },
+          orderBy: { startedAt: "desc" },
+          include: {
+            participantStatuses: { orderBy: { participantName: "asc" } },
+          },
+        });
+        if (remainingActive) {
+          return { kind: "active" as const, take: remainingActive };
+        }
+
+        const stoppedTarget = target
+          ? await tx.recordingTake.findUnique({
+              where: { id: requestedTakeId },
+              include: {
+                participantStatuses: { orderBy: { participantName: "asc" } },
+              },
+            })
+          : null;
+        return { kind: "inactive" as const, take: stoppedTarget };
       });
-      if (target && target.sessionId !== id) {
+
+      if (outcome.kind === "forbidden") {
         return NextResponse.json({ error: "forbidden" }, { status: 403 });
       }
-
-      // Recovery stops only the take finalize reported. A delayed confirmation
-      // must never stop a newer active take that appeared in the meantime.
-      if (target?.status === "recording") {
-        await db.recordingTake.updateMany({
-          where: { id: requestedTakeId, sessionId: id, status: "recording" },
-          data: { stoppedAt: new Date(), status: "stopped" },
-        });
-      }
-
-      const remainingActive = await findActiveTake(id);
-      if (remainingActive) {
+      if (outcome.kind === "active") {
         return NextResponse.json(
-          serializeRecordingState(remainingActive, true),
+          serializeRecordingState(outcome.take, true),
         );
       }
-
-      const stoppedTarget = target
-        ? await db.recordingTake.findUnique({
-            where: { id: requestedTakeId },
-            include: {
-              participantStatuses: { orderBy: { participantName: "asc" } },
-            },
-          })
-        : null;
       return NextResponse.json(
-        serializeRecordingState(stoppedTarget, false),
+        serializeRecordingState(outcome.take, false),
       );
     }
 

--- a/src/app/api/sessions/[id]/recording-state/route.ts
+++ b/src/app/api/sessions/[id]/recording-state/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest, NextResponse } from "next/server";
 import { db } from "@/lib/db";
+import { withSessionLock } from "@/lib/session-lock";
 import {
   principalParticipantId,
   resolvePrincipal,
@@ -143,15 +144,6 @@ function serializeParticipantStatus(status: {
   };
 }
 
-function isUniqueActiveTakeConflict(error: unknown): boolean {
-  return (
-    typeof error === "object" &&
-    error !== null &&
-    "code" in error &&
-    (error as { code?: unknown }).code === "P2002"
-  );
-}
-
 export async function GET(
   req: NextRequest,
   { params }: { params: Promise<{ id: string }> },
@@ -202,20 +194,6 @@ export async function POST(
     const active = body?.active === true;
 
     if (active) {
-      // A finalized/ready session has already been handed off for ingest.
-      // Starting a new take here would attach fresh audio to an old session
-      // id (issue #151), so the recording never ingests. Reject the start;
-      // the operator must create a new session instead.
-      if (session.status === "ready") {
-        return NextResponse.json(
-          {
-            error:
-              "This session is finalized and can no longer be recorded into. Start a new session.",
-          },
-          { status: 409 },
-        );
-      }
-
       const startedAt = parseStartedAt(body?.sessionStartedAt);
       if (!startedAt) {
         return NextResponse.json(
@@ -224,24 +202,50 @@ export async function POST(
         );
       }
 
-      const existing = await findActiveTake(id);
-      if (existing) {
-        return NextResponse.json(serializeRecordingState(existing, true));
-      }
+      // Re-read status and create the take under a per-session advisory lock so
+      // a concurrent finalize cannot interleave between the status check and the
+      // take creation (issue #151). Without the lock this is a check-then-create
+      // race: finalize could flip the session to `ready` just after we read
+      // `recording`, and we'd attach a new take to an already-ingested session.
+      // Holding the lock also serializes competing starts, so the loser observes
+      // the winner's take instead of colliding on the unique-active-take index.
+      const outcome = await withSessionLock(id, async (tx) => {
+        const fresh = await tx.session.findUnique({
+          where: { id },
+          select: { status: true },
+        });
+        if (!fresh) return { kind: "not_found" as const };
+        if (fresh.status === "ready") return { kind: "finalized" as const };
 
-      try {
-        const created = await db.recordingTake.create({
+        const existing = await tx.recordingTake.findFirst({
+          where: { sessionId: id, status: "recording" },
+          orderBy: { startedAt: "desc" },
+          include: {
+            participantStatuses: { orderBy: { participantName: "asc" } },
+          },
+        });
+        if (existing) return { kind: "existing" as const, take: existing };
+
+        const created = await tx.recordingTake.create({
           data: { sessionId: id, startedAt },
           include: { participantStatuses: true },
         });
-        return NextResponse.json(serializeRecordingState(created, true));
-      } catch (error) {
-        if (isUniqueActiveTakeConflict(error)) {
-          const current = await findActiveTake(id);
-          return NextResponse.json(serializeRecordingState(current, Boolean(current)));
-        }
-        throw error;
+        return { kind: "created" as const, take: created };
+      });
+
+      if (outcome.kind === "not_found") {
+        return NextResponse.json({ error: "Session not found" }, { status: 404 });
       }
+      if (outcome.kind === "finalized") {
+        return NextResponse.json(
+          {
+            error:
+              "This session is finalized and can no longer be recorded into. Start a new session.",
+          },
+          { status: 409 },
+        );
+      }
+      return NextResponse.json(serializeRecordingState(outcome.take, true));
     }
 
     // Stop is idempotent: if there's no recording take (already stopped, or a

--- a/src/app/api/upload/complete/route.ts
+++ b/src/app/api/upload/complete/route.ts
@@ -50,13 +50,23 @@ export async function POST(req: NextRequest) {
 
     const existingSegment = await db.trackSegment.findUnique({
       where: { id: segmentId },
-      select: { trackId: true },
+      select: { trackId: true, status: true },
     });
     if (!existingSegment) {
       return NextResponse.json({ error: "Track segment not found" }, { status: 404 });
     }
     if (existingSegment.trackId !== trackId) {
       return NextResponse.json({ error: "forbidden" }, { status: 403 });
+    }
+    if (existingSegment.status === "complete") {
+      const track = await db.track.findUnique({ where: { id: trackId } });
+      return NextResponse.json(track);
+    }
+    if (existingSegment.status === "failed") {
+      return NextResponse.json(
+        { error: "Track segment is terminal" },
+        { status: 409 },
+      );
     }
 
     await db.trackSegment.update({

--- a/src/app/api/upload/complete/route.ts
+++ b/src/app/api/upload/complete/route.ts
@@ -39,7 +39,6 @@ export async function POST(req: NextRequest) {
 
     const existingTrack = await db.track.findUnique({
       where: { id: trackId },
-      select: { sessionId: true },
     });
     if (!existingTrack) {
       return NextResponse.json({ error: "Track not found" }, { status: 404 });
@@ -58,9 +57,11 @@ export async function POST(req: NextRequest) {
     if (existingSegment.trackId !== trackId) {
       return NextResponse.json({ error: "forbidden" }, { status: 403 });
     }
-    if (existingSegment.status === "complete") {
-      const track = await db.track.findUnique({ where: { id: trackId } });
-      return NextResponse.json(track);
+    if (
+      existingSegment.status === "complete" &&
+      existingTrack.status === "complete"
+    ) {
+      return NextResponse.json(existingTrack);
     }
     if (existingSegment.status === "failed") {
       return NextResponse.json(
@@ -69,14 +70,16 @@ export async function POST(req: NextRequest) {
       );
     }
 
-    await db.trackSegment.update({
-      where: { id: segmentId },
-      data: {
-        status: "complete",
-        durationMs: durationMs ?? null,
-        completedAt: new Date(),
-      },
-    });
+    if (existingSegment.status !== "complete") {
+      await db.trackSegment.update({
+        where: { id: segmentId },
+        data: {
+          status: "complete",
+          durationMs: durationMs ?? null,
+          completedAt: new Date(),
+        },
+      });
+    }
 
     const segments = await db.trackSegment.findMany({
       where: { trackId },

--- a/src/app/api/upload/presign/route.ts
+++ b/src/app/api/upload/presign/route.ts
@@ -501,7 +501,9 @@ export async function POST(req: NextRequest) {
       partNumber === 9999
         ? trackSegmentRecordingKey(sessionId, logicalTrackId, segmentId)
         : trackSegmentPartKey(sessionId, logicalTrackId, segmentId, partNumber);
-    const url = await getPresignedPutUrl(key);
+    const url = await getPresignedPutUrl(key, {
+      createOnly: partNumber === 9999,
+    });
 
     return NextResponse.json({
       url,

--- a/src/app/api/upload/presign/route.ts
+++ b/src/app/api/upload/presign/route.ts
@@ -112,13 +112,16 @@ async function ensureLogicalTrackAndSegment(input: {
   if (requestedTakeId) {
     const requestedTake = await client.recordingTake.findUnique({
       where: { id: requestedTakeId },
-      select: { id: true, sessionId: true },
+      select: { id: true, sessionId: true, status: true },
     });
     if (!requestedTake) {
       throw new Error("TAKE_NOT_FOUND");
     }
     if (requestedTake.sessionId !== sessionId) {
       throw new Error("TAKE_SESSION_MISMATCH");
+    }
+    if (requestedTake.status !== "recording") {
+      throw new Error("TAKE_NOT_ACTIVE");
     }
     activeTake = { id: requestedTake.id };
   } else {
@@ -416,6 +419,12 @@ export async function POST(req: NextRequest) {
           return NextResponse.json(
             { error: "Recording take not found" },
             { status: 404 }
+          );
+        }
+        if (error instanceof Error && error.message === "TAKE_NOT_ACTIVE") {
+          return NextResponse.json(
+            { error: "Recording take is no longer active" },
+            { status: 409 }
           );
         }
         throw error;

--- a/src/app/api/upload/presign/route.ts
+++ b/src/app/api/upload/presign/route.ts
@@ -1,5 +1,7 @@
 import { NextRequest, NextResponse } from "next/server";
+import { Prisma } from "@prisma/client";
 import { db } from "@/lib/db";
+import { withSessionLock } from "@/lib/session-lock";
 import {
   trackRecordingKey,
   trackSegmentPartKey,
@@ -45,15 +47,23 @@ function isUniqueConstraintError(error: unknown): boolean {
   );
 }
 
-async function findActiveTake(sessionId: string): Promise<{ id: string } | null> {
-  return await db.recordingTake.findFirst({
+async function findActiveTake(
+  client: Prisma.TransactionClient,
+  sessionId: string,
+): Promise<{ id: string } | null> {
+  return await client.recordingTake.findFirst({
     where: { sessionId, status: "recording" },
     orderBy: { startedAt: "desc" },
     select: { id: true },
   });
 }
 
+// All reads/writes run through the caller-supplied transaction client so this
+// executes inside the per-session advisory lock (issue #151): the session's
+// `ready` status is re-checked and the track/segment are created atomically
+// with respect to a concurrent finalize.
 async function ensureLogicalTrackAndSegment(input: {
+  client: Prisma.TransactionClient;
   sessionId: string;
   requestedTrackId: string;
   requestedSegmentId: string;
@@ -67,6 +77,7 @@ async function ensureLogicalTrackAndSegment(input: {
   sessionStartedAt: unknown;
 }) {
   const {
+    client,
     sessionId,
     requestedTrackId,
     requestedSegmentId,
@@ -99,7 +110,7 @@ async function ensureLogicalTrackAndSegment(input: {
   // time presign arrives (the host may have moved on to a newer take).
   let activeTake: { id: string } | null = null;
   if (requestedTakeId) {
-    const requestedTake = await db.recordingTake.findUnique({
+    const requestedTake = await client.recordingTake.findUnique({
       where: { id: requestedTakeId },
       select: { id: true, sessionId: true },
     });
@@ -111,11 +122,11 @@ async function ensureLogicalTrackAndSegment(input: {
     }
     activeTake = { id: requestedTake.id };
   } else {
-    activeTake = await findActiveTake(sessionId);
+    activeTake = await findActiveTake(client, sessionId);
   }
 
   let track = activeTake
-    ? await db.track.findFirst({
+    ? await client.track.findFirst({
         where: {
           sessionId,
           takeId: activeTake.id,
@@ -126,7 +137,7 @@ async function ensureLogicalTrackAndSegment(input: {
     : null;
 
   if (!track) {
-    const existingTrack = await db.track.findUnique({
+    const existingTrack = await client.track.findUnique({
       where: { id: requestedTrackId },
     });
 
@@ -158,7 +169,7 @@ async function ensureLogicalTrackAndSegment(input: {
         : null;
 
     try {
-      track = await db.track.create({
+      track = await client.track.create({
         data: {
           id: requestedTrackId,
           sessionId,
@@ -176,7 +187,7 @@ async function ensureLogicalTrackAndSegment(input: {
       if (!activeTake || !isUniqueConstraintError(error)) {
         throw error;
       }
-      track = await db.track.findFirst({
+      track = await client.track.findFirst({
         where: {
           sessionId,
           takeId: activeTake.id,
@@ -188,7 +199,7 @@ async function ensureLogicalTrackAndSegment(input: {
     }
   }
 
-  let segment = await db.trackSegment.findUnique({
+  let segment = await client.trackSegment.findUnique({
     where: { id: requestedSegmentId },
   });
 
@@ -202,11 +213,11 @@ async function ensureLogicalTrackAndSegment(input: {
     // can collide; the loser recounts and retries.
     const maxAttempts = 3;
     for (let attempt = 1; !segment; attempt++) {
-      const segmentIndex = await db.trackSegment.count({
+      const segmentIndex = await client.trackSegment.count({
         where: { trackId: track.id },
       });
       try {
-        segment = await db.trackSegment.create({
+        segment = await client.trackSegment.create({
           data: {
             id: requestedSegmentId,
             trackId: track.id,
@@ -224,7 +235,7 @@ async function ensureLogicalTrackAndSegment(input: {
         }
         // A duplicate request may have created this exact segment id rather
         // than just claiming the index — reuse it instead of retrying.
-        const existing = await db.trackSegment.findUnique({
+        const existing = await client.trackSegment.findUnique({
           where: { id: requestedSegmentId },
         });
         if (existing) {
@@ -242,12 +253,13 @@ async function ensureLogicalTrackAndSegment(input: {
     // flight — pull it back to recording until completion resolves it. The
     // condition lives in the write so a completion that landed after our
     // track read still gets demoted.
-    const demoted = await db.track.updateMany({
+    const demoted = await client.track.updateMany({
       where: { id: track.id, status: { in: ["complete", "failed"] } },
       data: { status: "recording" },
     });
     if (demoted.count > 0) {
-      track = (await db.track.findUnique({ where: { id: track.id } })) ?? track;
+      track =
+        (await client.track.findUnique({ where: { id: track.id } })) ?? track;
     }
   }
 
@@ -314,7 +326,9 @@ export async function POST(req: NextRequest) {
       // any audio recorded here would attach to an old, already-ingested
       // session and never make it downstream (issue #151). Late chunk/final
       // uploads for tracks that started before finalize take the non-start
-      // path below and are unaffected.
+      // path below and are unaffected. This is a cheap early-out for the
+      // common already-finalized case; the authoritative check runs under the
+      // advisory lock below so a concurrent finalize can't slip in between.
       if (existingSession.status === "ready") {
         return NextResponse.json(
           {
@@ -326,21 +340,51 @@ export async function POST(req: NextRequest) {
       }
 
       try {
-        const { track, segment } = await ensureLogicalTrackAndSegment({
-          sessionId,
-          requestedTrackId: trackId,
-          requestedSegmentId: segmentId,
-          requestedTakeId,
-          localTrackSlotId,
-          principal,
-          participantName,
-          deviceLabel,
-          deviceId,
-          isBuiltInMic,
-          sessionStartedAt,
+        // Re-check status and materialize the track/segment under a per-session
+        // advisory lock so a finalize that flips the session to `ready` cannot
+        // interleave between the status read and the create (issue #151).
+        const locked = await withSessionLock(sessionId, async (tx) => {
+          const fresh = await tx.session.findUnique({
+            where: { id: sessionId },
+            select: { status: true },
+          });
+          if (!fresh) return { kind: "not_found" as const };
+          if (fresh.status === "ready") return { kind: "finalized" as const };
+
+          const { track, segment } = await ensureLogicalTrackAndSegment({
+            client: tx,
+            sessionId,
+            requestedTrackId: trackId,
+            requestedSegmentId: segmentId,
+            requestedTakeId,
+            localTrackSlotId,
+            principal,
+            participantName,
+            deviceLabel,
+            deviceId,
+            isBuiltInMic,
+            sessionStartedAt,
+          });
+          return { kind: "ok" as const, track, segment };
         });
-        logicalTrackId = track.id;
-        segmentId = segment.id;
+
+        if (locked.kind === "not_found") {
+          return NextResponse.json(
+            { error: `Session ${sessionId} was not found` },
+            { status: 404 }
+          );
+        }
+        if (locked.kind === "finalized") {
+          return NextResponse.json(
+            {
+              error:
+                "This session is finalized and can no longer be recorded into. Start a new session.",
+            },
+            { status: 409 }
+          );
+        }
+        logicalTrackId = locked.track.id;
+        segmentId = locked.segment.id;
       } catch (error) {
         if (
           error instanceof Error &&

--- a/src/app/api/upload/presign/route.ts
+++ b/src/app/api/upload/presign/route.ts
@@ -19,6 +19,8 @@ import {
   verifyRecordingUploadToken,
 } from "@/lib/auth";
 
+const UPLOADABLE_STATUSES = new Set(["recording", "uploading"]);
+
 function getUploadErrorMessage(error: unknown): string {
   if (!(error instanceof Error)) {
     return "Failed to generate presigned URL";
@@ -460,7 +462,7 @@ export async function POST(req: NextRequest) {
       // any writable URL is issued.
       const existingTrack = await db.track.findUnique({
         where: { id: trackId },
-        select: { sessionId: true },
+        select: { sessionId: true, status: true },
       });
       if (!existingTrack) {
         return NextResponse.json({ error: "Track not found" }, { status: 404 });
@@ -470,7 +472,7 @@ export async function POST(req: NextRequest) {
       }
       const existingSegment = await db.trackSegment.findUnique({
         where: { id: segmentId },
-        select: { trackId: true },
+        select: { trackId: true, status: true },
       });
       if (!existingSegment) {
         return NextResponse.json(
@@ -480,6 +482,18 @@ export async function POST(req: NextRequest) {
       }
       if (existingSegment.trackId !== trackId) {
         return NextResponse.json({ error: "forbidden" }, { status: 403 });
+      }
+      if (
+        !UPLOADABLE_STATUSES.has(existingTrack.status) ||
+        !UPLOADABLE_STATUSES.has(existingSegment.status)
+      ) {
+        return NextResponse.json(
+          {
+            error:
+              "Recording upload is already complete or terminal and cannot be overwritten",
+          },
+          { status: 409 }
+        );
       }
     }
 

--- a/src/app/api/upload/presign/route.ts
+++ b/src/app/api/upload/presign/route.ts
@@ -299,13 +299,29 @@ export async function POST(req: NextRequest) {
 
       const existingSession = await db.session.findUnique({
         where: { id: sessionId },
-        select: { id: true },
+        select: { id: true, status: true },
       });
 
       if (!existingSession) {
         return NextResponse.json(
           { error: `Session ${sessionId} was not found` },
           { status: 404 }
+        );
+      }
+
+      // Refuse to start a brand-new recording (new track/segment) on a
+      // finalized session. Its id has already been handed to ingest, so
+      // any audio recorded here would attach to an old, already-ingested
+      // session and never make it downstream (issue #151). Late chunk/final
+      // uploads for tracks that started before finalize take the non-start
+      // path below and are unaffected.
+      if (existingSession.status === "ready") {
+        return NextResponse.json(
+          {
+            error:
+              "This session is finalized and can no longer be recorded into. Start a new session.",
+          },
+          { status: 409 }
         );
       }
 

--- a/src/app/studio/[id]/page.tsx
+++ b/src/app/studio/[id]/page.tsx
@@ -36,6 +36,7 @@ import {
   completeUpload,
 } from "@/lib/upload";
 import {
+  RecordingStateError,
   reportRecordingTakeParticipantStatus,
   startRecordingTake,
   stopRecordingTake,
@@ -2396,7 +2397,16 @@ function RoomContent({
         recordingTakeIdRef.current = takeId;
       } catch (err) {
         console.error("Failed to activate recording take:", err);
-        showNotification("Couldn't update recording state");
+        // A finalized session rejects new takes (issue #151). Surface the
+        // server's explanation so the host knows to start a fresh session
+        // rather than seeing a generic failure.
+        const finalized =
+          err instanceof RecordingStateError && err.status === 409;
+        showNotification(
+          finalized && err.message
+            ? err.message
+            : "Couldn't update recording state",
+        );
         return;
       }
 

--- a/src/components/FinishRecordingButton.tsx
+++ b/src/components/FinishRecordingButton.tsx
@@ -1,10 +1,17 @@
 "use client";
 
 import { useCallback, useEffect, useRef, useState } from "react";
+import { stopRecordingTake } from "@/lib/recording-state";
+
+interface ActiveTake {
+  id: string;
+  startedAt: string;
+}
 
 type FinishState =
   | { kind: "idle" }
   | { kind: "polling"; pendingName?: string }
+  | { kind: "active_take"; activeTake: ActiveTake; message: string }
   | { kind: "ready" }
   | { kind: "timeout" }
   | { kind: "error"; message: string };
@@ -91,13 +98,29 @@ export function FinishRecordingButton({
 
       if (res.status === 409) {
         let pendingName: string | undefined;
+        let activeTake: ActiveTake | undefined;
+        let error: string | undefined;
         try {
-          const data = (await res.json()) as { pending?: PendingTrack[] };
+          const data = (await res.json()) as {
+            pending?: PendingTrack[];
+            activeTake?: ActiveTake;
+            error?: string;
+          };
           pendingName = data.pending?.[0]?.participantName;
+          activeTake = data.activeTake;
+          error = data.error;
         } catch {
           // ignore parse errors
         }
         if (controller.signal.aborted || !isMountedRef.current) return;
+        if (activeTake) {
+          safeSetState({
+            kind: "active_take",
+            activeTake,
+            message: error ?? "An unfinished recording take is still active.",
+          });
+          return;
+        }
         safeSetState({ kind: "polling", pendingName });
         await sleep(POLL_INTERVAL_MS, controller.signal);
         continue;
@@ -110,6 +133,28 @@ export function FinishRecordingButton({
 
     safeSetState({ kind: "timeout" });
   }, [sessionId, waitForUploads, onReady, safeSetState]);
+
+  const recoverActiveTake = useCallback(async () => {
+    if (state.kind !== "active_take") return;
+
+    const confirmed = window.confirm(
+      "End this unfinished recording take and continue finalizing?",
+    );
+    if (!confirmed) return;
+
+    safeSetState({ kind: "polling" });
+    try {
+      await stopRecordingTake(sessionId, { takeId: state.activeTake.id });
+    } catch (err) {
+      const message =
+        err instanceof Error ? err.message : "Failed to end unfinished take";
+      safeSetState({ kind: "error", message });
+      return;
+    }
+
+    if (!isMountedRef.current) return;
+    await runFinalize();
+  }, [runFinalize, safeSetState, sessionId, state]);
 
   const copyId = useCallback(async () => {
     try {
@@ -172,6 +217,23 @@ export function FinishRecordingButton({
           className="px-4 py-2 rounded-lg bg-indigo-600 hover:bg-indigo-700 text-white text-sm font-medium"
         >
           Retry
+        </button>
+      </div>
+    );
+  }
+
+  if (state.kind === "active_take") {
+    return (
+      <div className="flex flex-col items-center gap-3 p-4 rounded-xl bg-cozy-900 border border-yellow-700">
+        <p className="text-yellow-400 text-sm text-center">{state.message}</p>
+        <p className="text-gray-400 text-xs">
+          Started {new Date(state.activeTake.startedAt).toLocaleString()}
+        </p>
+        <button
+          onClick={recoverActiveTake}
+          className="px-4 py-2 rounded-lg bg-yellow-600 hover:bg-yellow-700 text-white text-sm font-medium"
+        >
+          End unfinished take and continue
         </button>
       </div>
     );

--- a/src/lib/recording-state.ts
+++ b/src/lib/recording-state.ts
@@ -91,7 +91,11 @@ export async function startRecordingTake(
 // retry transient failures until the stop is confirmed (or attempts run out).
 export async function stopRecordingTake(
   sessionId: string,
-  options: { maxAttempts?: number; retryDelayMs?: number } = {},
+  options: {
+    maxAttempts?: number;
+    retryDelayMs?: number;
+    takeId?: string;
+  } = {},
 ): Promise<RecordingTakeState> {
   const maxAttempts = Math.max(1, options.maxAttempts ?? STOP_MAX_ATTEMPTS);
   const path = `/api/sessions/${encodeURIComponent(sessionId)}/recording-state`;
@@ -101,6 +105,7 @@ export async function stopRecordingTake(
     try {
       return await jsonRequest<RecordingTakeState>(path, "POST", {
         active: false,
+        ...(options.takeId ? { takeId: options.takeId } : {}),
       });
     } catch (error) {
       lastError = error;

--- a/src/lib/s3.ts
+++ b/src/lib/s3.ts
@@ -131,11 +131,15 @@ export function sessionPrefix(sessionId: string): string {
   return `sessions/${sessionId}/`;
 }
 
-export async function getPresignedPutUrl(key: string): Promise<string> {
+export async function getPresignedPutUrl(
+  key: string,
+  options: { createOnly?: boolean } = {},
+): Promise<string> {
   const command = new PutObjectCommand({
     Bucket: bucket,
     Key: key,
     ContentType: "audio/webm",
+    IfNoneMatch: options.createOnly ? "*" : undefined,
   });
   return getSignedUrl(s3, command, { expiresIn: 3600 });
 }

--- a/src/lib/session-lock.ts
+++ b/src/lib/session-lock.ts
@@ -1,0 +1,35 @@
+import { Prisma } from "@prisma/client";
+import { db } from "@/lib/db";
+
+// Namespace for cozytrack session advisory locks. Postgres advisory locks share
+// a single global keyspace, so we partition ours under a fixed namespace int to
+// avoid colliding with any other pg_advisory lock user in the same database.
+// (0x021511 = "issue 151" mnemonic; any stable int4 works.)
+const SESSION_LOCK_NAMESPACE = 0x021511;
+
+/**
+ * Run `fn` while holding a transaction-scoped advisory lock keyed by
+ * `sessionId`, serializing it against any other `withSessionLock` call for the
+ * same session.
+ *
+ * We use `pg_advisory_xact_lock` (not the session-level variant) deliberately:
+ * runtime traffic runs through PgBouncer in transaction pooling mode, where a
+ * connection is only ours for the duration of a transaction, so a session-level
+ * advisory lock would leak onto whichever request reuses the connection next. A
+ * transaction-scoped lock is acquired inside the interactive transaction and
+ * released automatically on commit/rollback.
+ *
+ * This closes the check-then-create race (issue #151): the start guards
+ * (recording-take + presign) and `finalize` all take this lock, so a finalize
+ * that flips a session to `ready` cannot interleave between a start guard's
+ * status read and its track/take creation.
+ */
+export async function withSessionLock<T>(
+  sessionId: string,
+  fn: (tx: Prisma.TransactionClient) => Promise<T>,
+): Promise<T> {
+  return db.$transaction(async (tx) => {
+    await tx.$executeRaw`SELECT pg_advisory_xact_lock(${SESSION_LOCK_NAMESPACE}::int4, hashtext(${sessionId})::int4)`;
+    return fn(tx);
+  });
+}

--- a/src/lib/upload.ts
+++ b/src/lib/upload.ts
@@ -104,13 +104,29 @@ export async function getPresignedUploadUrl(
 }
 
 export async function uploadChunk(url: string, chunk: Blob): Promise<void> {
+  let createOnly = false;
+  try {
+    createOnly =
+      new URL(url).searchParams
+        .get("X-Amz-SignedHeaders")
+        ?.split(";")
+        .includes("if-none-match") ?? false;
+  } catch {
+    // Non-presigned URLs retain the existing upload behavior.
+  }
+
   const res = await fetch(url, {
     method: "PUT",
     body: chunk,
     headers: {
       "Content-Type": "audio/webm",
+      ...(createOnly ? { "If-None-Match": "*" } : {}),
     },
   });
+
+  // A create-only final upload is safe to retry: 412 means the first PUT
+  // already created the immutable recording object.
+  if (createOnly && res.status === 412) return;
 
   if (!res.ok) {
     throw new Error(`Failed to upload chunk: ${res.statusText}`);

--- a/tests/browser/recording-smoke.spec.ts
+++ b/tests/browser/recording-smoke.spec.ts
@@ -266,6 +266,161 @@ test("records a host track through the browser and stores a completed WebM", asy
   });
 });
 
+test("rejects recording from a stale Studio page after the session is finalized", async ({
+  page,
+}) => {
+  const sessionId = await createAndJoinHostStudio(
+    page,
+    `Stale finalized studio ${Date.now()}`,
+    "Stale Studio Host",
+  );
+  const writableRequests: string[] = [];
+  page.on("request", (request) => {
+    if (
+      request.url().includes("/api/upload/presign") ||
+      request.method() === "PUT"
+    ) {
+      writableRequests.push(`${request.method()} ${request.url()}`);
+    }
+  });
+
+  await db.session.update({
+    where: { id: sessionId },
+    data: { status: "ready", finalizedAt: new Date() },
+  });
+
+  await page.getByRole("button", { name: "Start recording" }).click();
+  await expect(
+    page.getByText(
+      "This session is finalized and can no longer be recorded into. Start a new session.",
+    ),
+  ).toBeVisible();
+
+  await page.waitForTimeout(500);
+  const [takes, tracks, segments] = await Promise.all([
+    db.recordingTake.count({ where: { sessionId } }),
+    db.track.count({ where: { sessionId } }),
+    db.trackSegment.count({ where: { track: { sessionId } } }),
+  ]);
+  expect({ takes, tracks, segments }).toEqual({
+    takes: 0,
+    tracks: 0,
+    segments: 0,
+  });
+  expect(writableRequests).toEqual([]);
+});
+
+test("recovers an unfinished active take before finalizing", async ({ page }) => {
+  const participantName = "Unfinished Take Host";
+  const sessionId = await createAndJoinHostStudio(
+    page,
+    `Unfinished take recovery ${Date.now()}`,
+    participantName,
+  );
+
+  await page.waitForTimeout(1_000);
+  await page.getByRole("button", { name: "Start recording" }).click();
+  await expect(page.getByRole("button", { name: "Stop recording" })).toBeVisible();
+  await page.waitForTimeout(2_000);
+  await page.getByRole("button", { name: "Stop recording" }).click();
+  await expect(page.getByText("FINALIZING").first()).toBeVisible();
+  await expect(
+    page.getByRole("button", { name: "Start recording" }),
+  ).toBeVisible({ timeout: 45_000 });
+
+  await expect
+    .poll(
+      async () =>
+        (
+          await db.track.findFirst({
+            where: { sessionId, participantName },
+            select: { status: true },
+          })
+        )?.status ?? null,
+      { timeout: 30_000 },
+    )
+    .toBe("complete");
+
+  const unfinishedTake = await db.recordingTake.create({
+    data: {
+      sessionId,
+      startedAt: new Date(),
+      status: "recording",
+    },
+  });
+  expect(
+    await db.track.count({ where: { takeId: unfinishedTake.id } }),
+  ).toBe(0);
+
+  await page.getByRole("button", { name: "Finish recording" }).click();
+  const recoveryAction = page.getByRole("button", {
+    name: "End unfinished take and continue",
+  });
+  await expect(recoveryAction).toBeVisible();
+  await expect(page.getByText("Ready for ingest")).toBeHidden();
+  await expect
+    .poll(async () =>
+      (
+        await db.session.findUniqueOrThrow({ where: { id: sessionId } })
+      ).status,
+    )
+    .toBe("recording");
+  await expect
+    .poll(async () =>
+      (
+        await db.recordingTake.findUniqueOrThrow({
+          where: { id: unfinishedTake.id },
+        })
+      ).status,
+    )
+    .toBe("recording");
+
+  page.once("dialog", async (dialog) => {
+    expect(dialog.type()).toBe("confirm");
+    await dialog.accept();
+  });
+  await recoveryAction.click();
+  await expect(page.getByText("Ready for ingest")).toBeVisible({
+    timeout: 45_000,
+  });
+  await expect
+    .poll(async () =>
+      (
+        await db.recordingTake.findUniqueOrThrow({
+          where: { id: unfinishedTake.id },
+        })
+      ).status,
+    )
+    .toBe("stopped");
+  await expect
+    .poll(async () =>
+      (
+        await db.session.findUniqueOrThrow({ where: { id: sessionId } })
+      ).status,
+    )
+    .toBe("ready");
+
+  const beforeRetry = await Promise.all([
+    db.recordingTake.count({ where: { sessionId } }),
+    db.track.count({ where: { sessionId } }),
+    db.trackSegment.count({ where: { track: { sessionId } } }),
+  ]);
+  await page.getByRole("button", { name: "Start recording" }).click();
+  await expect(
+    page.getByText(
+      "This session is finalized and can no longer be recorded into. Start a new session.",
+    ),
+  ).toBeVisible();
+  await page.waitForTimeout(500);
+  await expect(
+    Promise.all([
+      db.recordingTake.count({ where: { sessionId } }),
+      db.track.count({ where: { sessionId } }),
+      db.trackSegment.count({ where: { track: { sessionId } } }),
+    ]),
+  ).resolves.toEqual(beforeRetry);
+});
+
 test("recovers a failed final upload from the local browser backup", async ({
   page,
 }) => {

--- a/tests/finalize.test.ts
+++ b/tests/finalize.test.ts
@@ -10,8 +10,7 @@ type Session = {
 };
 
 const sessionStore = new Map<string, Session>();
-// Session ids that currently have an active (status "recording") RecordingTake.
-const activeTakeSessions = new Set<string>();
+const activeTakes = new Map<string, { id: string; startedAt: Date }>();
 
 function tracksFor(sessionId: string): Track[] {
   return sessionStore.get(sessionId)?.tracks ?? [];
@@ -73,8 +72,8 @@ vi.mock("@/lib/db", () => {
         }: {
           where: { sessionId: string; status?: string };
         }) =>
-          status === "recording" && activeTakeSessions.has(sessionId)
-            ? { id: `take-${sessionId}` }
+          status === "recording" && activeTakes.has(sessionId)
+            ? structuredClone(activeTakes.get(sessionId))
             : null,
       ),
     },
@@ -121,7 +120,7 @@ function req(): NextRequest {
 
 beforeEach(() => {
   sessionStore.clear();
-  activeTakeSessions.clear();
+  activeTakes.clear();
   vi.clearAllMocks();
 });
 
@@ -171,10 +170,18 @@ describe("POST /api/sessions/[id]/finalize", () => {
       finalizedAt: null,
       tracks: [],
     });
-    activeTakeSessions.add("s1");
+    const startedAt = new Date("2026-07-08T15:00:00.000Z");
+    activeTakes.set("s1", { id: "take-s1", startedAt });
 
     const res = await POST(req(), { params: Promise.resolve({ id: "s1" }) });
     expect(res.status).toBe(409);
+    await expect(res.json()).resolves.toEqual({
+      error: "An unfinished recording take is still active.",
+      activeTake: {
+        id: "take-s1",
+        startedAt: startedAt.toISOString(),
+      },
+    });
     expect(sessionStore.get("s1")?.status).toBe("recording");
     expect(sessionStore.get("s1")?.finalizedAt).toBeNull();
   });

--- a/tests/finalize.test.ts
+++ b/tests/finalize.test.ts
@@ -10,6 +10,8 @@ type Session = {
 };
 
 const sessionStore = new Map<string, Session>();
+// Session ids that currently have an active (status "recording") RecordingTake.
+const activeTakeSessions = new Set<string>();
 
 function tracksFor(sessionId: string): Track[] {
   return sessionStore.get(sessionId)?.tracks ?? [];
@@ -64,6 +66,18 @@ vi.mock("@/lib/db", () => {
         },
       ),
     },
+    recordingTake: {
+      findFirst: vi.fn(
+        async ({
+          where: { sessionId, status },
+        }: {
+          where: { sessionId: string; status?: string };
+        }) =>
+          status === "recording" && activeTakeSessions.has(sessionId)
+            ? { id: `take-${sessionId}` }
+            : null,
+      ),
+    },
     track: {
       findMany: vi.fn(
         async ({
@@ -107,6 +121,7 @@ function req(): NextRequest {
 
 beforeEach(() => {
   sessionStore.clear();
+  activeTakeSessions.clear();
   vi.clearAllMocks();
 });
 
@@ -143,6 +158,25 @@ describe("POST /api/sessions/[id]/finalize", () => {
       "t2",
       expect.objectContaining({ chunkStitchMinAgeMs: expect.any(Number) }),
     );
+  });
+
+  it("returns 409 while a recording take is active even before any track exists", async () => {
+    // Race window (issue #151): /recording-state created the take but presign
+    // hasn't created the first track yet. Finalize must not slip through and
+    // mark the session ready — that would strand the in-progress recording.
+    sessionStore.set("s1", {
+      id: "s1",
+      name: "demo",
+      status: "recording",
+      finalizedAt: null,
+      tracks: [],
+    });
+    activeTakeSessions.add("s1");
+
+    const res = await POST(req(), { params: Promise.resolve({ id: "s1" }) });
+    expect(res.status).toBe(409);
+    expect(sessionStore.get("s1")?.status).toBe("recording");
+    expect(sessionStore.get("s1")?.finalizedAt).toBeNull();
   });
 
   it("finalizes when recovery flips a stuck track to complete", async () => {

--- a/tests/finalize.test.ts
+++ b/tests/finalize.test.ts
@@ -21,8 +21,11 @@ vi.mock("@/lib/recovery", () => ({
   recoverTrack: vi.fn(async (trackId: string) => ({ trackId })),
 }));
 
-vi.mock("@/lib/db", () => ({
-  db: {
+vi.mock("@/lib/db", () => {
+  const client = {
+    // withSessionLock runs its callback inside db.$transaction and issues a raw
+    // advisory-lock query; the mock just needs these to exist and pass through.
+    $executeRaw: async () => 0,
     session: {
       findUnique: vi.fn(async ({ where: { id } }: { where: { id: string } }) => {
         const s = sessionStore.get(id);
@@ -66,9 +69,14 @@ vi.mock("@/lib/db", () => ({
         async ({
           where,
         }: {
-          where: { id: { in: string[] } };
+          where: { sessionId?: string; id?: { in: string[] } };
         }) => {
-          const ids = new Set(where.id.in);
+          // finalize now re-reads all tracks for a session under the advisory
+          // lock; still support the legacy id-in shape for safety.
+          if (where.sessionId !== undefined) {
+            return tracksFor(where.sessionId).map((t) => structuredClone(t));
+          }
+          const ids = new Set(where.id?.in ?? []);
           const all: Track[] = [];
           for (const s of sessionStore.values()) {
             for (const t of s.tracks) {
@@ -79,8 +87,14 @@ vi.mock("@/lib/db", () => ({
         },
       ),
     },
-  },
-}));
+  };
+  return {
+    db: {
+      ...client,
+      $transaction: async (fn: (tx: typeof client) => unknown) => fn(client),
+    },
+  };
+});
 
 import { POST } from "@/app/api/sessions/[id]/finalize/route";
 import { NextRequest } from "next/server";

--- a/tests/finalized-session-guard.test.ts
+++ b/tests/finalized-session-guard.test.ts
@@ -1,0 +1,157 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+
+// Regression coverage for issue #151: a finalized ("ready") session must not
+// accept new recording tracks. Before the guard, starting a new recording on
+// an already-ingested session created a fresh take + tracks under the old
+// session id, so the ingest command referenced audio that had already been
+// handed off and could never be ingested.
+
+type SessionRow = { id: string; status: string };
+
+const mocks = vi.hoisted(() => ({
+  sessions: new Map<string, SessionRow>(),
+  createTake: vi.fn(),
+  createTrack: vi.fn(),
+  findActiveTake: vi.fn(async () => null),
+  resolvePrincipal: vi.fn(),
+  issueRecordingUploadToken: vi.fn(async () => "token"),
+  getPresignedPutUrl: vi.fn(async (key: string) => `https://s3.example/${key}`),
+}));
+
+vi.mock("@/lib/db", () => ({
+  db: {
+    session: {
+      findUnique: vi.fn(
+        async ({ where: { id } }: { where: { id: string } }) =>
+          mocks.sessions.get(id) ?? null,
+      ),
+    },
+    recordingTake: {
+      findFirst: mocks.findActiveTake,
+      create: mocks.createTake,
+      update: vi.fn(),
+    },
+    track: {
+      findFirst: vi.fn(async () => null),
+      findUnique: vi.fn(async () => null),
+      create: mocks.createTrack,
+      updateMany: vi.fn(async () => ({ count: 0 })),
+    },
+    trackSegment: {
+      findUnique: vi.fn(async () => null),
+      create: vi.fn(),
+      count: vi.fn(async () => 0),
+    },
+  },
+}));
+
+vi.mock("@/lib/s3", async () => {
+  const actual = await vi.importActual<typeof import("@/lib/s3")>("@/lib/s3");
+  return { ...actual, getPresignedPutUrl: mocks.getPresignedPutUrl };
+});
+
+vi.mock("@/lib/auth", async () => {
+  const actual = await vi.importActual<typeof import("@/lib/auth")>("@/lib/auth");
+  return {
+    ...actual,
+    resolvePrincipal: mocks.resolvePrincipal,
+    issueRecordingUploadToken: mocks.issueRecordingUploadToken,
+  };
+});
+
+import { NextRequest } from "next/server";
+import { POST as setRecordingState } from "@/app/api/sessions/[id]/recording-state/route";
+import { POST as presign } from "@/app/api/upload/presign/route";
+
+const SESSION_ID = "finalized-session";
+
+function recordingStateRequest(body: Record<string, unknown>) {
+  return new NextRequest(
+    `http://localhost/api/sessions/${SESSION_ID}/recording-state`,
+    {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify(body),
+    },
+  );
+}
+
+function presignRequest(body: Record<string, unknown>) {
+  return new NextRequest("http://localhost/api/upload/presign", {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify(body),
+  });
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mocks.sessions.clear();
+  mocks.sessions.set(SESSION_ID, { id: SESSION_ID, status: "ready" });
+  mocks.resolvePrincipal.mockResolvedValue({
+    kind: "host",
+    participantId: "host",
+  });
+  mocks.findActiveTake.mockResolvedValue(null);
+});
+
+describe("finalized session recording guard (issue #151)", () => {
+  it("rejects starting a new recording take on a finalized session", async () => {
+    const res = await setRecordingState(
+      recordingStateRequest({
+        active: true,
+        sessionStartedAt: "2026-06-27T12:00:00.000Z",
+      }),
+      { params: Promise.resolve({ id: SESSION_ID }) },
+    );
+
+    expect(res.status).toBe(409);
+    await expect(res.json()).resolves.toMatchObject({
+      error: expect.stringContaining("finalized"),
+    });
+    // No take may be created on the already-ingested session.
+    expect(mocks.createTake).not.toHaveBeenCalled();
+  });
+
+  it("rejects presigning a new recording upload on a finalized session", async () => {
+    const res = await presign(
+      presignRequest({
+        sessionId: SESSION_ID,
+        trackId: "new-track",
+        partNumber: 0,
+        participantName: "Marty L",
+      }),
+    );
+
+    expect(res.status).toBe(409);
+    await expect(res.json()).resolves.toMatchObject({
+      error: expect.stringContaining("finalized"),
+    });
+    // No track may be materialized, and no writable URL may be issued.
+    expect(mocks.createTrack).not.toHaveBeenCalled();
+    expect(mocks.getPresignedPutUrl).not.toHaveBeenCalled();
+  });
+
+  it("still allows recording into a session that is still recording", async () => {
+    mocks.sessions.set(SESSION_ID, { id: SESSION_ID, status: "recording" });
+    mocks.createTake.mockResolvedValue({
+      id: "take-1",
+      sessionId: SESSION_ID,
+      startedAt: new Date("2026-06-27T12:00:00.000Z"),
+      stoppedAt: null,
+      status: "recording",
+      participantStatuses: [],
+    });
+
+    const res = await setRecordingState(
+      recordingStateRequest({
+        active: true,
+        sessionStartedAt: "2026-06-27T12:00:00.000Z",
+      }),
+      { params: Promise.resolve({ id: SESSION_ID }) },
+    );
+
+    expect(res.status).toBe(200);
+    expect(mocks.createTake).toHaveBeenCalledTimes(1);
+  });
+});

--- a/tests/finalized-session-guard.test.ts
+++ b/tests/finalized-session-guard.test.ts
@@ -22,6 +22,7 @@ const mocks = vi.hoisted(() => ({
   sessionFindUnique: vi.fn(),
   createTake: vi.fn(),
   createTrack: vi.fn(),
+  createSegment: vi.fn(),
   findActiveTake: vi.fn(async () => null),
   resolvePrincipal: vi.fn(),
   issueRecordingUploadToken: vi.fn(async () => "token"),
@@ -50,7 +51,7 @@ vi.mock("@/lib/db", () => {
     },
     trackSegment: {
       findUnique: vi.fn(async () => null),
-      create: vi.fn(),
+      create: mocks.createSegment,
       count: vi.fn(async () => 0),
     },
   };
@@ -147,6 +148,8 @@ describe("finalized session recording guard (issue #151)", () => {
       error: expect.stringContaining("finalized"),
     });
     expect(mocks.createTrack).not.toHaveBeenCalled();
+    expect(mocks.createSegment).not.toHaveBeenCalled();
+    expect(mocks.issueRecordingUploadToken).not.toHaveBeenCalled();
     expect(mocks.getPresignedPutUrl).not.toHaveBeenCalled();
   });
 

--- a/tests/finalized-session-guard.test.ts
+++ b/tests/finalized-session-guard.test.ts
@@ -5,11 +5,21 @@ import { describe, it, expect, beforeEach, vi } from "vitest";
 // an already-ingested session created a fresh take + tracks under the old
 // session id, so the ingest command referenced audio that had already been
 // handed off and could never be ingested.
+//
+// The guard also has to be atomic against a concurrent finalize (the race
+// flagged in review): both the start guards and finalize take a per-session
+// advisory lock via withSessionLock, so a finalize that flips the session to
+// `ready` cannot interleave between a start guard's status read and its
+// track/take creation. These tests drive the real withSessionLock code by
+// mocking db.$transaction to invoke the callback with the same mock client.
 
-type SessionRow = { id: string; status: string };
+type SessionRow = { status: string } | null;
 
 const mocks = vi.hoisted(() => ({
-  sessions: new Map<string, SessionRow>(),
+  // Status returned by session.findUnique. A test may override per-call with
+  // mockResolvedValueOnce to simulate a finalize landing mid-request.
+  sessionStatus: "ready" as string | null,
+  sessionFindUnique: vi.fn(),
   createTake: vi.fn(),
   createTrack: vi.fn(),
   findActiveTake: vi.fn(async () => null),
@@ -18,14 +28,15 @@ const mocks = vi.hoisted(() => ({
   getPresignedPutUrl: vi.fn(async (key: string) => `https://s3.example/${key}`),
 }));
 
-vi.mock("@/lib/db", () => ({
-  db: {
-    session: {
-      findUnique: vi.fn(
-        async ({ where: { id } }: { where: { id: string } }) =>
-          mocks.sessions.get(id) ?? null,
-      ),
-    },
+const SESSION_ID = "finalized-session";
+
+vi.mock("@/lib/db", () => {
+  // The shape shared by both the top-level client and the transaction client
+  // handed to withSessionLock's callback. $transaction just runs the callback
+  // with this same object so tx.* calls hit the same spies.
+  const client = {
+    $executeRaw: vi.fn(async () => 0),
+    session: { findUnique: mocks.sessionFindUnique },
     recordingTake: {
       findFirst: mocks.findActiveTake,
       create: mocks.createTake,
@@ -42,8 +53,15 @@ vi.mock("@/lib/db", () => ({
       create: vi.fn(),
       count: vi.fn(async () => 0),
     },
-  },
-}));
+  };
+  return {
+    db: {
+      ...client,
+      $transaction: async (fn: (tx: typeof client) => Promise<unknown>) =>
+        fn(client),
+    },
+  };
+});
 
 vi.mock("@/lib/s3", async () => {
   const actual = await vi.importActual<typeof import("@/lib/s3")>("@/lib/s3");
@@ -62,8 +80,6 @@ vi.mock("@/lib/auth", async () => {
 import { NextRequest } from "next/server";
 import { POST as setRecordingState } from "@/app/api/sessions/[id]/recording-state/route";
 import { POST as presign } from "@/app/api/upload/presign/route";
-
-const SESSION_ID = "finalized-session";
 
 function recordingStateRequest(body: Record<string, unknown>) {
   return new NextRequest(
@@ -86,8 +102,12 @@ function presignRequest(body: Record<string, unknown>) {
 
 beforeEach(() => {
   vi.clearAllMocks();
-  mocks.sessions.clear();
-  mocks.sessions.set(SESSION_ID, { id: SESSION_ID, status: "ready" });
+  mocks.sessionStatus = "ready";
+  mocks.sessionFindUnique.mockImplementation(async () =>
+    mocks.sessionStatus === null
+      ? null
+      : ({ id: SESSION_ID, status: mocks.sessionStatus } as SessionRow),
+  );
   mocks.resolvePrincipal.mockResolvedValue({
     kind: "host",
     participantId: "host",
@@ -109,7 +129,6 @@ describe("finalized session recording guard (issue #151)", () => {
     await expect(res.json()).resolves.toMatchObject({
       error: expect.stringContaining("finalized"),
     });
-    // No take may be created on the already-ingested session.
     expect(mocks.createTake).not.toHaveBeenCalled();
   });
 
@@ -127,13 +146,56 @@ describe("finalized session recording guard (issue #151)", () => {
     await expect(res.json()).resolves.toMatchObject({
       error: expect.stringContaining("finalized"),
     });
-    // No track may be materialized, and no writable URL may be issued.
     expect(mocks.createTrack).not.toHaveBeenCalled();
     expect(mocks.getPresignedPutUrl).not.toHaveBeenCalled();
   });
 
+  it("rejects a presign start when finalize lands after the early status read (race)", async () => {
+    // Early existence/status check sees "recording" (finalize hasn't committed
+    // yet), but the re-read inside withSessionLock sees "ready" — the exact
+    // check-then-create window the advisory lock closes. Must still 409 and
+    // must not materialize a track or issue a writable URL.
+    mocks.sessionFindUnique
+      .mockResolvedValueOnce({ id: SESSION_ID, status: "recording" })
+      .mockResolvedValue({ id: SESSION_ID, status: "ready" });
+
+    const res = await presign(
+      presignRequest({
+        sessionId: SESSION_ID,
+        trackId: "new-track",
+        partNumber: 0,
+        participantName: "Marty L",
+      }),
+    );
+
+    expect(res.status).toBe(409);
+    await expect(res.json()).resolves.toMatchObject({
+      error: expect.stringContaining("finalized"),
+    });
+    expect(mocks.createTrack).not.toHaveBeenCalled();
+    expect(mocks.getPresignedPutUrl).not.toHaveBeenCalled();
+  });
+
+  it("rejects a recording-take start when finalize lands after the existence check (race)", async () => {
+    // requireSession sees "recording"; the in-lock re-read sees "ready".
+    mocks.sessionFindUnique
+      .mockResolvedValueOnce({ id: SESSION_ID, status: "recording" })
+      .mockResolvedValue({ id: SESSION_ID, status: "ready" });
+
+    const res = await setRecordingState(
+      recordingStateRequest({
+        active: true,
+        sessionStartedAt: "2026-06-27T12:00:00.000Z",
+      }),
+      { params: Promise.resolve({ id: SESSION_ID }) },
+    );
+
+    expect(res.status).toBe(409);
+    expect(mocks.createTake).not.toHaveBeenCalled();
+  });
+
   it("still allows recording into a session that is still recording", async () => {
-    mocks.sessions.set(SESSION_ID, { id: SESSION_ID, status: "recording" });
+    mocks.sessionStatus = "recording";
     mocks.createTake.mockResolvedValue({
       id: "take-1",
       sessionId: SESSION_ID,

--- a/tests/finish-recording-button.test.ts
+++ b/tests/finish-recording-button.test.ts
@@ -1,0 +1,113 @@
+import React from "react";
+import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { FinishRecordingButton } from "@/components/FinishRecordingButton";
+
+const mocks = vi.hoisted(() => ({
+  stopRecordingTake: vi.fn(),
+}));
+
+vi.mock("@/lib/recording-state", () => ({
+  stopRecordingTake: mocks.stopRecordingTake,
+}));
+
+function response(body: unknown, status: number): Response {
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    json: async () => body,
+  } as Response;
+}
+
+let fetchMock: ReturnType<typeof vi.fn>;
+
+beforeEach(() => {
+  fetchMock = vi.fn();
+  vi.stubGlobal("fetch", fetchMock);
+  vi.stubGlobal("confirm", vi.fn(() => true));
+  mocks.stopRecordingTake.mockReset().mockResolvedValue({
+    active: false,
+    sessionStartedAt: null,
+    take: null,
+  });
+});
+
+afterEach(() => {
+  cleanup();
+  vi.unstubAllGlobals();
+});
+
+function renderButton() {
+  render(
+    React.createElement(FinishRecordingButton, {
+      sessionId: "session-1",
+      waitForUploads: async () => undefined,
+    }),
+  );
+}
+
+describe("FinishRecordingButton unfinished-take recovery", () => {
+  it("stops blind polling and never ends the take automatically", async () => {
+    fetchMock.mockResolvedValueOnce(
+      response(
+        {
+          error: "An unfinished recording take is still active.",
+          activeTake: {
+            id: "take-orphan",
+            startedAt: "2026-07-08T12:00:00.000Z",
+          },
+        },
+        409,
+      ),
+    );
+    renderButton();
+
+    fireEvent.click(screen.getByRole("button", { name: "Finish recording" }));
+
+    await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(1));
+    expect(mocks.stopRecordingTake).not.toHaveBeenCalled();
+    expect(
+      screen.getByRole("button", {
+        name: "End unfinished take and continue",
+      }),
+    ).toBeTruthy();
+  });
+
+  it("requires confirmation, targets the reported take, and retries finalization", async () => {
+    fetchMock
+      .mockResolvedValueOnce(
+        response(
+          {
+            error: "An unfinished recording take is still active.",
+            activeTake: {
+              id: "take-orphan",
+              startedAt: "2026-07-08T12:00:00.000Z",
+            },
+          },
+          409,
+        ),
+      )
+      .mockResolvedValueOnce(response({ status: "ready" }, 200));
+    const confirmMock = vi.mocked(confirm);
+    confirmMock.mockReturnValueOnce(false).mockReturnValueOnce(true);
+    renderButton();
+
+    fireEvent.click(screen.getByRole("button", { name: "Finish recording" }));
+    const recover = await screen.findByRole("button", {
+      name: "End unfinished take and continue",
+    });
+
+    fireEvent.click(recover);
+    expect(confirmMock).toHaveBeenCalledTimes(1);
+    expect(mocks.stopRecordingTake).not.toHaveBeenCalled();
+
+    fireEvent.click(recover);
+    await waitFor(() => {
+      expect(mocks.stopRecordingTake).toHaveBeenCalledWith("session-1", {
+        takeId: "take-orphan",
+      });
+    });
+    await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(2));
+    expect(screen.getByText("Ready for ingest")).toBeTruthy();
+  });
+});

--- a/tests/integration/upload-flow.test.ts
+++ b/tests/integration/upload-flow.test.ts
@@ -408,6 +408,62 @@ describe("recording upload service integration", () => {
     ).resolves.toMatchObject({ status: "ready" });
   });
 
+  it("rejects a delayed initial presign after targeted recovery stops its take", async () => {
+    const sessionId = await createSession("Stopped take presign guard");
+    const headers = await hostHeaders();
+    const started = await modules.setRecordingState(
+      postJson(
+        `/api/sessions/${sessionId}/recording-state`,
+        {
+          active: true,
+          sessionStartedAt: new Date().toISOString(),
+        },
+        headers,
+      ),
+      { params: Promise.resolve({ id: sessionId }) },
+    );
+    expect(started.status).toBe(200);
+    const startedBody = (await started.json()) as {
+      take: { id: string };
+    };
+
+    const stopped = await modules.setRecordingState(
+      postJson(
+        `/api/sessions/${sessionId}/recording-state`,
+        { active: false, takeId: startedBody.take.id },
+        headers,
+      ),
+      { params: Promise.resolve({ id: sessionId }) },
+    );
+    expect(stopped.status).toBe(200);
+
+    const delayedTrackId = `track-${randomUUID()}`;
+    const delayed = await modules.presignUpload(
+      postJson(
+        "/api/upload/presign",
+        {
+          sessionId,
+          trackId: delayedTrackId,
+          partNumber: 0,
+          participantName: "Delayed Participant",
+          takeId: startedBody.take.id,
+        },
+        headers,
+      ),
+    );
+
+    expect(delayed.status).toBe(409);
+    await expect(delayed.json()).resolves.toMatchObject({
+      error: expect.stringContaining("no longer active"),
+    });
+    await expect(
+      modules.db.track.findUnique({ where: { id: delayedTrackId } }),
+    ).resolves.toBeNull();
+    await expect(
+      modules.db.session.findUnique({ where: { id: sessionId } }),
+    ).resolves.toMatchObject({ status: "recording" });
+  });
+
   it("creates, stores, completes, and cleans up a recording through real Postgres and S3-compatible storage", async () => {
     const sessionId = await createSession();
     const trackId = `track-${randomUUID()}`;

--- a/tests/integration/upload-flow.test.ts
+++ b/tests/integration/upload-flow.test.ts
@@ -151,14 +151,30 @@ function postJson(
   });
 }
 
-async function putPresignedBytes(url: string, bytes: Uint8Array) {
+function presignedPutHeaders(url: string): Record<string, string> {
+  const signedHeaders = new URL(url).searchParams
+    .get("X-Amz-SignedHeaders")
+    ?.split(";");
+  return {
+    "content-type": "audio/webm",
+    ...(signedHeaders?.includes("if-none-match")
+      ? { "if-none-match": "*" }
+      : {}),
+  };
+}
+
+async function putPresignedBytesResponse(url: string, bytes: Uint8Array) {
   const body = new ArrayBuffer(bytes.byteLength);
   new Uint8Array(body).set(bytes);
-  const response = await fetch(url, {
+  return await fetch(url, {
     method: "PUT",
-    headers: { "content-type": "audio/webm" },
+    headers: presignedPutHeaders(url),
     body: new Blob([body], { type: "audio/webm" }),
   });
+}
+
+async function putPresignedBytes(url: string, bytes: Uint8Array) {
+  const response = await putPresignedBytesResponse(url, bytes);
 
   expect(response.ok).toBe(true);
 }
@@ -394,7 +410,8 @@ describe("recording upload service integration", () => {
     );
     expect(finalUpload.status).toBe(200);
     const finalBody = (await finalUpload.json()) as { url: string };
-    await putPresignedBytes(finalBody.url, await makeTinyWebm(880));
+    const originalRecording = await makeTinyWebm(880);
+    await putPresignedBytes(finalBody.url, originalRecording);
 
     const complete = await modules.completeUpload(
       postJson(
@@ -422,6 +439,26 @@ describe("recording upload service integration", () => {
     await expect(overwrite.json()).resolves.toMatchObject({
       error: expect.stringContaining("already complete"),
     });
+
+    const heldUrlOverwrite = await putPresignedBytesResponse(
+      finalBody.url,
+      await makeTinyWebm(990),
+    );
+    expect(heldUrlOverwrite.status).toBe(412);
+
+    const repeatedComplete = await modules.completeUpload(
+      postJson(
+        "/api/upload/complete",
+        { sessionId, trackId, durationMs: 999 },
+        { "x-cozytrack-recording-token": recordingToken },
+      ),
+    );
+    expect(repeatedComplete.status).toBe(200);
+    await expect(
+      modules.s3.getObjectBytes(
+        modules.s3.trackRecordingKey(sessionId, trackId),
+      ),
+    ).resolves.toEqual(originalRecording);
   });
 
   it("rejects a delayed initial presign after targeted recovery stops its take", async () => {

--- a/tests/integration/upload-flow.test.ts
+++ b/tests/integration/upload-flow.test.ts
@@ -21,6 +21,7 @@ type Modules = {
   db: typeof import("@/lib/db").db;
   finalizeSession: typeof import("@/app/api/sessions/[id]/finalize/route").POST;
   presignUpload: typeof import("@/app/api/upload/presign/route").POST;
+  setRecordingState: typeof import("@/app/api/sessions/[id]/recording-state/route").POST;
   recoverTrack: typeof import("@/lib/recovery").recoverTrack;
   s3: typeof import("@/lib/s3");
 };
@@ -60,6 +61,7 @@ async function loadModules(): Promise<Modules> {
     dbModule,
     finalizeRoute,
     presignRoute,
+    recordingStateRoute,
     recovery,
     s3,
   ] = await Promise.all([
@@ -68,6 +70,7 @@ async function loadModules(): Promise<Modules> {
     import("@/lib/db"),
     import("@/app/api/sessions/[id]/finalize/route"),
     import("@/app/api/upload/presign/route"),
+    import("@/app/api/sessions/[id]/recording-state/route"),
     import("@/lib/recovery"),
     import("@/lib/s3"),
   ]);
@@ -78,6 +81,7 @@ async function loadModules(): Promise<Modules> {
     db: dbModule.db,
     finalizeSession: finalizeRoute.POST,
     presignUpload: presignRoute.POST,
+    setRecordingState: recordingStateRoute.POST,
     recoverTrack: recovery.recoverTrack,
     s3,
   };
@@ -257,6 +261,153 @@ afterEach(async () => {
 });
 
 describe("recording upload service integration", () => {
+  it("serializes concurrent take and track starts against finalize across fresh sessions", async () => {
+    const takeRaceSessions = await Promise.all(
+      Array.from({ length: 6 }, (_, index) =>
+        createSession(`Take/finalize race ${index}`),
+      ),
+    );
+
+    await Promise.all(
+      takeRaceSessions.map(async (sessionId) => {
+        const headers = await hostHeaders();
+        const [start, finalize] = await Promise.all([
+          modules.setRecordingState(
+            postJson(
+              `/api/sessions/${sessionId}/recording-state`,
+              {
+                active: true,
+                sessionStartedAt: new Date().toISOString(),
+              },
+              headers,
+            ),
+            { params: Promise.resolve({ id: sessionId }) },
+          ),
+          modules.finalizeSession(
+            postJson(`/api/sessions/${sessionId}/finalize`, {}),
+            { params: Promise.resolve({ id: sessionId }) },
+          ),
+        ]);
+
+        expect([start.status, finalize.status].sort()).toEqual([200, 409]);
+        const [session, activeTake] = await Promise.all([
+          modules.db.session.findUniqueOrThrow({ where: { id: sessionId } }),
+          modules.db.recordingTake.findFirst({
+            where: { sessionId, status: "recording" },
+          }),
+        ]);
+        expect(session.status === "ready" && activeTake !== null).toBe(false);
+        if (session.status === "ready") {
+          expect(start.status).toBe(409);
+          expect(activeTake).toBeNull();
+        } else {
+          expect(start.status).toBe(200);
+          expect(finalize.status).toBe(409);
+          expect(activeTake).not.toBeNull();
+        }
+      }),
+    );
+
+    const trackRaceSessions = await Promise.all(
+      Array.from({ length: 6 }, (_, index) =>
+        createSession(`Track/finalize race ${index}`),
+      ),
+    );
+
+    await Promise.all(
+      trackRaceSessions.map(async (sessionId) => {
+        const trackId = `track-${randomUUID()}`;
+        const headers = await hostHeaders();
+        const [start, finalize] = await Promise.all([
+          modules.presignUpload(
+            postJson(
+              "/api/upload/presign",
+              {
+                sessionId,
+                trackId,
+                partNumber: 0,
+                participantName: "Integration Host",
+              },
+              headers,
+            ),
+          ),
+          modules.finalizeSession(
+            postJson(`/api/sessions/${sessionId}/finalize`, {}),
+            { params: Promise.resolve({ id: sessionId }) },
+          ),
+        ]);
+
+        expect([start.status, finalize.status].sort()).toEqual([200, 409]);
+        const [session, track] = await Promise.all([
+          modules.db.session.findUniqueOrThrow({ where: { id: sessionId } }),
+          modules.db.track.findUnique({ where: { id: trackId } }),
+        ]);
+        expect(session.status === "ready" && track !== null).toBe(false);
+        if (session.status === "ready") {
+          expect(start.status).toBe(409);
+          expect(track).toBeNull();
+        } else {
+          expect(start.status).toBe(200);
+          expect(finalize.status).toBe(409);
+          expect(track).not.toBeNull();
+        }
+      }),
+    );
+  });
+
+  it("rejects a new MinIO upload start after finalize but allows an existing track to finish", async () => {
+    const sessionId = await createSession("Finalized upload recovery");
+    const { recordingToken, trackId } = await startUpload(sessionId);
+    await modules.db.session.update({
+      where: { id: sessionId },
+      data: { status: "ready", finalizedAt: new Date() },
+    });
+
+    const rejectedTrackId = `track-${randomUUID()}`;
+    const rejected = await modules.presignUpload(
+      postJson(
+        "/api/upload/presign",
+        {
+          sessionId,
+          trackId: rejectedTrackId,
+          partNumber: 0,
+          participantName: "Too Late",
+        },
+        await hostHeaders(),
+      ),
+    );
+    expect(rejected.status).toBe(409);
+    await expect(
+      modules.db.track.findUnique({ where: { id: rejectedTrackId } }),
+    ).resolves.toBeNull();
+
+    const finalUpload = await modules.presignUpload(
+      postJson(
+        "/api/upload/presign",
+        { sessionId, trackId, partNumber: 9999 },
+        { "x-cozytrack-recording-token": recordingToken },
+      ),
+    );
+    expect(finalUpload.status).toBe(200);
+    const finalBody = (await finalUpload.json()) as { url: string };
+    await putPresignedBytes(finalBody.url, await makeTinyWebm(880));
+
+    const complete = await modules.completeUpload(
+      postJson(
+        "/api/upload/complete",
+        { sessionId, trackId, durationMs: 120 },
+        { "x-cozytrack-recording-token": recordingToken },
+      ),
+    );
+    expect(complete.status).toBe(200);
+    await expect(
+      modules.db.track.findUnique({ where: { id: trackId } }),
+    ).resolves.toMatchObject({ status: "complete", durationMs: 120 });
+    await expect(
+      modules.db.session.findUnique({ where: { id: sessionId } }),
+    ).resolves.toMatchObject({ status: "ready" });
+  });
+
   it("creates, stores, completes, and cleans up a recording through real Postgres and S3-compatible storage", async () => {
     const sessionId = await createSession();
     const trackId = `track-${randomUUID()}`;

--- a/tests/integration/upload-flow.test.ts
+++ b/tests/integration/upload-flow.test.ts
@@ -22,6 +22,7 @@ type Modules = {
   finalizeSession: typeof import("@/app/api/sessions/[id]/finalize/route").POST;
   presignUpload: typeof import("@/app/api/upload/presign/route").POST;
   setRecordingState: typeof import("@/app/api/sessions/[id]/recording-state/route").POST;
+  withSessionLock: typeof import("@/lib/session-lock").withSessionLock;
   recoverTrack: typeof import("@/lib/recovery").recoverTrack;
   s3: typeof import("@/lib/s3");
 };
@@ -64,6 +65,7 @@ async function loadModules(): Promise<Modules> {
     recordingStateRoute,
     recovery,
     s3,
+    sessionLock,
   ] = await Promise.all([
     import("@/lib/auth"),
     import("@/app/api/upload/complete/route"),
@@ -73,6 +75,7 @@ async function loadModules(): Promise<Modules> {
     import("@/app/api/sessions/[id]/recording-state/route"),
     import("@/lib/recovery"),
     import("@/lib/s3"),
+    import("@/lib/session-lock"),
   ]);
 
   return {
@@ -82,6 +85,7 @@ async function loadModules(): Promise<Modules> {
     finalizeSession: finalizeRoute.POST,
     presignUpload: presignRoute.POST,
     setRecordingState: recordingStateRoute.POST,
+    withSessionLock: sessionLock.withSessionLock,
     recoverTrack: recovery.recoverTrack,
     s3,
   };
@@ -474,6 +478,69 @@ describe("recording upload service integration", () => {
     await expect(
       modules.db.session.findUnique({ where: { id: sessionId } }),
     ).resolves.toMatchObject({ status: "recording" });
+  });
+
+  it("serializes targeted recovery stop behind an in-flight presign lock", async () => {
+    const sessionId = await createSession("Targeted stop lock contract");
+    const headers = await hostHeaders();
+    const started = await modules.setRecordingState(
+      postJson(
+        `/api/sessions/${sessionId}/recording-state`,
+        {
+          active: true,
+          sessionStartedAt: new Date().toISOString(),
+        },
+        headers,
+      ),
+      { params: Promise.resolve({ id: sessionId }) },
+    );
+    const startedBody = (await started.json()) as { take: { id: string } };
+
+    let enterCriticalSection: () => void = () => {};
+    const criticalSectionEntered = new Promise<void>((resolve) => {
+      enterCriticalSection = resolve;
+    });
+    let releaseCriticalSection: () => void = () => {};
+    const holdCriticalSection = new Promise<void>((resolve) => {
+      releaseCriticalSection = resolve;
+    });
+    const presignCriticalSection = modules.withSessionLock(
+      sessionId,
+      async () => {
+        enterCriticalSection();
+        await holdCriticalSection;
+      },
+    );
+    await criticalSectionEntered;
+
+    let stopSettled = false;
+    const stopPromise = modules
+      .setRecordingState(
+        postJson(
+          `/api/sessions/${sessionId}/recording-state`,
+          { active: false, takeId: startedBody.take.id },
+          headers,
+        ),
+        { params: Promise.resolve({ id: sessionId }) },
+      )
+      .then((response) => {
+        stopSettled = true;
+        return response;
+      });
+
+    await new Promise((resolve) => setTimeout(resolve, 50));
+    const stopSettledWhileLocked = stopSettled;
+    releaseCriticalSection();
+    await presignCriticalSection;
+    const stopped = await stopPromise;
+
+    expect(stopSettledWhileLocked).toBe(false);
+    expect(stopped.status).toBe(200);
+    await expect(
+      modules.db.recordingTake.findUnique({
+        where: { id: startedBody.take.id },
+      }),
+    ).resolves.toMatchObject({ status: "stopped" });
   });
 
   it("creates, stores, completes, and cleans up a recording through real Postgres and S3-compatible storage", async () => {

--- a/tests/integration/upload-flow.test.ts
+++ b/tests/integration/upload-flow.test.ts
@@ -458,7 +458,7 @@ describe("recording upload service integration", () => {
       modules.s3.getObjectBytes(
         modules.s3.trackRecordingKey(sessionId, trackId),
       ),
-    ).resolves.toEqual(originalRecording);
+    ).resolves.toEqual(new Uint8Array(originalRecording));
   });
 
   it("rejects a delayed initial presign after targeted recovery stops its take", async () => {

--- a/tests/integration/upload-flow.test.ts
+++ b/tests/integration/upload-flow.test.ts
@@ -406,6 +406,18 @@ describe("recording upload service integration", () => {
     await expect(
       modules.db.session.findUnique({ where: { id: sessionId } }),
     ).resolves.toMatchObject({ status: "ready" });
+
+    const overwrite = await modules.presignUpload(
+      postJson(
+        "/api/upload/presign",
+        { sessionId, trackId, partNumber: 9999 },
+        { "x-cozytrack-recording-token": recordingToken },
+      ),
+    );
+    expect(overwrite.status).toBe(409);
+    await expect(overwrite.json()).resolves.toMatchObject({
+      error: expect.stringContaining("already complete"),
+    });
   });
 
   it("rejects a delayed initial presign after targeted recovery stops its take", async () => {

--- a/tests/logical-track-segments.test.ts
+++ b/tests/logical-track-segments.test.ts
@@ -46,8 +46,11 @@ const mocks = vi.hoisted(() => ({
   resolvePrincipal: vi.fn<() => Promise<Principal | null>>(),
 }));
 
-vi.mock("@/lib/db", () => ({
-  db: {
+vi.mock("@/lib/db", () => {
+  const client = {
+    // withSessionLock runs its callback inside db.$transaction and issues a raw
+    // advisory-lock query; the mock just needs these to exist and pass through.
+    $executeRaw: async () => 0,
     session: {
       findUnique: vi.fn(async ({ where: { id } }: { where: { id: string } }) =>
         mocks.sessions.has(id) ? { id } : null,
@@ -212,8 +215,14 @@ vi.mock("@/lib/db", () => ({
         },
       ),
     },
-  },
-}));
+  };
+  return {
+    db: {
+      ...client,
+      $transaction: async (fn: (tx: typeof client) => unknown) => fn(client),
+    },
+  };
+});
 
 vi.mock("@/lib/s3", () => ({
   getPresignedPutUrl: mocks.getPresignedPutUrl,

--- a/tests/logical-track-segments.test.ts
+++ b/tests/logical-track-segments.test.ts
@@ -545,6 +545,47 @@ describe("logical track segments", () => {
     );
   });
 
+  it("retries materialization when the segment is complete but the track failed", async () => {
+    mocks.tracks.set("track-1", {
+      id: "track-1",
+      sessionId: "s1",
+      participantName: "Alice",
+      participantId: "guest_alice",
+      s3Key: "sessions/s1/tracks/track-1/recording.webm",
+      status: "failed",
+      durationMs: null,
+    });
+    mocks.segments.set("track-1", {
+      id: "track-1",
+      trackId: "track-1",
+      segmentIndex: 0,
+      s3Prefix: "sessions/s1/tracks/track-1/",
+      status: "complete",
+      durationMs: 12345,
+    });
+    const recordingToken = await issueRecordingUploadToken("s1", "track-1");
+
+    const res = await completeUpload(
+      postJson(
+        "/api/upload/complete",
+        {
+          sessionId: "s1",
+          trackId: "track-1",
+          segmentId: "track-1",
+          durationMs: 12345,
+        },
+        { "x-cozytrack-recording-token": recordingToken },
+      ),
+    );
+
+    expect(res.status).toBe(200);
+    expect(mocks.materializeTrack).toHaveBeenCalledWith("track-1");
+    expect(mocks.tracks.get("track-1")).toMatchObject({
+      status: "complete",
+      durationMs: 12345,
+    });
+  });
+
   it("materializes the logical track once all segments complete", async () => {
     mocks.tracks.set("logical-track", {
       id: "logical-track",

--- a/tests/logical-track-segments.test.ts
+++ b/tests/logical-track-segments.test.ts
@@ -836,9 +836,10 @@ describe("logical track segments", () => {
     expect(mocks.tracks.get("logical-track")?.status).not.toBe("complete");
   });
 
-  it("binds a stale recording start to its broadcast take, not the newer active take", async () => {
-    // The participant's start was delayed: by the time presign arrives, the
-    // host has stopped take-a and started take-b. The audio belongs to take-a.
+  it("rejects a stale recording start after its broadcast take is stopped", async () => {
+    // The participant's start was delayed until after recovery stopped take-a.
+    // It must not create a brand-new track on that terminal take, even if the
+    // room has since started a newer take-b.
     mocks.recordingTakes.set("take-a", {
       id: "take-a",
       sessionId: "s1",
@@ -870,10 +871,11 @@ describe("logical track segments", () => {
       }),
     );
 
-    expect(res.status).toBe(200);
-    expect(mocks.tracks.get("track-1")).toMatchObject({
-      takeId: "take-a",
+    expect(res.status).toBe(409);
+    await expect(res.json()).resolves.toMatchObject({
+      error: expect.stringContaining("no longer active"),
     });
+    expect(mocks.tracks.has("track-1")).toBe(false);
   });
 
   it("rejects a recording start for a take from another session", async () => {

--- a/tests/recording-state-client.test.ts
+++ b/tests/recording-state-client.test.ts
@@ -62,6 +62,26 @@ describe("stopRecordingTake durability", () => {
     expect(fetchMock).toHaveBeenCalledTimes(1);
   });
 
+  it("targets only the unfinished take reported by finalization", async () => {
+    fetchMock.mockResolvedValueOnce(jsonResponse(inactiveState, 200));
+
+    await stopRecordingTake("s1", {
+      takeId: "take-from-finalize",
+      retryDelayMs: 0,
+    });
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      "/api/sessions/s1/recording-state",
+      expect.objectContaining({
+        method: "POST",
+        body: JSON.stringify({
+          active: false,
+          takeId: "take-from-finalize",
+        }),
+      }),
+    );
+  });
+
   it("gives up after exhausting attempts and throws the last error", async () => {
     fetchMock.mockResolvedValue(jsonResponse({ error: "still down" }, 500));
 

--- a/tests/recording-take.test.ts
+++ b/tests/recording-take.test.ts
@@ -160,7 +160,7 @@ vi.mock("@/lib/db", () => {
   const transaction = vi.fn(
     async (fn: (tx: typeof client) => Promise<unknown>) => {
       const previous = transactionTail;
-      let release = () => undefined;
+      let release: () => void = () => {};
       transactionTail = new Promise<void>((resolve) => {
         release = resolve;
       });
@@ -446,11 +446,11 @@ describe("/api/sessions/[id]/recording-state", () => {
       status: "recording",
     });
 
-    let enterCriticalSection = () => undefined;
+    let enterCriticalSection: () => void = () => {};
     const criticalSectionEntered = new Promise<void>((resolve) => {
       enterCriticalSection = resolve;
     });
-    let releaseCriticalSection = () => undefined;
+    let releaseCriticalSection: () => void = () => {};
     const holdCriticalSection = new Promise<void>((resolve) => {
       releaseCriticalSection = resolve;
     });

--- a/tests/recording-take.test.ts
+++ b/tests/recording-take.test.ts
@@ -44,8 +44,11 @@ function activeTakeFor(sessionId: string): RecordingTake | null {
   );
 }
 
-vi.mock("@/lib/db", () => ({
-  db: {
+vi.mock("@/lib/db", () => {
+  const client = {
+    // withSessionLock runs its callback inside db.$transaction and issues a raw
+    // advisory-lock query; the mock just needs these to exist and pass through.
+    $executeRaw: async () => 0,
     session: {
       findUnique: vi.fn(async ({ where: { id } }: { where: { id: string } }) =>
         mocks.sessions.has(id) ? { id } : null,
@@ -132,8 +135,14 @@ vi.mock("@/lib/db", () => ({
         },
       ),
     },
-  },
-}));
+  };
+  return {
+    db: {
+      ...client,
+      $transaction: async (fn: (tx: typeof client) => unknown) => fn(client),
+    },
+  };
+});
 
 vi.mock("@/lib/auth", async () => {
   const actual = await vi.importActual<typeof import("@/lib/auth")>(

--- a/tests/recording-take.test.ts
+++ b/tests/recording-take.test.ts
@@ -156,10 +156,26 @@ vi.mock("@/lib/db", () => {
       ),
     },
   };
+  let transactionTail = Promise.resolve();
+  const transaction = vi.fn(
+    async (fn: (tx: typeof client) => Promise<unknown>) => {
+      const previous = transactionTail;
+      let release = () => undefined;
+      transactionTail = new Promise<void>((resolve) => {
+        release = resolve;
+      });
+      await previous;
+      try {
+        return await fn(client);
+      } finally {
+        release();
+      }
+    },
+  );
   return {
     db: {
       ...client,
-      $transaction: async (fn: (tx: typeof client) => unknown) => fn(client),
+      $transaction: transaction,
     },
   };
 });
@@ -180,6 +196,7 @@ import {
   PATCH as reportRecordingState,
   POST as setRecordingState,
 } from "@/app/api/sessions/[id]/recording-state/route";
+import { withSessionLock } from "@/lib/session-lock";
 
 function params(id = "s1") {
   return { params: Promise.resolve({ id }) };
@@ -418,6 +435,55 @@ describe("/api/sessions/[id]/recording-state", () => {
       status: "recording",
       stoppedAt: null,
     });
+  });
+
+  it("waits for the session lock before applying a targeted recovery stop", async () => {
+    mocks.takes.set("take-reported", {
+      id: "take-reported",
+      sessionId: "s1",
+      startedAt: new Date("2026-07-08T12:00:00.000Z"),
+      stoppedAt: null,
+      status: "recording",
+    });
+
+    let enterCriticalSection = () => undefined;
+    const criticalSectionEntered = new Promise<void>((resolve) => {
+      enterCriticalSection = resolve;
+    });
+    let releaseCriticalSection = () => undefined;
+    const holdCriticalSection = new Promise<void>((resolve) => {
+      releaseCriticalSection = resolve;
+    });
+
+    // Simulate an initial presign that already read take.status=recording and
+    // is paused before creating its track/segment while holding the session
+    // advisory lock.
+    const presignCriticalSection = withSessionLock("s1", async () => {
+      enterCriticalSection();
+      await holdCriticalSection;
+    });
+    await criticalSectionEntered;
+
+    let stopSettled = false;
+    const stopPromise = setRecordingState(
+      request("POST", { active: false, takeId: "take-reported" }),
+      params(),
+    ).then((response) => {
+      stopSettled = true;
+      return response;
+    });
+
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    const stopSettledWhileLocked = stopSettled;
+    const statusWhileLocked = mocks.takes.get("take-reported")?.status;
+
+    releaseCriticalSection();
+    await presignCriticalSection;
+    const stop = await stopPromise;
+    expect(stopSettledWhileLocked).toBe(false);
+    expect(statusWhileLocked).toBe("recording");
+    expect(stop.status).toBe(200);
+    expect(mocks.takes.get("take-reported")?.status).toBe("stopped");
   });
 
   it("treats status, not stoppedAt, as the active signal", async () => {

--- a/tests/recording-take.test.ts
+++ b/tests/recording-take.test.ts
@@ -111,6 +111,26 @@ vi.mock("@/lib/db", () => {
           return cloneTake(updated);
         },
       ),
+      updateMany: vi.fn(
+        async ({
+          where,
+          data,
+        }: {
+          where: { id: string; sessionId?: string; status?: string };
+          data: { stoppedAt?: Date | null; status?: string };
+        }) => {
+          const take = mocks.takes.get(where.id);
+          if (!take) return { count: 0 };
+          if (where.sessionId !== undefined && take.sessionId !== where.sessionId) {
+            return { count: 0 };
+          }
+          if (where.status !== undefined && take.status !== where.status) {
+            return { count: 0 };
+          }
+          mocks.takes.set(where.id, { ...take, ...data });
+          return { count: 1 };
+        },
+      ),
     },
     recordingTakeParticipantStatus: {
       upsert: vi.fn(
@@ -366,6 +386,38 @@ describe("/api/sessions/[id]/recording-state", () => {
     const stored = mocks.takes.get("take-1");
     expect(stored?.status).toBe("stopped");
     expect(stored?.stoppedAt).toEqual(expect.any(Date));
+  });
+
+  it("does not stop a newer active take when a targeted recovery stop is stale", async () => {
+    mocks.takes.set("take-reported", {
+      id: "take-reported",
+      sessionId: "s1",
+      startedAt: new Date("2026-07-08T12:00:00.000Z"),
+      stoppedAt: new Date("2026-07-08T12:05:00.000Z"),
+      status: "stopped",
+    });
+    mocks.takes.set("take-newer", {
+      id: "take-newer",
+      sessionId: "s1",
+      startedAt: new Date("2026-07-08T12:10:00.000Z"),
+      stoppedAt: null,
+      status: "recording",
+    });
+
+    const stop = await setRecordingState(
+      request("POST", { active: false, takeId: "take-reported" }),
+      params(),
+    );
+
+    expect(stop.status).toBe(200);
+    await expect(stop.json()).resolves.toMatchObject({
+      active: true,
+      take: { id: "take-newer", status: "recording" },
+    });
+    expect(mocks.takes.get("take-newer")).toMatchObject({
+      status: "recording",
+      stoppedAt: null,
+    });
   });
 
   it("treats status, not stoppedAt, as the active signal", async () => {

--- a/tests/recording-take.test.ts
+++ b/tests/recording-take.test.ts
@@ -486,6 +486,51 @@ describe("/api/sessions/[id]/recording-state", () => {
     expect(mocks.takes.get("take-reported")?.status).toBe("stopped");
   });
 
+  it("waits for the session lock before applying an untargeted stop", async () => {
+    mocks.takes.set("take-active", {
+      id: "take-active",
+      sessionId: "s1",
+      startedAt: new Date("2026-07-08T12:00:00.000Z"),
+      stoppedAt: null,
+      status: "recording",
+    });
+
+    let enterCriticalSection: () => void = () => {};
+    const criticalSectionEntered = new Promise<void>((resolve) => {
+      enterCriticalSection = resolve;
+    });
+    let releaseCriticalSection: () => void = () => {};
+    const holdCriticalSection = new Promise<void>((resolve) => {
+      releaseCriticalSection = resolve;
+    });
+    const presignCriticalSection = withSessionLock("s1", async () => {
+      enterCriticalSection();
+      await holdCriticalSection;
+    });
+    await criticalSectionEntered;
+
+    let stopSettled = false;
+    const stopPromise = setRecordingState(
+      request("POST", { active: false }),
+      params(),
+    ).then((response) => {
+      stopSettled = true;
+      return response;
+    });
+
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    const stopSettledWhileLocked = stopSettled;
+    const statusWhileLocked = mocks.takes.get("take-active")?.status;
+    releaseCriticalSection();
+    await presignCriticalSection;
+    const stop = await stopPromise;
+
+    expect(stopSettledWhileLocked).toBe(false);
+    expect(statusWhileLocked).toBe("recording");
+    expect(stop.status).toBe(200);
+    expect(mocks.takes.get("take-active")?.status).toBe("stopped");
+  });
+
   it("treats status, not stoppedAt, as the active signal", async () => {
     // A take whose stop write landed (status stopped) must never read as active,
     // even though a returning participant might still hold a stale reference.

--- a/tests/upload-auth.test.ts
+++ b/tests/upload-auth.test.ts
@@ -22,7 +22,7 @@ type TrackSegment = {
 };
 
 const mocks = vi.hoisted(() => ({
-  sessions: new Set<string>(),
+  sessions: new Map<string, string>(),
   tracks: new Map<string, Track>(),
   segments: new Map<string, TrackSegment>(),
   getPresignedPutUrl: vi.fn(async (key: string) => `https://s3.example/${key}`),
@@ -37,7 +37,7 @@ vi.mock("@/lib/db", () => {
     $executeRaw: async () => 0,
     session: {
       findUnique: vi.fn(async ({ where: { id } }: { where: { id: string } }) =>
-        mocks.sessions.has(id) ? { id } : null,
+        mocks.sessions.has(id) ? { id, status: mocks.sessions.get(id) } : null,
       ),
     },
     recordingTake: {
@@ -251,7 +251,7 @@ beforeEach(() => {
   mocks.sessions.clear();
   mocks.tracks.clear();
   mocks.segments.clear();
-  mocks.sessions.add("s1");
+  mocks.sessions.set("s1", "recording");
   vi.clearAllMocks();
   mocks.resolvePrincipal.mockResolvedValue(null);
 });
@@ -461,6 +461,46 @@ describe("recording upload auth", () => {
       durationMs: 12345,
     });
     expect(mocks.deleteTrackSegmentChunks).toHaveBeenCalledWith("s1", "t1", "t1");
+  });
+
+  it("allows authorized chunk presign and completion for a track created before finalization", async () => {
+    mocks.resolvePrincipal.mockResolvedValueOnce({ kind: "host" });
+    const start = await presignUpload(
+      postJson("/api/upload/presign", {
+        sessionId: "s1",
+        trackId: "t1",
+        partNumber: 0,
+        participantName: "Alice",
+      }),
+    );
+    expect(start.status).toBe(200);
+    const { recordingToken } = (await start.json()) as {
+      recordingToken: string;
+    };
+
+    mocks.sessions.set("s1", "ready");
+
+    const chunk = await presignUpload(
+      postJson(
+        "/api/upload/presign",
+        { sessionId: "s1", trackId: "t1", partNumber: 1 },
+        { "x-cozytrack-recording-token": recordingToken },
+      ),
+    );
+    expect(chunk.status).toBe(200);
+
+    const complete = await completeUpload(
+      postJson(
+        "/api/upload/complete",
+        { sessionId: "s1", trackId: "t1", durationMs: 12345 },
+        { "x-cozytrack-recording-token": recordingToken },
+      ),
+    );
+    expect(complete.status).toBe(200);
+    expect(mocks.tracks.get("t1")).toMatchObject({
+      status: "complete",
+      durationMs: 12345,
+    });
   });
 
   it("forbids completing a track outside the requested session", async () => {

--- a/tests/upload-auth.test.ts
+++ b/tests/upload-auth.test.ts
@@ -503,6 +503,42 @@ describe("recording upload auth", () => {
     });
   });
 
+  it("does not issue a writable URL for a complete track after finalization", async () => {
+    mocks.sessions.set("s1", "ready");
+    mocks.tracks.set("t1", {
+      id: "t1",
+      sessionId: "s1",
+      participantName: "Alice",
+      s3Key: "sessions/s1/tracks/t1/recording.webm",
+      status: "complete",
+      durationMs: 12345,
+    });
+    mocks.segments.set("t1", {
+      id: "t1",
+      trackId: "t1",
+      segmentIndex: 0,
+      s3Prefix: "sessions/s1/tracks/t1/",
+      status: "complete",
+      durationMs: 12345,
+    });
+    const recordingToken = await issueRecordingUploadToken("s1", "t1");
+    mocks.getPresignedPutUrl.mockClear();
+
+    const res = await presignUpload(
+      postJson(
+        "/api/upload/presign",
+        { sessionId: "s1", trackId: "t1", partNumber: 9999 },
+        { "x-cozytrack-recording-token": recordingToken },
+      ),
+    );
+
+    expect(res.status).toBe(409);
+    await expect(res.json()).resolves.toMatchObject({
+      error: expect.stringContaining("already complete"),
+    });
+    expect(mocks.getPresignedPutUrl).not.toHaveBeenCalled();
+  });
+
   it("forbids completing a track outside the requested session", async () => {
     mocks.tracks.set("t1", {
       id: "t1",

--- a/tests/upload-auth.test.ts
+++ b/tests/upload-auth.test.ts
@@ -400,6 +400,7 @@ describe("recording upload auth", () => {
     const { recordingToken } = (await start.json()) as {
       recordingToken: string;
     };
+    mocks.getPresignedPutUrl.mockClear();
 
     const res = await presignUpload(
       postJson(
@@ -412,6 +413,10 @@ describe("recording upload auth", () => {
     expect(res.status).toBe(200);
     const body = (await res.json()) as { key: string; url: string };
     expect(body.key).toBe("sessions/s1/tracks/t1/recording.webm");
+    expect(mocks.getPresignedPutUrl).toHaveBeenCalledWith(
+      "sessions/s1/tracks/t1/recording.webm",
+      { createOnly: true },
+    );
   });
 
   it("rejects a recording token for a different track", async () => {
@@ -461,6 +466,16 @@ describe("recording upload auth", () => {
       durationMs: 12345,
     });
     expect(mocks.deleteTrackSegmentChunks).toHaveBeenCalledWith("s1", "t1", "t1");
+
+    const retry = await completeUpload(
+      postJson(
+        "/api/upload/complete",
+        { sessionId: "s1", trackId: "t1", durationMs: 12345 },
+        { "x-cozytrack-recording-token": recordingToken },
+      ),
+    );
+    expect(retry.status).toBe(200);
+    expect(mocks.deleteTrackSegmentChunks).toHaveBeenCalledTimes(1);
   });
 
   it("allows authorized chunk presign and completion for a track created before finalization", async () => {

--- a/tests/upload-auth.test.ts
+++ b/tests/upload-auth.test.ts
@@ -30,8 +30,11 @@ const mocks = vi.hoisted(() => ({
   resolvePrincipal: vi.fn(),
 }));
 
-vi.mock("@/lib/db", () => ({
-  db: {
+vi.mock("@/lib/db", () => {
+  const client = {
+    // withSessionLock runs its callback inside db.$transaction and issues a raw
+    // advisory-lock query; the mock just needs these to exist and pass through.
+    $executeRaw: async () => 0,
     session: {
       findUnique: vi.fn(async ({ where: { id } }: { where: { id: string } }) =>
         mocks.sessions.has(id) ? { id } : null,
@@ -176,8 +179,14 @@ vi.mock("@/lib/db", () => ({
         },
       ),
     },
-  },
-}));
+  };
+  return {
+    db: {
+      ...client,
+      $transaction: async (fn: (tx: typeof client) => unknown) => fn(client),
+    },
+  };
+});
 
 vi.mock("@/lib/s3", () => ({
   getPresignedPutUrl: mocks.getPresignedPutUrl,

--- a/tests/upload-client.test.ts
+++ b/tests/upload-client.test.ts
@@ -3,6 +3,7 @@ import {
   completeUpload,
   getPresignedUploadTarget,
   getPresignedUploadUrl,
+  uploadChunk,
 } from "@/lib/upload";
 
 const fetchMock = vi.fn();
@@ -115,6 +116,27 @@ describe("upload client auth", () => {
         headers: {
           "Content-Type": "application/json",
           "X-Cozytrack-Recording-Token": "recording-token",
+        },
+      }),
+    );
+  });
+
+  it("sends create-only protection when the presigned URL requires it", async () => {
+    fetchMock.mockResolvedValueOnce(new Response(null, { status: 200 }));
+    const chunk = new Blob(["recording"], { type: "audio/webm" });
+
+    await uploadChunk(
+      "https://s3.example/recording.webm?X-Amz-SignedHeaders=host%3Bif-none-match",
+      chunk,
+    );
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      expect.stringContaining("recording.webm"),
+      expect.objectContaining({
+        method: "PUT",
+        headers: {
+          "Content-Type": "audio/webm",
+          "If-None-Match": "*",
         },
       }),
     );

--- a/tests/upload-client.test.ts
+++ b/tests/upload-client.test.ts
@@ -141,4 +141,15 @@ describe("upload client auth", () => {
       }),
     );
   });
+
+  it("treats a create-only precondition failure as an idempotent upload", async () => {
+    fetchMock.mockResolvedValueOnce(new Response(null, { status: 412 }));
+
+    await expect(
+      uploadChunk(
+        "https://s3.example/recording.webm?X-Amz-SignedHeaders=host%3Bif-none-match",
+        new Blob(["recording"], { type: "audio/webm" }),
+      ),
+    ).resolves.toBeUndefined();
+  });
 });


### PR DESCRIPTION
Fixes #151.

## Problem

A stale `/studio/<id>` page could create a new take and tracks on a session that was already finalized and handed to Podline. The previous guard also had finalize/start race windows, and blocking on an active take without surfacing it left finalize polling forever when a browser died before creating its first track.

## Fix

- serialize recording start, initial presign, targeted and untargeted stops, and finalization with a transaction-scoped per-session PostgreSQL advisory lock
- keep S3, recovery, materialization, ffmpeg, presigning, and cleanup outside the lock transaction
- reject new takes, tracks, segments, upload tokens, and writable URLs after a session is ready
- preserve authorized recovery presigns and completion while an existing track and segment remain `recording` or `uploading`
- refuse new writable URLs once an existing track or segment is complete/failed
- sign final `recording.webm` PUTs with `If-None-Match: *`, so even an already-issued URL cannot overwrite the completed artifact
- treat a final-upload 412 as an idempotent client retry; fully complete retries are no-ops, while failed/incomplete logical tracks can retry materialization
- preserve current main's host-only two-channel local track slots, including slot authorization and stable participant IDs, inside the locked initial-presign path
- reject delayed initial presigns whose explicit take has already been stopped, before creating a track or URL
- prevent either stop path from interleaving between take-status validation and track/segment creation
- reread all tracks and the active take under the lock before conditionally changing `recording → ready`
- return pending tracks while uploads remain, or an explicit `activeTake` conflict for an unfinished take
- let the Studio host confirm “End unfinished take and continue,” stop exactly the take reported by finalize, and retry finalization
- accept optional `takeId` targeting in the stop API/client without changing existing untargeted idempotency
- surface the finalized-session 409 message directly in Studio

No expiry policy, session reopening, schema change, or historical production-data repair is included.

## Confidence

### Unit/API/UI

- ready-session creation guards, including no segment/token/presigned URL
- finalize/start race contracts
- explicit zero-track active-take conflict
- targeted stop cannot terminate a newer take
- delayed initial presign cannot create a track on the stopped recovery take
- both targeted and untargeted stops wait behind an in-flight presign critical section
- complete/failed artifacts cannot receive overwrite URLs
- final upload retries use S3 create-only protection; repeated completion is idempotent without blocking failed materialization recovery
- recovery never stops automatically, requires confirmation, and retries finalize
- incomplete existing-track chunk presign and upload completion remain allowed
- current main's single-track and two-channel Studio contracts remain green

### Real services

- real Postgres advisory-lock races through the actual take-start, presign, stop, and finalize routes
- real targeted-stop-then-delayed-presign rejection
- real targeted stop blocked by an already-held session lock
- real MinIO incomplete-track recovery and terminal-artifact overwrite rejection
- held final presign returns 412 after completion, repeated completion returns 200, and stored bytes remain unchanged

### Browser smoke

- stale finalized Studio page creates no take, track, segment, or writable upload request
- unfinished zero-track take is surfaced, explicitly recovered, finalized to Ready for ingest, and remains guarded against a later start
- recording backup recovery and multi-participant recording paths remain green

## Validation

- `npm ci`
- focused red regressions, then green
- `npm test`: 224/224 after rebasing onto current `main`
- `npm run typecheck`
- `npm run lint`
- `npx prisma validate`
- `npm run build`
- `npm run test:integration`: 11/11
- `npm run test:browser`: 5/5
