### PR TITLE
Reconnect catch-up: resume active take on rejoin (stack 5, phase A)

### DIFF
--- a/src/app/studio/[id]/page.tsx
+++ b/src/app/studio/[id]/page.tsx
@@ -2044,6 +2044,11 @@ function RoomContent({
       ) {
         return;
       }
+      // The room can connect before getUserMedia finishes. Do not spend the
+      // take's catch-up attempt until recorder inputs exist. recordingStream is
+      // a dependency, so becoming ready reruns this effect and fetches a fresh
+      // authoritative take snapshot before starting.
+      if (!recordingStream) return;
       // Resume each active take at most once, and only while we're still idle —
       // a start/stop the user triggered in the meantime takes precedence.
       if (caughtUpTakeIdRef.current === state.take.id) return;
@@ -2063,7 +2068,13 @@ function RoomContent({
     return () => {
       cancelled = true;
     };
-  }, [studioState, sessionId, startRecordingLocal, showNotification]);
+  }, [
+    studioState,
+    recordingStream,
+    sessionId,
+    startRecordingLocal,
+    showNotification,
+  ]);
 
 
   // Block accidental navigation while recording, finalizing, or uploading.

--- a/src/app/studio/[id]/page.tsx
+++ b/src/app/studio/[id]/page.tsx
@@ -35,6 +35,7 @@ import {
   completeUpload,
 } from "@/lib/upload";
 import {
+  getRecordingTakeState,
   RecordingStateError,
   reportRecordingTakeParticipantStatus,
   startRecordingTake,
@@ -837,6 +838,11 @@ function RoomContent({
     useState<string | null>(null);
   const recordingSessionStartedAtRef = useRef<string | null>(null);
   const recordingTakeIdRef = useRef<string | null>(null);
+  // Reconnect catch-up: the id of the active take we've already attempted to
+  // resume on this client, so a participant returning mid-recording rejoins a
+  // given take at most once. Cleared back to null if the resume fails so a
+  // later connect can retry.
+  const caughtUpTakeIdRef = useRef<string | null>(null);
   const setRecordingSessionStartedAtSync = useCallback((next: string | null) => {
     recordingSessionStartedAtRef.current = next;
     setRecordingSessionStartedAt(next);
@@ -2004,6 +2010,60 @@ function RoomContent({
     remoteParticipantName,
     updateRemoteRecordingStatus,
   ]);
+
+  // Reconnect catch-up (stack 5). A participant who (re)joins after the host
+  // pressed record missed the live `recording_start` control message, so on
+  // reaching `connected` we ask the server for the authoritative active take.
+  // Because RecordingTake.status is the source of truth (a host stop durably
+  // flips it to "stopped" before the room tears down — see #148/#150), a take
+  // that still reads `recording` here is genuinely ongoing: we resume it by
+  // starting a fresh segment under the same logical track (presign re-links via
+  // the take id). A stopped take reports active:false and nothing happens — no
+  // host-stop marker needed. startRecordingLocal is idempotent, so this can't
+  // race a live start/stop into a double recorder.
+  useEffect(() => {
+    if (studioState !== "connected") return;
+    let cancelled = false;
+
+    void (async () => {
+      let state;
+      try {
+        state = await getRecordingTakeState(sessionId);
+      } catch (err) {
+        // GET is side-effect-free; skip catch-up this time and let a later
+        // connect retry rather than surfacing noise to the user.
+        console.error("Failed to check for an active recording take:", err);
+        return;
+      }
+      if (cancelled) return;
+      if (
+        !state.active ||
+        !state.take ||
+        state.take.status !== "recording" ||
+        !state.sessionStartedAt
+      ) {
+        return;
+      }
+      // Resume each active take at most once, and only while we're still idle —
+      // a start/stop the user triggered in the meantime takes precedence.
+      if (caughtUpTakeIdRef.current === state.take.id) return;
+      if (studioStateRef.current !== "connected") return;
+      caughtUpTakeIdRef.current = state.take.id;
+
+      const started = await startRecordingLocal(
+        state.sessionStartedAt,
+        state.take.id,
+      );
+      if (!started && !cancelled) {
+        caughtUpTakeIdRef.current = null;
+        showNotification("Couldn't resume the active recording — check your mic");
+      }
+    })();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [studioState, sessionId, startRecordingLocal, showNotification]);
 
 
   // Block accidental navigation while recording, finalizing, or uploading.

--- a/src/lib/recording-state.ts
+++ b/src/lib/recording-state.ts
@@ -74,6 +74,25 @@ function delay(ms: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, ms));
 }
 
+// Read the authoritative recording state for a session. Used by the studio
+// page's reconnect catch-up: a participant returning mid-take asks whether a
+// take is still `recording` and, if so, resumes it. GET has no side effects, so
+// there's nothing to retry — a transient failure just means we skip catch-up
+// this time and the caller can try again on the next connect.
+export async function getRecordingTakeState(
+  sessionId: string,
+): Promise<RecordingTakeState> {
+  const res = await fetch(
+    `/api/sessions/${encodeURIComponent(sessionId)}/recording-state`,
+  );
+
+  if (!res.ok) {
+    throw new RecordingStateError(await parseError(res), res.status);
+  }
+
+  return (await res.json()) as RecordingTakeState;
+}
+
 export async function startRecordingTake(
   sessionId: string,
   sessionStartedAt: string,

--- a/tests/helpers/studio-page.ts
+++ b/tests/helpers/studio-page.ts
@@ -179,7 +179,7 @@ vi.mock("@/hooks/useNavigationGuard", () => ({
   useNavigationGuard: vi.fn(),
 }));
 
-function mediaStream(): MediaStream {
+export function mediaStream(): MediaStream {
   const track = {
     stop: vi.fn(),
     getSettings: () => ({}),

--- a/tests/helpers/studio-page.ts
+++ b/tests/helpers/studio-page.ts
@@ -22,6 +22,7 @@ const studioPageHarness = vi.hoisted(() => ({
   audioContexts: [] as unknown[],
   startRecordingTake: vi.fn(),
   stopRecordingTake: vi.fn(),
+  getRecordingTakeState: vi.fn(),
   reportRecordingTakeParticipantStatus: vi.fn(async () => undefined),
   getPresignedUploadTarget: vi.fn(),
   getPresignedUploadUrl: vi.fn(async () => "https://s3.example/recording.webm"),
@@ -97,6 +98,7 @@ vi.mock("@/lib/transport", () => {
 vi.mock("@/lib/recording-state", () => ({
   startRecordingTake: studioPageHarness.startRecordingTake,
   stopRecordingTake: studioPageHarness.stopRecordingTake,
+  getRecordingTakeState: studioPageHarness.getRecordingTakeState,
   reportRecordingTakeParticipantStatus:
     studioPageHarness.reportRecordingTakeParticipantStatus,
 }));
@@ -255,6 +257,13 @@ beforeEach(() => {
       stoppedAt: "2026-06-27T12:01:00.000Z",
     },
   });
+  // Default: no active take, so the reconnect catch-up effect is a no-op for
+  // tests that don't opt in. Reconnect tests override this per case.
+  studioPageHarness.getRecordingTakeState.mockReset().mockResolvedValue({
+    active: false,
+    sessionStartedAt: null,
+    take: null,
+  });
   studioPageHarness.reportRecordingTakeParticipantStatus
     .mockReset()
     .mockResolvedValue(undefined);
@@ -351,6 +360,7 @@ export function renderGuestStudioPage({
       });
     },
     screen,
+    harness: studioPageHarness,
   };
 }
 

--- a/tests/recording-state-client.test.ts
+++ b/tests/recording-state-client.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
+  getRecordingTakeState,
   RecordingStateError,
   stopRecordingTake,
 } from "@/lib/recording-state";
@@ -89,5 +90,38 @@ describe("stopRecordingTake durability", () => {
       stopRecordingTake("s1", { maxAttempts: 3, retryDelayMs: 0 }),
     ).rejects.toBeInstanceOf(RecordingStateError);
     expect(fetchMock).toHaveBeenCalledTimes(3);
+  });
+});
+
+describe("getRecordingTakeState", () => {
+  it("GETs the recording-state endpoint and returns the parsed state", async () => {
+    const state = {
+      active: true,
+      sessionStartedAt: "2026-07-03T09:00:00.000Z",
+      take: {
+        id: "take-live",
+        sessionId: "s1",
+        startedAt: "2026-07-03T09:00:00.000Z",
+        stoppedAt: null,
+        status: "recording",
+      },
+    };
+    fetchMock.mockResolvedValueOnce(jsonResponse(state, 200));
+
+    const result = await getRecordingTakeState("s1");
+
+    expect(result).toEqual(state);
+    expect(fetchMock).toHaveBeenCalledWith(
+      "/api/sessions/s1/recording-state",
+    );
+  });
+
+  it("throws a RecordingStateError carrying the HTTP status on failure", async () => {
+    fetchMock.mockResolvedValueOnce(jsonResponse({ error: "nope" }, 404));
+
+    await expect(getRecordingTakeState("s1")).rejects.toMatchObject({
+      name: "RecordingStateError",
+      status: 404,
+    });
   });
 });

--- a/tests/studio-page-reconnect.test.ts
+++ b/tests/studio-page-reconnect.test.ts
@@ -1,0 +1,98 @@
+import { waitFor } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { renderGuestStudioPage, renderHostStudioPage } from "./helpers/studio-page";
+
+// Stack 5 (reconnect-safe recording): a participant who (re)joins while a take
+// is still active missed the live `recording_start` broadcast. On connecting,
+// the studio page asks the server for the authoritative active take and, if one
+// is still `recording`, resumes it by starting a fresh segment under the same
+// logical track (presign re-links via the take id). Because RecordingTake.status
+// is authoritative (a host stop flips it to "stopped"), a stopped take reports
+// active:false and nothing resumes — no host-stop marker needed.
+
+const activeTake = {
+  active: true,
+  sessionStartedAt: "2026-07-03T09:00:00.000Z",
+  take: {
+    id: "take-live",
+    sessionId: "session-host",
+    startedAt: "2026-07-03T09:00:00.000Z",
+    stoppedAt: null,
+    status: "recording",
+  },
+};
+
+function takeIdOfPresign(harness: {
+  getPresignedUploadTarget: { mock: { calls: unknown[][] } };
+}): string | undefined {
+  const call = harness.getPresignedUploadTarget.mock.calls.at(-1);
+  const options = call?.[4] as { takeId?: string } | undefined;
+  return options?.takeId;
+}
+
+describe("StudioPage reconnect catch-up", () => {
+  it("resumes the active take for a returning host by starting a new segment", async () => {
+    const studio = renderHostStudioPage();
+    studio.harness.getRecordingTakeState.mockResolvedValue(activeTake);
+
+    await studio.join();
+
+    // No Start click: the catch-up effect should have resumed on its own.
+    await waitFor(() => {
+      expect(studio.harness.recorderStart).toHaveBeenCalled();
+    });
+    expect(takeIdOfPresign(studio.harness)).toBe("take-live");
+    await studio.screen.findByRole("button", { name: "Stop recording" });
+  });
+
+  it("resumes the active take for a returning guest", async () => {
+    const studio = renderGuestStudioPage();
+    studio.harness.getRecordingTakeState.mockResolvedValue(activeTake);
+
+    await studio.join();
+
+    await waitFor(() => {
+      expect(studio.harness.recorderStart).toHaveBeenCalled();
+    });
+    expect(takeIdOfPresign(studio.harness)).toBe("take-live");
+  });
+
+  it("does not resume when the server reports no active take", async () => {
+    const studio = renderHostStudioPage();
+    // Default harness state is inactive; assert we stay idle.
+
+    await studio.join();
+    // Give any pending catch-up effect a chance to run before asserting.
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    expect(studio.harness.recorderStart).not.toHaveBeenCalled();
+    expect(
+      studio.screen.getByRole("button", { name: "Start recording" }),
+    ).toBeTruthy();
+  });
+
+  it("does not resume a take the host has already stopped", async () => {
+    const studio = renderHostStudioPage();
+    // A stopped take is authoritatively inactive: active:false even though a
+    // take row exists.
+    studio.harness.getRecordingTakeState.mockResolvedValue({
+      active: false,
+      sessionStartedAt: null,
+      take: {
+        id: "take-live",
+        sessionId: "session-host",
+        startedAt: "2026-07-03T09:00:00.000Z",
+        stoppedAt: "2026-07-03T09:05:00.000Z",
+        status: "stopped",
+      },
+    });
+
+    await studio.join();
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    expect(studio.harness.recorderStart).not.toHaveBeenCalled();
+    expect(
+      studio.screen.getByRole("button", { name: "Start recording" }),
+    ).toBeTruthy();
+  });
+});

--- a/tests/studio-page-reconnect.test.ts
+++ b/tests/studio-page-reconnect.test.ts
@@ -1,6 +1,10 @@
 import { waitFor } from "@testing-library/react";
 import { describe, expect, it } from "vitest";
-import { renderGuestStudioPage, renderHostStudioPage } from "./helpers/studio-page";
+import {
+  mediaStream,
+  renderGuestStudioPage,
+  renderHostStudioPage,
+} from "./helpers/studio-page";
 
 // Stack 5 (reconnect-safe recording): a participant who (re)joins while a take
 // is still active missed the live `recording_start` broadcast. On connecting,
@@ -31,6 +35,39 @@ function takeIdOfPresign(harness: {
 }
 
 describe("StudioPage reconnect catch-up", () => {
+  it("retries catch-up after the recording stream becomes ready", async () => {
+    const studio = renderHostStudioPage();
+    studio.harness.getRecordingTakeState.mockResolvedValue(activeTake);
+
+    // Let the prejoin device probe finish, then delay the recording stream
+    // acquired after the room mounts so the active-state GET wins the race.
+    await waitFor(() => {
+      expect(studio.harness.getUserMedia).toHaveBeenCalledTimes(1);
+    });
+    let resolveRecordingStream!: (stream: MediaStream) => void;
+    studio.harness.getUserMedia.mockImplementationOnce(
+      () =>
+        new Promise<MediaStream>((resolve) => {
+          resolveRecordingStream = resolve;
+        }),
+    );
+
+    const joinPromise = studio.join();
+
+    await waitFor(() => {
+      expect(studio.harness.getRecordingTakeState).toHaveBeenCalled();
+    });
+    expect(studio.harness.recorderStart).not.toHaveBeenCalled();
+
+    resolveRecordingStream(mediaStream());
+    await joinPromise;
+
+    await waitFor(() => {
+      expect(studio.harness.recorderStart).toHaveBeenCalled();
+    });
+    expect(takeIdOfPresign(studio.harness)).toBe("take-live");
+  });
+
   it("resumes the active take for a returning host by starting a new segment", async () => {
     const studio = renderHostStudioPage();
     studio.harness.getRecordingTakeState.mockResolvedValue(activeTake);


### PR DESCRIPTION
## Why

Stack 5 continues the reconnect-safe recording work that #150 cleared the runway for. #150 made `RecordingTake.status` authoritative and stops durable; this PR builds the first user-visible piece on that foundation: a participant who returns to a session **mid-recording** now rejoins the active take instead of starting fresh.

Previously, a returning host/guest missed the live `recording_start` control message and never resumed. #137 attempted this on the old take model and leaned on a `HOST_STOPPED_ROOM_REASON` marker to tell "host deliberately stopped" from "should resume." With authoritative status that marker is unnecessary and is not reintroduced here.

## What

- **`getRecordingTakeState(sessionId)`** — a GET wrapper on the recording-state endpoint. No retry: it's side-effect-free, so a transient failure just skips catch-up until the next connect.
- **Catch-up effect** in the studio page — on reaching `connected`, read the authoritative state; if a take is still `recording`, resume by starting a new segment under the same logical track (presign re-links via the take id). A stopped take reports `active:false`, so nothing resurrects.
- `caughtUpTakeIdRef` guards each take to one resume attempt per client; the existing idempotency in `startRecordingLocal` (no-ops when already recording/finalizing) prevents racing a live start/stop into a double recorder.

## Why this is safe (no resurrection)

The host's stop is persisted server-side (`status='stopped'`) and awaited **before** local teardown, so by the time a returning participant reaches `connected` and queries state, a genuinely-ended recording already reads `active:false`. This is exactly the guarantee #150 established.

## Scope / follow-ups

Out of scope, tracked for **stack 5 phase B/C**:
- **Heartbeat liveness lease** — so a crashed host (take stuck at `recording` with no clean stop) can't be resumed into. Foundation for the #154 zombie-take sweeper.
- **Returning-host/guest browser smoke tests.**

Advances #75. Foundation: #148 / #150.

## Tests

TDD, tests written first:
- `tests/studio-page-reconnect.test.ts` (new) — returning host resumes; returning guest resumes; no active take → stays idle; already-stopped take → stays idle.
- `tests/recording-state-client.test.ts` — `getRecordingTakeState` GETs the endpoint and surfaces HTTP status on failure.
- Full suite: 26 files / 192 tests pass. `typecheck` and `lint` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)