### PR TITLE
Local multichannel recording with remote participant (#135)

### DIFF
--- a/.github/workflows/codex-review.yml
+++ b/.github/workflows/codex-review.yml
@@ -123,6 +123,7 @@ jobs:
         uses: openai/codex-action@v1
         with:
           openai-api-key: ${{ secrets.OPENAI_API_KEY }}
+          model: gpt-5.5
           sandbox: read-only
           prompt: |
             Review this pull request for bugs, regressions, security issues, and missing tests.

--- a/src/app/api/upload/presign/route.ts
+++ b/src/app/api/upload/presign/route.ts
@@ -9,6 +9,8 @@ import {
 } from "@/lib/s3";
 import {
   issueRecordingUploadToken,
+  isLocalTrackSlotId,
+  localTrackSlotParticipantId,
   principalParticipantId,
   resolvePrincipal,
   type Principal,
@@ -56,6 +58,7 @@ async function ensureLogicalTrackAndSegment(input: {
   requestedTrackId: string;
   requestedSegmentId: string;
   requestedTakeId?: string;
+  localTrackSlotId?: string;
   principal: Principal;
   participantName: unknown;
   deviceLabel: unknown;
@@ -68,6 +71,7 @@ async function ensureLogicalTrackAndSegment(input: {
     requestedTrackId,
     requestedSegmentId,
     requestedTakeId,
+    localTrackSlotId,
     principal,
     participantName,
     deviceLabel,
@@ -75,7 +79,21 @@ async function ensureLogicalTrackAndSegment(input: {
     isBuiltInMic,
     sessionStartedAt,
   } = input;
-  const participantId = principalParticipantId(principal);
+  // Local channel slots are host-owned. A guest must never be able to write
+  // into a synthetic host participant id, so reject the slot before deriving
+  // anything from it; an unknown slot id is a client bug, not an auth failure.
+  let participantId: string;
+  if (localTrackSlotId !== undefined) {
+    if (principal.kind !== "host") {
+      throw new Error("LOCAL_SLOT_FORBIDDEN");
+    }
+    if (!isLocalTrackSlotId(localTrackSlotId)) {
+      throw new Error("LOCAL_SLOT_INVALID");
+    }
+    participantId = localTrackSlotParticipantId(localTrackSlotId);
+  } else {
+    participantId = principalParticipantId(principal);
+  }
   // Prefer the take the client was actually recording for. A delayed start
   // must not attach its audio to whichever take happens to be active by the
   // time presign arrives (the host may have moved on to a newer take).
@@ -250,6 +268,8 @@ export async function POST(req: NextRequest) {
       sessionStartedAt,
     } = body;
     const requestedTakeId = cleanNonEmptyString(body?.takeId) ?? undefined;
+    const localTrackSlotId =
+      cleanNonEmptyString(body?.localTrackSlotId) ?? undefined;
 
     if (!sessionId || !trackId || partNumber === undefined) {
       return NextResponse.json(
@@ -295,6 +315,7 @@ export async function POST(req: NextRequest) {
           requestedTrackId: trackId,
           requestedSegmentId: segmentId,
           requestedTakeId,
+          localTrackSlotId,
           principal,
           participantName,
           deviceLabel,
@@ -313,6 +334,15 @@ export async function POST(req: NextRequest) {
             { error: "participantName is required to start an upload" },
             { status: 400 }
           );
+        }
+        if (error instanceof Error && error.message === "LOCAL_SLOT_INVALID") {
+          return NextResponse.json(
+            { error: "Unknown local track slot" },
+            { status: 400 }
+          );
+        }
+        if (error instanceof Error && error.message === "LOCAL_SLOT_FORBIDDEN") {
+          return NextResponse.json({ error: "forbidden" }, { status: 403 });
         }
         if (
           error instanceof Error &&

--- a/src/app/studio/[id]/page.tsx
+++ b/src/app/studio/[id]/page.tsx
@@ -1202,8 +1202,12 @@ function RoomContent({
 
     let cancelled = false;
     async function acquireSplit() {
+      // Hoisted so every failure/cancel path can stop the captured device — an
+      // orphaned 2-channel input stream would otherwise hold the mic open until
+      // page teardown.
+      let rawStream: MediaStream | null = null;
       try {
-        const rawStream = await navigator.mediaDevices.getUserMedia({
+        rawStream = await navigator.mediaDevices.getUserMedia({
           audio: {
             deviceId: selectedMic ? { exact: selectedMic } : undefined,
             echoCancellation: false,
@@ -1218,6 +1222,8 @@ function RoomContent({
           return;
         }
 
+        // splitStereoStream fails closed (never throws), so a non-"ok" result
+        // is the single signal to release the input stream.
         const result = splitStereoStream(rawStream);
         if (result.state !== "ok") {
           rawStream.getTracks().forEach((track) => track.stop());
@@ -1238,6 +1244,11 @@ function RoomContent({
         setTwoChannelStatus("ok");
       } catch (err) {
         console.error("Failed to acquire two-channel stream:", err);
+        // Defense in depth: if anything after acquisition throws, the stream we
+        // opened isn't owned by splitRawStreamRef yet, so stop it here.
+        if (rawStream && splitRawStreamRef.current !== rawStream) {
+          rawStream.getTracks().forEach((track) => track.stop());
+        }
         if (!cancelled) {
           setTwoChannelStatus("unsupported");
           setSlotCapturesSync([]);
@@ -1982,6 +1993,11 @@ function RoomContent({
       })();
       try {
         await trackerTrackUpload(finalBytes, finalUpload, { rethrow: true });
+        // Drain every in-flight upload (both channels' background chunk PUTs
+        // and final blobs) before completing. /complete deletes the temporary
+        // chunk objects, so a slow chunk PUT that lands afterwards would leave
+        // stale objects — the single-track path waits here for the same reason.
+        await trackerWaitForUploads();
         await completeUpload(
           sessionId,
           slot.trackId,
@@ -2012,7 +2028,12 @@ function RoomContent({
         return false;
       }
     },
-    [sessionId, trackerOnChunkRecorded, trackerTrackUpload],
+    [
+      sessionId,
+      trackerOnChunkRecorded,
+      trackerTrackUpload,
+      trackerWaitForUploads,
+    ],
   );
 
   // Start both channel recorders as a single logical "start". Mirrors the

--- a/src/app/studio/[id]/page.tsx
+++ b/src/app/studio/[id]/page.tsx
@@ -28,6 +28,7 @@ import {
 import { v4 as uuidv4 } from "uuid";
 import { CozyRecorder } from "@/lib/recorder";
 import { forceMonoStream, getTrackChannelCount } from "@/lib/audio-downmix";
+import { splitStereoStream } from "@/lib/audio-splitter";
 import {
   getPresignedUploadTarget,
   getPresignedUploadUrl,
@@ -112,6 +113,36 @@ const BANDWIDTH_SAVING_PUBLISH = {
 } as const;
 
 const RECORDING_CONFIRMATION_TIMEOUT_MS = 4000;
+
+// Host-owned local channel slots (issue #135). The slot ids are the contract
+// values the upload presign endpoint accepts and derives stable synthetic
+// participant ids from — they are duplicated here (rather than imported from
+// @/lib/auth, which pulls server-only deps) because this is a client bundle.
+const LOCAL_TRACK_SLOTS = [
+  { slotId: "host-local-ch-1", label: "Local Ch 1" },
+  { slotId: "host-local-ch-2", label: "Local Ch 2" },
+] as const;
+type LocalTrackSlotId = (typeof LOCAL_TRACK_SLOTS)[number]["slotId"];
+
+type TwoChannelStatus = "idle" | "ok" | "unsupported" | "missing-channels";
+
+// One split desktop channel wired up for capture and metering.
+type SlotCapture = {
+  slotId: LocalTrackSlotId;
+  label: string;
+  stream: MediaStream;
+};
+
+// A slot with an active recorder + upload identity mid-take.
+type ActiveSlot = {
+  slotId: LocalTrackSlotId;
+  label: string;
+  recorder: CozyRecorder;
+  trackId: string;
+  segmentId: string;
+  uploadToken?: string;
+  backupId: string | null;
+};
 
 // ---------- Helpers ----------
 
@@ -725,6 +756,27 @@ function RoomContent({
   const streamRef = useRef<MediaStream | null>(null);
   const downmixDisposeRef = useRef<(() => void) | null>(null);
   const [recordingStream, setRecordingStream] = useState<MediaStream | null>(null);
+
+  // ---- Two-channel local mode (issue #135) ----
+  // An additive, host-only capture path. When off, the single-track machinery
+  // above is the sole recorder and behaves exactly as before. When on, one
+  // desktop interface is split into two mono channels, each recorded as its
+  // own logical track slot. The slot array *is* the "small array of local
+  // recording slots" — single-track mode is the degenerate 1-recorder case
+  // served by the untouched path above.
+  const [twoChannelMode, setTwoChannelMode] = useState(false);
+  const [twoChannelStatus, setTwoChannelStatus] =
+    useState<TwoChannelStatus>("idle");
+  const [slotCaptures, setSlotCaptures] = useState<SlotCapture[]>([]);
+  const slotCapturesRef = useRef<SlotCapture[]>([]);
+  const slotRecordersRef = useRef<ActiveSlot[]>([]);
+  const [slotLevels, setSlotLevels] = useState<Map<string, number>>(new Map());
+  const splitterDisposeRef = useRef<(() => void) | null>(null);
+  const splitRawStreamRef = useRef<MediaStream | null>(null);
+  const setSlotCapturesSync = useCallback((next: SlotCapture[]) => {
+    slotCapturesRef.current = next;
+    setSlotCaptures(next);
+  }, []);
   // Mirror of studioState so callbacks invoked from transport subscriptions
   // (which close over the value at subscription time) can check current state
   // without re-subscribing on every render.
@@ -1140,6 +1192,121 @@ function RoomContent({
       audioCtx.close();
     };
   }, [participantName, recordingStream]);
+
+  // Acquire and split the selected interface into two mono channels whenever
+  // two-channel mode is enabled. Fails closed via splitStereoStream: if the
+  // device can't prove 2-channel capture we surface a status instead of two
+  // silent/duplicated slots. Host-only.
+  useEffect(() => {
+    if (!isHost || !twoChannelMode) return;
+
+    let cancelled = false;
+    async function acquireSplit() {
+      try {
+        const rawStream = await navigator.mediaDevices.getUserMedia({
+          audio: {
+            deviceId: selectedMic ? { exact: selectedMic } : undefined,
+            echoCancellation: false,
+            noiseSuppression: false,
+            autoGainControl: false,
+            sampleRate: 48000,
+            channelCount: 2,
+          },
+        });
+        if (cancelled) {
+          rawStream.getTracks().forEach((track) => track.stop());
+          return;
+        }
+
+        const result = splitStereoStream(rawStream);
+        if (result.state !== "ok") {
+          rawStream.getTracks().forEach((track) => track.stop());
+          setTwoChannelStatus(result.state);
+          setSlotCapturesSync([]);
+          return;
+        }
+
+        splitRawStreamRef.current = rawStream;
+        splitterDisposeRef.current = result.dispose;
+        setSlotCapturesSync(
+          LOCAL_TRACK_SLOTS.map((slot, i) => ({
+            slotId: slot.slotId,
+            label: slot.label,
+            stream: result.channels[i],
+          })),
+        );
+        setTwoChannelStatus("ok");
+      } catch (err) {
+        console.error("Failed to acquire two-channel stream:", err);
+        if (!cancelled) {
+          setTwoChannelStatus("unsupported");
+          setSlotCapturesSync([]);
+        }
+      }
+    }
+
+    void acquireSplit();
+
+    return () => {
+      cancelled = true;
+      splitterDisposeRef.current?.();
+      splitterDisposeRef.current = null;
+      splitRawStreamRef.current?.getTracks().forEach((track) => track.stop());
+      splitRawStreamRef.current = null;
+      setSlotCapturesSync([]);
+      setTwoChannelStatus("idle");
+    };
+  }, [isHost, twoChannelMode, selectedMic, setSlotCapturesSync]);
+
+  // Per-slot level meters. One analyser per split channel, feeding slotLevels
+  // keyed by slot id (kept separate from the shared audioLevels map, whose
+  // remote-merge effect would otherwise wipe these keys).
+  useEffect(() => {
+    if (slotCaptures.length === 0) {
+      setSlotLevels(new Map());
+      return;
+    }
+
+    const cleanups: Array<() => void> = [];
+    for (const capture of slotCaptures) {
+      const audioCtx = new AudioContext();
+      const source = audioCtx.createMediaStreamSource(capture.stream);
+      const analyser = audioCtx.createAnalyser();
+      analyser.fftSize = 2048;
+      analyser.smoothingTimeConstant = 0.85;
+      source.connect(analyser);
+      const dataArray = new Uint8Array(analyser.fftSize);
+      let raf = 0;
+      let level = 0;
+
+      const tick = () => {
+        analyser.getByteTimeDomainData(dataArray);
+        let sumSquares = 0;
+        for (const value of dataArray) {
+          const centered = (value - 128) / 128;
+          sumSquares += centered * centered;
+        }
+        const rms = Math.sqrt(sumSquares / dataArray.length);
+        const normalized = Math.min(1, Math.max(0, (rms - 0.01) / 0.12));
+        const target = Math.round(shapeLevel(normalized) * 255);
+        level = Math.round(smoothLevel(level, target));
+        setSlotLevels((prev) => {
+          const next = new Map(prev);
+          next.set(capture.slotId, level);
+          return next;
+        });
+        raf = requestAnimationFrame(tick);
+      };
+      tick();
+
+      cleanups.push(() => {
+        cancelAnimationFrame(raf);
+        audioCtx.close();
+      });
+    }
+
+    return () => cleanups.forEach((fn) => fn());
+  }, [slotCaptures]);
 
   // Track remote audio levels via getStats() polling on each remote audio
   // track's RTCRtpReceiver. Replaces the prior `useSpeakingParticipants`
@@ -1676,6 +1843,347 @@ function RoomContent({
     timingDebug,
   ]);
 
+  // ---- Two-channel slot recorders ----
+  // Set up one recorder for a single split channel: presign a slot-scoped
+  // track, wire chunk uploads (with crash-safe local backup) through the shared
+  // upload tracker, and start capturing. Throws on failure so the caller can
+  // roll back the whole two-channel start.
+  const beginSlotRecorder = useCallback(
+    async (
+      capture: SlotCapture,
+      sessionStartedAtIso: string,
+      takeId: string | null,
+    ): Promise<ActiveSlot> => {
+      const requestedTrackId = uuidv4();
+      const initialUpload = await getPresignedUploadTarget(
+        sessionId,
+        requestedTrackId,
+        0,
+        capture.label,
+        {
+          deviceInfo: {
+            deviceLabel: selectedMicLabel
+              ? `${capture.label} · ${selectedMicLabel}`
+              : capture.label,
+            deviceId: selectedMic,
+            isBuiltInMic: selectedMicIsBuiltIn,
+          },
+          sessionStartedAt: sessionStartedAtIso,
+          takeId: takeId ?? undefined,
+          localTrackSlotId: capture.slotId,
+        },
+      );
+      const trackId = initialUpload.trackId ?? requestedTrackId;
+      const segmentId = initialUpload.segmentId ?? requestedTrackId;
+      const uploadToken = initialUpload.recordingToken;
+
+      let backupId: string | null = null;
+      try {
+        await browserRecordingBackupStore.startBackup({
+          sessionId,
+          trackId,
+          segmentId,
+          participantName: capture.label,
+          recordingToken: uploadToken,
+        });
+        backupId = recordingBackupId(sessionId, segmentId);
+      } catch (backupErr) {
+        console.error("Failed to init local slot backup:", backupErr);
+      }
+
+      const recorder = new CozyRecorder(capture.stream);
+      recorder.onChunk((chunk, index) => {
+        const byteLength = chunk.size;
+        trackerOnChunkRecorded(byteLength);
+        const capturedAt = new Date();
+        const backupSave = backupId
+          ? browserRecordingBackupStore
+              .saveChunk({
+                sessionId,
+                trackId,
+                segmentId,
+                chunkIndex: index,
+                chunk,
+                capturedAt,
+              })
+              .catch((backupErr) => {
+                console.error("Failed to write local slot backup:", backupErr);
+                return null;
+              })
+          : Promise.resolve(null);
+
+        const uploadPromise = (async () => {
+          await backupSave;
+          const url = await getPresignedUploadUrl(
+            sessionId,
+            trackId,
+            index,
+            undefined,
+            { segmentId },
+            uploadToken,
+          );
+          await uploadChunk(url, chunk);
+          if (backupId) {
+            try {
+              await browserRecordingBackupStore.markChunkUploaded(
+                sessionId,
+                trackId,
+                index,
+                segmentId,
+              );
+            } catch (backupErr) {
+              console.error("Failed to mark slot chunk uploaded:", backupErr);
+            }
+          }
+        })();
+
+        void trackerTrackUpload(byteLength, uploadPromise);
+      });
+
+      await recorder.start(5000);
+      return {
+        slotId: capture.slotId,
+        label: capture.label,
+        recorder,
+        trackId,
+        segmentId,
+        uploadToken,
+        backupId,
+      };
+    },
+    [
+      sessionId,
+      selectedMic,
+      selectedMicLabel,
+      selectedMicIsBuiltIn,
+      trackerOnChunkRecorded,
+      trackerTrackUpload,
+    ],
+  );
+
+  // Start both channel recorders as a single logical "start". Mirrors the
+  // orchestration in startRecordingLocal (state, confirmation, broadcast,
+  // preview-quality switch) but drives the slot array instead of one recorder.
+  const startLocalSlots = useCallback(
+    async (
+      sessionStartedAtIso: string,
+      takeId?: string | null,
+    ): Promise<boolean> => {
+      const effectiveTakeId = takeId ?? recordingTakeIdRef.current;
+      if (effectiveTakeId) recordingTakeIdRef.current = effectiveTakeId;
+      if (studioStateRef.current === "finalizing") {
+        void broadcastRecordingStatus(
+          "failed",
+          sessionStartedAtIso,
+          "still finalizing previous recording",
+          effectiveTakeId,
+        );
+        return false;
+      }
+      if (
+        studioStateRef.current === "recording" ||
+        slotRecordersRef.current.length > 0
+      ) {
+        void broadcastRecordingStatus(
+          "recording",
+          recordingSessionStartedAtRef.current ?? sessionStartedAtIso,
+          undefined,
+          effectiveTakeId,
+        );
+        return true;
+      }
+
+      const captures = slotCapturesRef.current;
+      if (captures.length !== LOCAL_TRACK_SLOTS.length) {
+        clearRecordingConfirmationState();
+        void broadcastRecordingStatus(
+          "failed",
+          sessionStartedAtIso,
+          "two-channel capture unavailable",
+          effectiveTakeId,
+        );
+        return false;
+      }
+
+      trackerReset();
+      recordingStartRef.current = Date.now();
+
+      const started: ActiveSlot[] = [];
+      try {
+        for (const capture of captures) {
+          started.push(
+            await beginSlotRecorder(capture, sessionStartedAtIso, effectiveTakeId),
+          );
+        }
+      } catch (err) {
+        console.error("Failed to start two-channel recorders:", err);
+        await Promise.all(
+          started.map(async (slot) => {
+            try {
+              await slot.recorder.stop();
+            } catch {
+              // Best-effort teardown of partially-started recorders.
+            }
+          }),
+        );
+        slotRecordersRef.current = [];
+        clearRecordingConfirmationState();
+        void broadcastRecordingStatus(
+          "failed",
+          sessionStartedAtIso,
+          "recorder failed to start",
+          effectiveTakeId,
+        );
+        return false;
+      }
+
+      slotRecordersRef.current = started;
+      setRecordingSessionStartedAtSync(sessionStartedAtIso);
+      scheduleRecordingConfirmationCheck(sessionStartedAtIso);
+      setStudioStateSync("recording");
+      void broadcastRecordingStatus(
+        "recording",
+        sessionStartedAtIso,
+        undefined,
+        effectiveTakeId,
+      );
+
+      const switched = await switchAudioQuality("bandwidth-saving");
+      if (switched) {
+        showNotification("Preview quality reduced — local recording is unaffected");
+      } else {
+        showNotification("Couldn't switch audio quality — check console");
+      }
+      return true;
+    },
+    [
+      beginSlotRecorder,
+      broadcastRecordingStatus,
+      clearRecordingConfirmationState,
+      scheduleRecordingConfirmationCheck,
+      setRecordingSessionStartedAtSync,
+      setStudioStateSync,
+      showNotification,
+      switchAudioQuality,
+      trackerReset,
+    ],
+  );
+
+  // Stop both channel recorders, finalize each track, then return to connected.
+  const stopLocalSlots = useCallback(async () => {
+    const sessionStartedAtForStatus =
+      recordingSessionStartedAtRef.current ?? undefined;
+    const takeIdForStatus = recordingTakeIdRef.current;
+    if (studioStateRef.current === "finalizing") return;
+    clearRecordingConfirmationState(false);
+
+    const slots = slotRecordersRef.current;
+    if (slots.length === 0) {
+      setRecordingSessionStartedAtSync(null);
+      recordingTakeIdRef.current = null;
+      void broadcastRecordingStatus(
+        "connected",
+        sessionStartedAtForStatus,
+        undefined,
+        takeIdForStatus,
+      );
+      return;
+    }
+
+    slotRecordersRef.current = [];
+    const startedAt = recordingStartRef.current;
+    setStudioStateSync("finalizing");
+    void broadcastRecordingStatus(
+      "finalizing",
+      sessionStartedAtForStatus,
+      undefined,
+      takeIdForStatus,
+    );
+
+    try {
+      const stopped = await Promise.all(
+        slots.map(async (slot) => ({ slot, blob: await slot.recorder.stop() })),
+      );
+      const durationMs = Date.now() - startedAt;
+      trackerFreezeRecorded();
+
+      // Each channel's final recording.webm is critical — rethrow so a failure
+      // surfaces and we skip completeUpload for that channel rather than let
+      // the server discard chunks for a track that never finalized.
+      for (const { slot, blob } of stopped) {
+        const finalBytes = blob.size;
+        trackerOnChunkRecorded(finalBytes);
+        const finalUpload = (async () => {
+          const url = await getPresignedUploadUrl(
+            sessionId,
+            slot.trackId,
+            9999,
+            undefined,
+            { segmentId: slot.segmentId },
+            slot.uploadToken,
+          );
+          await uploadChunk(url, blob);
+        })();
+        await trackerTrackUpload(finalBytes, finalUpload, { rethrow: true });
+      }
+
+      await trackerWaitForUploads();
+
+      for (const { slot } of stopped) {
+        await completeUpload(
+          sessionId,
+          slot.trackId,
+          durationMs,
+          slot.uploadToken,
+          slot.segmentId,
+        );
+        if (slot.backupId) {
+          try {
+            await browserRecordingBackupStore.clearBackup(
+              slot.backupId,
+              "verified-upload",
+            );
+          } catch (backupErr) {
+            console.error("Failed to clear slot backup:", backupErr);
+          }
+        }
+      }
+
+      setHasRecorded(true);
+    } catch (err) {
+      console.error("Failed to stop two-channel recording:", err);
+    } finally {
+      try {
+        await trackerWaitForUploads();
+      } catch (drainErr) {
+        console.error("Failed while draining slot uploads:", drainErr);
+      }
+      setStudioStateSync("connected");
+      setRecordingSessionStartedAtSync(null);
+      recordingTakeIdRef.current = null;
+      void broadcastRecordingStatus(
+        "connected",
+        sessionStartedAtForStatus,
+        undefined,
+        takeIdForStatus,
+      );
+      void switchAudioQuality("full").catch((err) => {
+        console.error("Failed to restore audio quality:", err);
+      });
+    }
+  }, [
+    broadcastRecordingStatus,
+    clearRecordingConfirmationState,
+    sessionId,
+    setRecordingSessionStartedAtSync,
+    setStudioStateSync,
+    switchAudioQuality,
+    trackerFreezeRecorded,
+    trackerOnChunkRecorded,
+    trackerTrackUpload,
+    trackerWaitForUploads,
+  ]);
+
   const handleRetryLocalBackupUpload = useCallback(async () => {
     if (backupAction !== "idle") return;
     if (studioStateRef.current !== "connected") return;
@@ -1780,7 +2288,8 @@ function RoomContent({
       startingRef.current ||
       studioStateRef.current === "recording" ||
       studioStateRef.current === "finalizing" ||
-      recorderRef.current
+      recorderRef.current ||
+      slotRecordersRef.current.length > 0
     ) {
       return;
     }
@@ -1823,7 +2332,9 @@ function RoomContent({
         return;
       }
 
-      const started = await startRecordingLocal(sessionStartedAt, takeId);
+      const started = twoChannelMode
+        ? await startLocalSlots(sessionStartedAt, takeId)
+        : await startRecordingLocal(sessionStartedAt, takeId);
       if (!started) {
         showNotification("Couldn't start your recorder — stopping the room");
         try {
@@ -1841,7 +2352,15 @@ function RoomContent({
     } finally {
       startingRef.current = false;
     }
-  }, [isHost, sessionId, transport, startRecordingLocal, showNotification]);
+  }, [
+    isHost,
+    sessionId,
+    transport,
+    startRecordingLocal,
+    startLocalSlots,
+    twoChannelMode,
+    showNotification,
+  ]);
 
   const handleStopRecording = useCallback(async () => {
     if (!isHost) return;
@@ -1864,11 +2383,23 @@ function RoomContent({
         console.error("Failed to broadcast recording_stop:", err);
         showNotification("Couldn't tell the room to stop recording");
       }
-      await stopRecordingLocal();
+      if (twoChannelMode) {
+        await stopLocalSlots();
+      } else {
+        await stopRecordingLocal();
+      }
     } finally {
       stoppingRef.current = false;
     }
-  }, [isHost, sessionId, transport, stopRecordingLocal, showNotification]);
+  }, [
+    isHost,
+    sessionId,
+    transport,
+    stopRecordingLocal,
+    stopLocalSlots,
+    twoChannelMode,
+    showNotification,
+  ]);
 
   // Subscribe to remote control messages. LiveKit does not echo the sender's
   // own messages back, but startRecordingLocal/stopRecordingLocal are
@@ -1975,6 +2506,11 @@ function RoomContent({
       if (monoStream && monoStream !== rawStream) {
         monoStream.getTracks().forEach((t) => t.stop());
       }
+      // Two-channel split teardown.
+      splitterDisposeRef.current?.();
+      splitterDisposeRef.current = null;
+      splitRawStreamRef.current?.getTracks().forEach((t) => t.stop());
+      splitRawStreamRef.current = null;
     };
   }, []);
 
@@ -2123,15 +2659,84 @@ function RoomContent({
       {/* Main layout: strips + right sidebar */}
       <div className="flex flex-1 min-h-0">
         <div className="flex-1 p-5 flex flex-col gap-2.5 overflow-y-auto">
-          <ParticipantStrip
-            name={participantName}
-            role={isHost ? "host" : "guest"}
-            micLabel={selectedMicLabel ?? "Unknown mic"}
-            isBuiltIn={selectedMicIsBuiltIn}
-            level={audioLevels.get(participantName) ?? 0}
-            status={localStatus}
-            clipping={localClipping}
-          />
+          {/* Host-only two-channel toggle. Disabled mid-take so the capture
+              graph can't be swapped out from under an active recording. */}
+          {isHost && (
+            <div
+              className="flex items-center gap-2.5 rounded-lg px-4 py-2.5 border select-none"
+              style={{ background: "var(--card)", borderColor: "var(--border)" }}
+            >
+              {/* Standalone input (not wrapped in a <label>) — a wrapping
+                  label re-forwards the click to its control, which recurses
+                  under happy-dom. aria-label carries the accessible name. */}
+              <input
+                id="two-channel-toggle"
+                type="checkbox"
+                aria-label="Two-channel local mode"
+                checked={twoChannelMode}
+                disabled={studioState !== "connected"}
+                onChange={(e) => setTwoChannelMode(e.target.checked)}
+                className="accent-[var(--amber)] cursor-pointer"
+              />
+              <label
+                htmlFor="two-channel-toggle"
+                className="text-[12px] text-text-2 cursor-pointer"
+              >
+                Two-channel local mode
+              </label>
+              {twoChannelMode && twoChannelStatus === "ok" && (
+                <span className="ml-auto font-mono text-[10px] text-text-3 truncate max-w-[45%]">
+                  {selectedMicLabel ?? "selected interface"} → 2 channels
+                </span>
+              )}
+            </div>
+          )}
+
+          {isHost && twoChannelMode ? (
+            slotCaptures.length === LOCAL_TRACK_SLOTS.length ? (
+              LOCAL_TRACK_SLOTS.map((slot) => (
+                <ParticipantStrip
+                  key={slot.slotId}
+                  name={slot.label}
+                  role="host"
+                  micLabel={selectedMicLabel ?? "Interface"}
+                  isBuiltIn={false}
+                  level={slotLevels.get(slot.slotId) ?? 0}
+                  status={localStatus}
+                />
+              ))
+            ) : (
+              <div
+                role="status"
+                className="rounded-lg px-4 py-3.5 border flex items-start gap-2.5"
+                style={{
+                  background: "rgba(232,168,48,0.08)",
+                  borderColor: "rgba(232,168,48,0.28)",
+                }}
+              >
+                <span className="mt-0.5 flex-shrink-0">
+                  <IcoAlert size={14} color="var(--warn)" />
+                </span>
+                <span className="text-[12px] leading-5 text-warn">
+                  {twoChannelStatus === "missing-channels"
+                    ? "Selected interface reports a single channel — pick a 2-channel input to split into Local Ch 1 and Ch 2."
+                    : twoChannelStatus === "unsupported"
+                    ? "This browser or device can't prove 2-channel capture, so two-channel recording is unavailable."
+                    : "Preparing two channels…"}
+                </span>
+              </div>
+            )
+          ) : (
+            <ParticipantStrip
+              name={participantName}
+              role={isHost ? "host" : "guest"}
+              micLabel={selectedMicLabel ?? "Unknown mic"}
+              isBuiltIn={selectedMicIsBuiltIn}
+              level={audioLevels.get(participantName) ?? 0}
+              status={localStatus}
+              clipping={localClipping}
+            />
+          )}
 
           {remoteParticipants.map((p) => (
             <ParticipantStrip

--- a/src/app/studio/[id]/page.tsx
+++ b/src/app/studio/[id]/page.tsx
@@ -1961,6 +1961,60 @@ function RoomContent({
     ],
   );
 
+  // Finalize one slot's track: upload the final recording.webm, mark the track
+  // complete, and clear its backup. Each slot is independent — a failure here
+  // is contained (backup kept + marked failed) so it can never prevent a
+  // sibling channel from finalizing. Returns true iff the track completed.
+  const finalizeSlot = useCallback(
+    async (slot: ActiveSlot, blob: Blob, durationMs: number): Promise<boolean> => {
+      const finalBytes = blob.size;
+      trackerOnChunkRecorded(finalBytes);
+      const finalUpload = (async () => {
+        const url = await getPresignedUploadUrl(
+          sessionId,
+          slot.trackId,
+          9999,
+          undefined,
+          { segmentId: slot.segmentId },
+          slot.uploadToken,
+        );
+        await uploadChunk(url, blob);
+      })();
+      try {
+        await trackerTrackUpload(finalBytes, finalUpload, { rethrow: true });
+        await completeUpload(
+          sessionId,
+          slot.trackId,
+          durationMs,
+          slot.uploadToken,
+          slot.segmentId,
+        );
+        if (slot.backupId) {
+          try {
+            await browserRecordingBackupStore.clearBackup(
+              slot.backupId,
+              "verified-upload",
+            );
+          } catch (backupErr) {
+            console.error("Failed to clear slot backup:", backupErr);
+          }
+        }
+        return true;
+      } catch (err) {
+        console.error(`Failed to finalize slot ${slot.slotId}:`, err);
+        if (slot.backupId) {
+          try {
+            await browserRecordingBackupStore.markBackupFailed(slot.backupId, err);
+          } catch (backupErr) {
+            console.error("Failed to mark slot backup failed:", backupErr);
+          }
+        }
+        return false;
+      }
+    },
+    [sessionId, trackerOnChunkRecorded, trackerTrackUpload],
+  );
+
   // Start both channel recorders as a single logical "start". Mirrors the
   // orchestration in startRecordingLocal (state, confirmation, broadcast,
   // preview-quality switch) but drives the slot array instead of one recorder.
@@ -2017,15 +2071,28 @@ function RoomContent({
         }
       } catch (err) {
         console.error("Failed to start two-channel recorders:", err);
+        // Two-channel start is all-or-nothing. Any slot that DID start already
+        // created a server track/segment — finalize it through the normal path
+        // so it doesn't linger in `recording` waiting on recovery. Best-effort:
+        // stop the recorder, then run finalizeSlot with whatever it captured.
+        const durationMs = Date.now() - recordingStartRef.current;
+        trackerFreezeRecorded();
         await Promise.all(
           started.map(async (slot) => {
+            let blob: Blob | null = null;
             try {
-              await slot.recorder.stop();
-            } catch {
-              // Best-effort teardown of partially-started recorders.
+              blob = await slot.recorder.stop();
+            } catch (stopErr) {
+              console.error("Failed to stop partial slot recorder:", stopErr);
             }
+            if (blob) await finalizeSlot(slot, blob, durationMs);
           }),
         );
+        try {
+          await trackerWaitForUploads();
+        } catch (drainErr) {
+          console.error("Failed while draining partial slot uploads:", drainErr);
+        }
         slotRecordersRef.current = [];
         clearRecordingConfirmationState();
         void broadcastRecordingStatus(
@@ -2060,12 +2127,15 @@ function RoomContent({
       beginSlotRecorder,
       broadcastRecordingStatus,
       clearRecordingConfirmationState,
+      finalizeSlot,
       scheduleRecordingConfirmationCheck,
       setRecordingSessionStartedAtSync,
       setStudioStateSync,
       showNotification,
       switchAudioQuality,
+      trackerFreezeRecorded,
       trackerReset,
+      trackerWaitForUploads,
     ],
   );
 
@@ -2107,49 +2177,15 @@ function RoomContent({
       const durationMs = Date.now() - startedAt;
       trackerFreezeRecorded();
 
-      // Each channel's final recording.webm is critical — rethrow so a failure
-      // surfaces and we skip completeUpload for that channel rather than let
-      // the server discard chunks for a track that never finalized.
-      for (const { slot, blob } of stopped) {
-        const finalBytes = blob.size;
-        trackerOnChunkRecorded(finalBytes);
-        const finalUpload = (async () => {
-          const url = await getPresignedUploadUrl(
-            sessionId,
-            slot.trackId,
-            9999,
-            undefined,
-            { segmentId: slot.segmentId },
-            slot.uploadToken,
-          );
-          await uploadChunk(url, blob);
-        })();
-        await trackerTrackUpload(finalBytes, finalUpload, { rethrow: true });
-      }
-
+      // Finalize channels independently: each slot's final upload + complete is
+      // self-contained, so one channel failing (kept + marked failed in its
+      // backup) can never strand a sibling channel that finalized cleanly.
+      const outcomes = await Promise.all(
+        stopped.map(({ slot, blob }) => finalizeSlot(slot, blob, durationMs)),
+      );
       await trackerWaitForUploads();
 
-      for (const { slot } of stopped) {
-        await completeUpload(
-          sessionId,
-          slot.trackId,
-          durationMs,
-          slot.uploadToken,
-          slot.segmentId,
-        );
-        if (slot.backupId) {
-          try {
-            await browserRecordingBackupStore.clearBackup(
-              slot.backupId,
-              "verified-upload",
-            );
-          } catch (backupErr) {
-            console.error("Failed to clear slot backup:", backupErr);
-          }
-        }
-      }
-
-      setHasRecorded(true);
+      if (outcomes.some(Boolean)) setHasRecorded(true);
     } catch (err) {
       console.error("Failed to stop two-channel recording:", err);
     } finally {
@@ -2174,13 +2210,11 @@ function RoomContent({
   }, [
     broadcastRecordingStatus,
     clearRecordingConfirmationState,
-    sessionId,
+    finalizeSlot,
     setRecordingSessionStartedAtSync,
     setStudioStateSync,
     switchAudioQuality,
     trackerFreezeRecorded,
-    trackerOnChunkRecorded,
-    trackerTrackUpload,
     trackerWaitForUploads,
   ]);
 
@@ -2291,6 +2325,19 @@ function RoomContent({
       recorderRef.current ||
       slotRecordersRef.current.length > 0
     ) {
+      return;
+    }
+
+    // In two-channel mode, refuse to start a take / broadcast to the room until
+    // the split capture is proven ready — otherwise we'd blip remote
+    // participants and create a throwaway take that startLocalSlots then has to
+    // roll back. The REC button is also disabled in this state; this guards the
+    // programmatic/devtools path.
+    if (
+      twoChannelMode &&
+      slotCapturesRef.current.length !== LOCAL_TRACK_SLOTS.length
+    ) {
+      showNotification("Two-channel capture isn't ready yet");
       return;
     }
 
@@ -2522,6 +2569,11 @@ function RoomContent({
 
   const isRecording = studioState === "recording";
   const isFinalizing = studioState === "finalizing";
+  // In two-channel mode the host can't start until both split channels are
+  // captured; block the REC button so a click can't create a bad take.
+  const twoChannelNotReady =
+    twoChannelMode && slotCaptures.length !== LOCAL_TRACK_SLOTS.length;
+  const startDisabled = isFinalizing || (!isRecording && twoChannelNotReady);
 
   const localStatus: Status = isFinalizing
     ? "uploading"
@@ -2803,14 +2855,14 @@ function RoomContent({
                 <button
                   type="button"
                   onClick={() => (isRecording ? handleStopRecording() : handleStartRecording())}
-                  disabled={isFinalizing}
+                  disabled={startDisabled}
                   className={`w-[60px] h-[60px] rounded-full flex items-center justify-center border-2 ${
                     isRecording ? "rec-ring" : ""
-                  } ${isFinalizing ? "cursor-not-allowed" : "cursor-pointer"}`}
+                  } ${startDisabled ? "cursor-not-allowed" : "cursor-pointer"}`}
                   style={{
                     background: isRecording ? "rgba(232,80,80,0.1)" : "var(--card)",
                     borderColor: isRecording ? "var(--rec)" : "var(--border-hi)",
-                    opacity: isFinalizing ? 0.5 : 1,
+                    opacity: startDisabled ? 0.5 : 1,
                     transition: "all 200ms ease",
                   }}
                   aria-label={
@@ -2821,7 +2873,11 @@ function RoomContent({
                       : "Start recording"
                   }
                   title={
-                    isFinalizing ? "Finalizing previous recording…" : undefined
+                    isFinalizing
+                      ? "Finalizing previous recording…"
+                      : twoChannelNotReady
+                      ? "Waiting for two-channel capture…"
+                      : undefined
                   }
                 >
                   {isRecording ? (

--- a/src/app/studio/[id]/page.tsx
+++ b/src/app/studio/[id]/page.tsx
@@ -2020,16 +2020,34 @@ function RoomContent({
         console.error(`Failed to finalize slot ${slot.slotId}:`, err);
         if (slot.backupId) {
           try {
-            await browserRecordingBackupStore.markBackupFailed(slot.backupId, err);
+            // Surface the failed backup into React state — same as the
+            // single-track path — so the recovery panel (Retry/Download/Clear)
+            // renders in-session. Without this the backup is kept on disk but
+            // invisible until a reload re-runs listBackups(). We only surface on
+            // *failure*, not on startBackup, so a successful two-channel take
+            // never leaves a stale panel behind.
+            const failedBackup = await browserRecordingBackupStore.markBackupFailed(
+              slot.backupId,
+              err,
+            );
+            setRecoveryBackupSync(failedBackup);
+            setBackupError(null);
           } catch (backupErr) {
             console.error("Failed to mark slot backup failed:", backupErr);
+            setBackupError(backupErrorMessage(backupErr));
           }
+        } else {
+          // No local backup for this channel — at least tell the host the
+          // upload failed rather than failing silently.
+          setBackupError(backupErrorMessage(err));
         }
         return false;
       }
     },
     [
       sessionId,
+      setBackupError,
+      setRecoveryBackupSync,
       trackerOnChunkRecorded,
       trackerTrackUpload,
       trackerWaitForUploads,

--- a/src/lib/audio-splitter.ts
+++ b/src/lib/audio-splitter.ts
@@ -74,18 +74,44 @@ export function splitStereoStream(
     };
   }
 
-  const ctx = new Ctor();
-  const sourceNode = ctx.createMediaStreamSource(source);
-  const splitter = ctx.createChannelSplitter(2);
-  sourceNode.connect(splitter);
+  // Build the graph inside a try so construction failures (e.g. a browser
+  // without MediaStreamAudioDestinationNode, or one that rejects the options)
+  // fail closed rather than throwing. On failure we tear down whatever context
+  // we created and return an explicit state — the caller still owns and stops
+  // the source stream. Failing closed here keeps every caller's cleanup path
+  // simple: a non-"ok" result is the single signal to stop the input stream.
+  let ctx: AudioContext | undefined;
+  let sourceNode: MediaStreamAudioSourceNode;
+  let splitter: ChannelSplitterNode;
+  let dest1: MediaStreamAudioDestinationNode;
+  let dest2: MediaStreamAudioDestinationNode;
+  try {
+    ctx = new Ctor();
+    sourceNode = ctx.createMediaStreamSource(source);
+    splitter = ctx.createChannelSplitter(2);
+    sourceNode.connect(splitter);
 
-  const dest1 = new MediaStreamAudioDestinationNode(ctx, { channelCount: 1 });
-  const dest2 = new MediaStreamAudioDestinationNode(ctx, { channelCount: 1 });
-  // Splitter output N carries source channel N. Wire each to its own mono
-  // destination so the two channels never bleed into one another.
-  splitter.connect(dest1, 0);
-  splitter.connect(dest2, 1);
+    dest1 = new MediaStreamAudioDestinationNode(ctx, { channelCount: 1 });
+    dest2 = new MediaStreamAudioDestinationNode(ctx, { channelCount: 1 });
+    // Splitter output N carries source channel N. Wire each to its own mono
+    // destination so the two channels never bleed into one another.
+    splitter.connect(dest1, 0);
+    splitter.connect(dest2, 1);
+  } catch (err) {
+    try {
+      void ctx?.close();
+    } catch {
+      // Ignore teardown failures on the partially-built context.
+    }
+    return {
+      state: "unsupported",
+      reason: `failed to construct split audio graph: ${
+        err instanceof Error ? err.message : String(err)
+      }`,
+    };
+  }
 
+  const activeCtx = ctx;
   let disposed = false;
   const dispose = () => {
     if (disposed) return;
@@ -114,7 +140,7 @@ export function splitStereoStream(
     }
     // close() can reject on already-closed/suspended contexts. Swallow so
     // dispose stays best-effort and silent.
-    void ctx.close().catch(() => {
+    void activeCtx?.close().catch(() => {
       // Ignore close failures.
     });
   };

--- a/src/lib/audio-splitter.ts
+++ b/src/lib/audio-splitter.ts
@@ -1,0 +1,123 @@
+"use client";
+
+// Split one 2-channel input stream into two independent mono MediaStreams —
+// the capture primitive behind host-owned two-channel local recording (issue
+// #135). A host points Cozytrack at a single desktop audio interface that
+// carries two distinct sources on its left/right channels (e.g. two mics into
+// a small mixer, or a loopback of two apps) and records each channel as its
+// own logical track.
+//
+// We deliberately fail closed. `getUserMedia({ channelCount: 2 })` is advisory
+// (see the sibling reasoning in `@/lib/audio-downmix`): a device may hand back
+// a 1-channel track, or a 2-channel track whose right channel is silent
+// padding. If we cannot *prove* the source carries two channels we return an
+// explicit `unsupported`/`missing-channels` state instead of silently
+// recording a duplicated or empty second channel. The caller surfaces that to
+// the host rather than shipping a broken take.
+//
+// Web Audio wiring: a ChannelSplitterNode fans the source's channels out to
+// numbered outputs; output 0 feeds a 1-channel destination (Local Ch 1) and
+// output 1 feeds a second (Local Ch 2). Each destination exposes a mono
+// MediaStreamTrack. The caller keeps the source stream live (Web Audio holds a
+// reference) and calls `dispose()` when recording stops.
+
+import { getTrackChannelCount } from "@/lib/audio-downmix";
+import type { AudioContextCtor } from "@/lib/audio-downmix";
+
+export type SplitStereoResult =
+  | { state: "ok"; channels: [MediaStream, MediaStream]; dispose: () => void }
+  | { state: "unsupported"; reason: string }
+  | { state: "missing-channels"; reason: string; channelCount: number };
+
+function resolveAudioContextCtor(
+  AudioCtxCtor?: AudioContextCtor,
+): AudioContextCtor | undefined {
+  return (
+    AudioCtxCtor ??
+    (typeof window !== "undefined"
+      ? (window.AudioContext ??
+        (window as unknown as { webkitAudioContext?: AudioContextCtor })
+          .webkitAudioContext)
+      : undefined)
+  );
+}
+
+export function splitStereoStream(
+  source: MediaStream,
+  AudioCtxCtor?: AudioContextCtor,
+): SplitStereoResult {
+  const Ctor = resolveAudioContextCtor(AudioCtxCtor);
+  if (!Ctor) {
+    return { state: "unsupported", reason: "no AudioContext available" };
+  }
+
+  const [sourceTrack] = source.getAudioTracks
+    ? source.getAudioTracks()
+    : source.getTracks();
+  if (!sourceTrack) {
+    return { state: "unsupported", reason: "source stream has no audio track" };
+  }
+
+  // Fail closed: only proceed when the device positively reports >= 2 channels.
+  const channelCount = getTrackChannelCount(sourceTrack);
+  if (channelCount === undefined) {
+    return {
+      state: "unsupported",
+      reason: "device did not report a channel count; cannot prove 2 channels",
+    };
+  }
+  if (channelCount < 2) {
+    return {
+      state: "missing-channels",
+      reason: `device reported ${channelCount} channel(s); need 2`,
+      channelCount,
+    };
+  }
+
+  const ctx = new Ctor();
+  const sourceNode = ctx.createMediaStreamSource(source);
+  const splitter = ctx.createChannelSplitter(2);
+  sourceNode.connect(splitter);
+
+  const dest1 = new MediaStreamAudioDestinationNode(ctx, { channelCount: 1 });
+  const dest2 = new MediaStreamAudioDestinationNode(ctx, { channelCount: 1 });
+  // Splitter output N carries source channel N. Wire each to its own mono
+  // destination so the two channels never bleed into one another.
+  splitter.connect(dest1, 0);
+  splitter.connect(dest2, 1);
+
+  let disposed = false;
+  const dispose = () => {
+    if (disposed) return;
+    disposed = true;
+    try {
+      sourceNode.disconnect();
+    } catch {
+      // Already disconnected — ignore.
+    }
+    try {
+      splitter.disconnect();
+    } catch {
+      // Already disconnected — ignore.
+    }
+    // Stop the synthetic destination tracks so callers that drop their
+    // reference don't leak live MediaStreamTracks. AudioContext.close() alone
+    // does not reliably end them on every browser.
+    for (const dest of [dest1, dest2]) {
+      for (const track of dest.stream.getTracks()) {
+        try {
+          track.stop();
+        } catch {
+          // Already stopped or unavailable — ignore.
+        }
+      }
+    }
+    // close() can reject on already-closed/suspended contexts. Swallow so
+    // dispose stays best-effort and silent.
+    void ctx.close().catch(() => {
+      // Ignore close failures.
+    });
+  };
+
+  return { state: "ok", channels: [dest1.stream, dest2.stream], dispose };
+}

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -142,6 +142,37 @@ export function principalParticipantId(principal: Principal): string {
   return principal.participantId;
 }
 
+// ---------- Host-owned local track slots ----------
+//
+// Two-channel local recording (issue #135) splits one desktop audio interface
+// into two host-owned channels. Each channel records as a normal Track, but
+// they share the host principal — so they need distinct, stable participant ids
+// to coexist under the Track [takeId, participantId] uniqueness constraint. The
+// slot id IS the synthetic participant id: deterministic, host-scoped, and not
+// derivable by a guest (the server rejects guest-supplied slot ids).
+
+export const LOCAL_TRACK_SLOT_IDS = [
+  "host-local-ch-1",
+  "host-local-ch-2",
+] as const;
+export type LocalTrackSlotId = (typeof LOCAL_TRACK_SLOT_IDS)[number];
+
+export function isLocalTrackSlotId(value: unknown): value is LocalTrackSlotId {
+  return (
+    typeof value === "string" &&
+    (LOCAL_TRACK_SLOT_IDS as readonly string[]).includes(value)
+  );
+}
+
+/**
+ * Stable synthetic participant id for a local channel slot. The slot id is
+ * already host-scoped and unique per channel, so it doubles as the participant
+ * id — keeping the two channels distinct without minting extra identifiers.
+ */
+export function localTrackSlotParticipantId(slotId: LocalTrackSlotId): string {
+  return slotId;
+}
+
 // ---------- Recording upload tokens ----------
 
 export async function issueRecordingUploadToken(

--- a/src/lib/upload.ts
+++ b/src/lib/upload.ts
@@ -15,6 +15,10 @@ export interface TrackInitInfo {
   // The take this recording was broadcast for. Binds a delayed start to its
   // original take instead of whatever take is active when presign arrives.
   takeId?: string;
+  // Host-only local channel slot (issue #135). When set, the server derives a
+  // stable synthetic participant id from it so a split desktop channel records
+  // as its own logical track. Guests supplying this are rejected.
+  localTrackSlotId?: string;
 }
 
 export interface PresignedUploadTarget {
@@ -50,6 +54,7 @@ export async function getPresignedUploadTarget(
       sessionStartedAt: trackInit?.sessionStartedAt,
       segmentId: trackInit?.segmentId,
       takeId: trackInit?.takeId,
+      localTrackSlotId: trackInit?.localTrackSlotId,
     }),
   });
 

--- a/tests/audio-splitter.test.ts
+++ b/tests/audio-splitter.test.ts
@@ -1,0 +1,186 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { splitStereoStream } from "@/lib/audio-splitter";
+
+// Minimal Web Audio mocks: we only need to verify that splitStereoStream wires
+// a ChannelSplitterNode to two mono destinations and fails closed when the
+// device cannot prove 2-channel capture. A real AudioContext can't run in the
+// node test environment.
+
+function makeNode() {
+  return {
+    connect: vi.fn(),
+    disconnect: vi.fn(),
+  };
+}
+
+class MockMediaStream {
+  readonly _kind = "stream" as const;
+  private readonly _tracks: MediaStreamTrack[];
+  constructor(tracks: MediaStreamTrack[] = []) {
+    this._tracks = tracks;
+  }
+  getTracks(): MediaStreamTrack[] {
+    return this._tracks;
+  }
+}
+
+class MockDestinationNode {
+  channelCount: number;
+  stream: MediaStream;
+  connect = vi.fn();
+  disconnect = vi.fn();
+  constructor(_ctx: unknown, opts?: { channelCount?: number }) {
+    this.channelCount = opts?.channelCount ?? 2;
+    this.stream = new MockMediaStream([
+      { stop: vi.fn() } as unknown as MediaStreamTrack,
+    ]) as unknown as MediaStream;
+  }
+}
+
+function makeMockAudioContextCtor() {
+  const sourceNode = makeNode();
+  const splitterNode = makeNode();
+  const destinationCalls: Array<{
+    args: unknown[];
+    instance: MockDestinationNode;
+  }> = [];
+  const audioContextInstances: Array<{ close: ReturnType<typeof vi.fn> }> = [];
+
+  function DestinationCtorImpl(
+    this: MockDestinationNode,
+    ctx: unknown,
+    opts?: { channelCount?: number },
+  ) {
+    const inst = new MockDestinationNode(ctx, opts);
+    destinationCalls.push({ args: [ctx, opts], instance: inst });
+    return inst;
+  }
+  const DestinationCtor = DestinationCtorImpl as unknown as new (
+    ctx: unknown,
+    opts?: { channelCount?: number },
+  ) => MockDestinationNode;
+
+  class MockAudioContext {
+    createMediaStreamSource = vi.fn().mockReturnValue(sourceNode);
+    createChannelSplitter = vi.fn().mockReturnValue(splitterNode);
+    close = vi.fn().mockResolvedValue(undefined);
+    constructor() {
+      audioContextInstances.push(this as unknown as { close: ReturnType<typeof vi.fn> });
+    }
+  }
+
+  return {
+    Ctor: MockAudioContext as unknown as typeof AudioContext,
+    sourceNode,
+    splitterNode,
+    DestinationCtor,
+    destinationCalls,
+    audioContextInstances,
+  };
+}
+
+function stereoStream(channelCount: number | undefined): MediaStream {
+  const track = {
+    stop: vi.fn(),
+    getSettings: () => (channelCount === undefined ? {} : { channelCount }),
+  } as unknown as MediaStreamTrack;
+  return new MockMediaStream([track]) as unknown as MediaStream;
+}
+
+describe("splitStereoStream", () => {
+  let originalDestinationCtor: unknown;
+  let captured: ReturnType<typeof makeMockAudioContextCtor>;
+
+  beforeEach(() => {
+    captured = makeMockAudioContextCtor();
+    originalDestinationCtor = (
+      globalThis as { MediaStreamAudioDestinationNode?: unknown }
+    ).MediaStreamAudioDestinationNode;
+    (
+      globalThis as { MediaStreamAudioDestinationNode: unknown }
+    ).MediaStreamAudioDestinationNode = captured.DestinationCtor;
+  });
+
+  afterEach(() => {
+    (
+      globalThis as { MediaStreamAudioDestinationNode?: unknown }
+    ).MediaStreamAudioDestinationNode = originalDestinationCtor;
+  });
+
+  it("returns two mono output streams when the device proves 2 channels", () => {
+    const result = splitStereoStream(stereoStream(2), captured.Ctor);
+
+    expect(result.state).toBe("ok");
+    if (result.state !== "ok") throw new Error("expected ok");
+    expect(result.channels).toHaveLength(2);
+    expect(result.channels[0]).not.toBe(result.channels[1]);
+    // Both destinations are single-channel so each output track is mono.
+    expect(captured.destinationCalls).toHaveLength(2);
+    expect(captured.destinationCalls[0].args[1]).toEqual({ channelCount: 1 });
+    expect(captured.destinationCalls[1].args[1]).toEqual({ channelCount: 1 });
+  });
+
+  it("routes splitter output 0 to channel 1 and output 1 to channel 2", () => {
+    splitStereoStream(stereoStream(2), captured.Ctor);
+
+    // source -> splitter, then splitter output N -> destination N.
+    expect(captured.sourceNode.connect).toHaveBeenCalledWith(
+      captured.splitterNode,
+    );
+    const [dest1, dest2] = captured.destinationCalls.map((c) => c.instance);
+    expect(captured.splitterNode.connect).toHaveBeenCalledWith(dest1, 0);
+    expect(captured.splitterNode.connect).toHaveBeenCalledWith(dest2, 1);
+  });
+
+  it("dispose() stops both destination tracks and closes the context once", () => {
+    const result = splitStereoStream(stereoStream(2), captured.Ctor);
+    if (result.state !== "ok") throw new Error("expected ok");
+
+    const stops = captured.destinationCalls.map(
+      (c) => c.instance.stream.getTracks()[0].stop as ReturnType<typeof vi.fn>,
+    );
+    const ctx = captured.audioContextInstances[0];
+
+    result.dispose();
+    expect(stops[0]).toHaveBeenCalledTimes(1);
+    expect(stops[1]).toHaveBeenCalledTimes(1);
+    expect(captured.sourceNode.disconnect).toHaveBeenCalledTimes(1);
+    expect(captured.splitterNode.disconnect).toHaveBeenCalledTimes(1);
+    expect(ctx.close).toHaveBeenCalledTimes(1);
+
+    // Idempotent — a second call must not double-stop or double-close.
+    result.dispose();
+    expect(stops[0]).toHaveBeenCalledTimes(1);
+    expect(ctx.close).toHaveBeenCalledTimes(1);
+  });
+
+  it("fails closed as unsupported when no AudioContext is available", () => {
+    const result = splitStereoStream(stereoStream(2), undefined);
+    expect(result.state).toBe("unsupported");
+    // No graph should have been constructed.
+    expect(captured.destinationCalls).toHaveLength(0);
+  });
+
+  it("fails closed as unsupported when the source has no audio track", () => {
+    const empty = new MockMediaStream([]) as unknown as MediaStream;
+    const result = splitStereoStream(empty, captured.Ctor);
+    expect(result.state).toBe("unsupported");
+    expect(captured.destinationCalls).toHaveLength(0);
+  });
+
+  it("fails closed as missing-channels when the device reports mono", () => {
+    const result = splitStereoStream(stereoStream(1), captured.Ctor);
+    expect(result.state).toBe("missing-channels");
+    if (result.state !== "missing-channels") throw new Error("expected missing-channels");
+    expect(result.channelCount).toBe(1);
+    expect(captured.destinationCalls).toHaveLength(0);
+  });
+
+  it("fails closed when channel count cannot be determined", () => {
+    const result = splitStereoStream(stereoStream(undefined), captured.Ctor);
+    // Cannot *prove* 2 channels — fail closed rather than record a silent
+    // duplicated channel.
+    expect(result.state).not.toBe("ok");
+    expect(captured.destinationCalls).toHaveLength(0);
+  });
+});

--- a/tests/audio-splitter.test.ts
+++ b/tests/audio-splitter.test.ts
@@ -183,4 +183,21 @@ describe("splitStereoStream", () => {
     expect(result.state).not.toBe("ok");
     expect(captured.destinationCalls).toHaveLength(0);
   });
+
+  it("fails closed (does not throw) when audio-graph construction fails", () => {
+    // A browser where MediaStreamAudioDestinationNode construction throws must
+    // not leak an exception to the caller — the acquire path relies on a
+    // non-"ok" result to release the input stream.
+    (
+      globalThis as { MediaStreamAudioDestinationNode: unknown }
+    ).MediaStreamAudioDestinationNode = function () {
+      throw new Error("no destination node in this browser");
+    };
+
+    let result: ReturnType<typeof splitStereoStream>;
+    expect(() => {
+      result = splitStereoStream(stereoStream(2), captured.Ctor);
+    }).not.toThrow();
+    expect(result!.state).toBe("unsupported");
+  });
 });

--- a/tests/helpers/studio-page.ts
+++ b/tests/helpers/studio-page.ts
@@ -38,6 +38,17 @@ const studioPageHarness = vi.hoisted(() => ({
   syncMarkerDispose: vi.fn(),
   splitStereoStream: vi.fn(),
   splitterDispose: vi.fn(),
+  recordingBackupStore: {
+    startBackup: vi.fn(),
+    saveChunk: vi.fn(),
+    markChunkFailed: vi.fn(),
+    markChunkUploaded: vi.fn(),
+    markBackupAvailable: vi.fn(),
+    markBackupFailed: vi.fn(),
+    clearBackup: vi.fn(),
+    getBackup: vi.fn(),
+    buildRecordingBlob: vi.fn(),
+  },
 }));
 
 vi.mock("next/navigation", () => ({
@@ -132,15 +143,7 @@ vi.mock("@/lib/audio-splitter", () => ({
 vi.mock("@/lib/recording-backup", () => ({
   browserRecordingBackupStore: {
     listBackups: studioPageHarness.listBackups,
-    startBackup: vi.fn(),
-    saveChunk: vi.fn(),
-    markChunkFailed: vi.fn(),
-    markChunkUploaded: vi.fn(),
-    markBackupAvailable: vi.fn(),
-    markBackupFailed: vi.fn(),
-    clearBackup: vi.fn(),
-    getBackup: vi.fn(),
-    buildRecordingBlob: vi.fn(),
+    ...studioPageHarness.recordingBackupStore,
   },
   recordingBackupId: (sessionId: string, trackId: string) =>
     `${sessionId}:${trackId}`,
@@ -279,6 +282,9 @@ beforeEach(() => {
   studioPageHarness.syncMarkerPlay.mockReset().mockResolvedValue(undefined);
   studioPageHarness.syncMarkerDispose.mockReset();
   studioPageHarness.splitterDispose.mockReset();
+  for (const fn of Object.values(studioPageHarness.recordingBackupStore)) {
+    fn.mockReset();
+  }
   // Default: the split succeeds with two distinct mono channel streams so the
   // two named local slots render and record. Tests that need failure states
   // override this.

--- a/tests/helpers/studio-page.ts
+++ b/tests/helpers/studio-page.ts
@@ -283,7 +283,9 @@ beforeEach(() => {
   studioPageHarness.syncMarkerDispose.mockReset();
   studioPageHarness.splitterDispose.mockReset();
   for (const fn of Object.values(studioPageHarness.recordingBackupStore)) {
-    fn.mockReset();
+    // These store methods are async in the real implementation; resolve so
+    // chunk-pipeline code that chains .then/.catch on them behaves.
+    fn.mockReset().mockResolvedValue(undefined);
   }
   // Default: the split succeeds with two distinct mono channel streams so the
   // two named local slots render and record. Tests that need failure states

--- a/tests/helpers/studio-page.ts
+++ b/tests/helpers/studio-page.ts
@@ -36,6 +36,8 @@ const studioPageHarness = vi.hoisted(() => ({
   syncMarkerPrepare: vi.fn(async () => undefined),
   syncMarkerPlay: vi.fn(async () => undefined),
   syncMarkerDispose: vi.fn(),
+  splitStereoStream: vi.fn(),
+  splitterDispose: vi.fn(),
 }));
 
 vi.mock("next/navigation", () => ({
@@ -43,31 +45,43 @@ vi.mock("next/navigation", () => ({
   usePathname: () => `/studio/${studioPageHarness.route.sessionId}`,
 }));
 
-vi.mock("@livekit/components-react", () => ({
-  LiveKitRoom: ({ children }: { children: ReactNode }) =>
-    React.createElement("div", { "data-testid": "livekit-room" }, children),
-  RoomAudioRenderer: () => null,
-  useRemoteParticipants: () => [],
-  useLocalParticipant: () => ({
+vi.mock("@livekit/components-react", () => {
+  // Stable identities defined inside the factory (which runs once, when the
+  // mocked module first loads). The real LiveKit hooks memoize these, and
+  // studio effects depend on them — returning fresh objects/arrays each render
+  // turns those effects into re-render loops once any synchronous setState
+  // fires.
+  const remoteParticipants: unknown[] = [];
+  const localParticipant = {
     localParticipant: {
       republishAllTracks: studioPageHarness.republishAllTracks,
     },
-  }),
-}));
+  };
+  return {
+    LiveKitRoom: ({ children }: { children: ReactNode }) =>
+      React.createElement("div", { "data-testid": "livekit-room" }, children),
+    RoomAudioRenderer: () => null,
+    useRemoteParticipants: () => remoteParticipants,
+    useLocalParticipant: () => localParticipant,
+  };
+});
 
 vi.mock("@/lib/livekit", () => ({
   LIVEKIT_URL: "ws://livekit.test",
   getToken: studioPageHarness.getToken,
 }));
 
-vi.mock("@/lib/transport", () => ({
-  useTransport: () => ({
+vi.mock("@/lib/transport", () => {
+  const transport = {
     sendControlMessage: studioPageHarness.sendControlMessage,
     onControlMessage: studioPageHarness.onControlMessage,
-  }),
-  isHostSender: () => false,
-  parseParticipantMetadata: () => null,
-}));
+  };
+  return {
+    useTransport: () => transport,
+    isHostSender: () => false,
+    parseParticipantMetadata: () => null,
+  };
+});
 
 vi.mock("@/lib/recording-state", () => ({
   startRecordingTake: studioPageHarness.startRecordingTake,
@@ -111,6 +125,10 @@ vi.mock("@/lib/audio-downmix", () => ({
   getTrackChannelCount: () => undefined,
 }));
 
+vi.mock("@/lib/audio-splitter", () => ({
+  splitStereoStream: studioPageHarness.splitStereoStream,
+}));
+
 vi.mock("@/lib/recording-backup", () => ({
   browserRecordingBackupStore: {
     listBackups: studioPageHarness.listBackups,
@@ -136,12 +154,17 @@ vi.mock("@/hooks/useMicMonitor", () => ({
   useMicMonitor: vi.fn(),
 }));
 
-vi.mock("@/hooks/useRemoteAudioLevels", () => ({
-  useRemoteAudioLevels: () => ({
+vi.mock("@/hooks/useRemoteAudioLevels", () => {
+  // Return a *stable* result object. The real hook memoizes its return value;
+  // a fresh object each call makes remoteAudio.levels a new identity every
+  // render, which turns the studio's remote-levels merge effect into an
+  // infinite re-render loop the moment any synchronous setState occurs.
+  const stable = {
     levels: new Map<string, number>(),
     clipping: new Set<string>(),
-  }),
-}));
+  };
+  return { useRemoteAudioLevels: () => stable };
+});
 
 vi.mock("@/hooks/useTimingDiagnostics", () => ({
   useTimingDiagnostics: vi.fn(),
@@ -255,6 +278,15 @@ beforeEach(() => {
   studioPageHarness.syncMarkerPrepare.mockReset().mockResolvedValue(undefined);
   studioPageHarness.syncMarkerPlay.mockReset().mockResolvedValue(undefined);
   studioPageHarness.syncMarkerDispose.mockReset();
+  studioPageHarness.splitterDispose.mockReset();
+  // Default: the split succeeds with two distinct mono channel streams so the
+  // two named local slots render and record. Tests that need failure states
+  // override this.
+  studioPageHarness.splitStereoStream.mockReset().mockImplementation(() => ({
+    state: "ok",
+    channels: [mediaStream(), mediaStream()],
+    dispose: studioPageHarness.splitterDispose,
+  }));
 
   vi.stubGlobal("AudioContext", FakeAudioContext);
   vi.stubGlobal(

--- a/tests/studio-two-channel.test.ts
+++ b/tests/studio-two-channel.test.ts
@@ -114,4 +114,147 @@ describe("StudioPage two-channel local mode", () => {
       expect(completedTracks).toContain("host-local-ch-2");
     });
   });
+
+  it("still completes the healthy channel when the other channel's final upload fails", async () => {
+    const studio = renderHostStudioPage();
+    await studio.join();
+
+    studio.harness.getPresignedUploadTarget.mockImplementation(
+      async (
+        _sessionId: string,
+        _trackId: string,
+        _part: number,
+        _name: string,
+        init?: { localTrackSlotId?: string },
+      ) => ({
+        url: "https://s3.example/0.webm",
+        key: "sessions/session-host/tracks/x/0.webm",
+        recordingToken: `token-${init?.localTrackSlotId ?? "primary"}`,
+        trackId: init?.localTrackSlotId ?? "track-1",
+        segmentId: init?.localTrackSlotId ?? "segment-1",
+      }),
+    );
+    // Fail only Ch 1's final (partNumber 9999) upload URL.
+    studio.harness.getPresignedUploadUrl.mockImplementation(
+      async (...args: unknown[]) => {
+        const trackId = args[1] as string;
+        const part = args[2] as number;
+        if (trackId === "host-local-ch-1" && part === 9999) {
+          throw new Error("ch1 final upload failed");
+        }
+        return "https://s3.example/recording.webm";
+      },
+    );
+
+    fireEvent.click(
+      studio.screen.getByRole("checkbox", { name: /two-channel local/i }),
+    );
+    await studio.screen.findByText("Local Ch 1");
+
+    fireEvent.click(
+      studio.screen.getByRole("button", { name: "Start recording" }),
+    );
+    await studio.screen.findByRole("button", { name: "Stop recording" });
+
+    fireEvent.click(
+      studio.screen.getByRole("button", { name: "Stop recording" }),
+    );
+
+    await waitFor(() => {
+      const completedTracks = (
+        studio.harness.completeUpload.mock.calls as unknown[][]
+      ).map((call) => call[1]);
+      // Ch 2 must complete even though Ch 1's final upload threw...
+      expect(completedTracks).toContain("host-local-ch-2");
+      // ...and Ch 1 must NOT be completed (its recording never finalized).
+      expect(completedTracks).not.toContain("host-local-ch-1");
+    });
+    // Ch 1's local backup is kept + marked failed for recovery.
+    expect(
+      studio.harness.recordingBackupStore.markBackupFailed,
+    ).toHaveBeenCalledWith("session-host:host-local-ch-1", expect.anything());
+  });
+
+  it("disables the record button while two-channel capture is unavailable", async () => {
+    const studio = renderHostStudioPage();
+    await studio.join();
+
+    studio.harness.splitStereoStream.mockReturnValue({
+      state: "unsupported",
+      reason: "cannot prove 2 channels",
+    });
+
+    fireEvent.click(
+      studio.screen.getByRole("checkbox", { name: /two-channel local/i }),
+    );
+
+    await waitFor(() => {
+      const recButton = studio.screen.getByRole("button", {
+        name: "Start recording",
+      }) as HTMLButtonElement;
+      expect(recButton.disabled).toBe(true);
+    });
+
+    // Clicking the disabled button must not start a take or broadcast to remotes.
+    fireEvent.click(
+      studio.screen.getByRole("button", { name: "Start recording" }),
+    );
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    expect(studio.harness.startRecordingTake).not.toHaveBeenCalled();
+    expect(
+      studio.harness.sendControlMessage.mock.calls.some(
+        ([message]) => message.type === "recording_start",
+      ),
+    ).toBe(false);
+  });
+
+  it("finalizes an already-started channel when the other channel fails to start", async () => {
+    const studio = renderHostStudioPage();
+    await studio.join();
+
+    // Ch 1 presigns fine; Ch 2's presign rejects so it never starts.
+    studio.harness.getPresignedUploadTarget.mockImplementation(
+      async (
+        _sessionId: string,
+        _trackId: string,
+        _part: number,
+        _name: string,
+        init?: { localTrackSlotId?: string },
+      ) => {
+        if (init?.localTrackSlotId === "host-local-ch-2") {
+          throw new Error("ch2 presign failed");
+        }
+        return {
+          url: "https://s3.example/0.webm",
+          key: "sessions/session-host/tracks/x/0.webm",
+          recordingToken: `token-${init?.localTrackSlotId ?? "primary"}`,
+          trackId: init?.localTrackSlotId ?? "track-1",
+          segmentId: init?.localTrackSlotId ?? "segment-1",
+        };
+      },
+    );
+
+    fireEvent.click(
+      studio.screen.getByRole("checkbox", { name: /two-channel local/i }),
+    );
+    await studio.screen.findByText("Local Ch 1");
+
+    fireEvent.click(
+      studio.screen.getByRole("button", { name: "Start recording" }),
+    );
+
+    // The started Ch 1 track is finalized (not left dangling in `recording`)...
+    await waitFor(() => {
+      const completedTracks = (
+        studio.harness.completeUpload.mock.calls as unknown[][]
+      ).map((call) => call[1]);
+      expect(completedTracks).toContain("host-local-ch-1");
+    });
+    // ...and the failed start rolls the room back to idle.
+    await waitFor(() => {
+      expect(
+        studio.screen.getByRole("button", { name: "Start recording" }),
+      ).toBeTruthy();
+    });
+  });
 });

--- a/tests/studio-two-channel.test.ts
+++ b/tests/studio-two-channel.test.ts
@@ -1,0 +1,117 @@
+import { fireEvent, waitFor } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { renderGuestStudioPage, renderHostStudioPage } from "./helpers/studio-page";
+
+// Two-channel local recording (issue #135): the host can split one desktop
+// audio interface into two host-owned channels, each recorded as its own
+// logical track alongside remote participants.
+
+describe("StudioPage two-channel local mode", () => {
+  it("is host-only — guests never see the toggle", async () => {
+    const studio = renderGuestStudioPage({ name: "Guest Alice" });
+    await studio.join();
+
+    expect(
+      studio.screen.queryByRole("checkbox", { name: /two-channel local/i }),
+    ).toBeNull();
+  });
+
+  it("renders two named local channel rows when enabled", async () => {
+    const studio = renderHostStudioPage();
+    await studio.join();
+
+    fireEvent.click(
+      studio.screen.getByRole("checkbox", { name: /two-channel local/i }),
+    );
+
+    await waitFor(() => {
+      expect(studio.screen.getByText("Local Ch 1")).toBeTruthy();
+      expect(studio.screen.getByText("Local Ch 2")).toBeTruthy();
+    });
+  });
+
+  it("records both channels with distinct host slot ids", async () => {
+    const studio = renderHostStudioPage();
+    await studio.join();
+
+    studio.harness.getPresignedUploadTarget.mockImplementation(
+      async (
+        _sessionId: string,
+        _trackId: string,
+        _part: number,
+        _name: string,
+        init?: { localTrackSlotId?: string },
+      ) => ({
+        url: "https://s3.example/0.webm",
+        key: "sessions/session-host/tracks/x/0.webm",
+        recordingToken: `token-${init?.localTrackSlotId ?? "primary"}`,
+        trackId: init?.localTrackSlotId ?? "track-1",
+        segmentId: init?.localTrackSlotId ?? "segment-1",
+      }),
+    );
+
+    fireEvent.click(
+      studio.screen.getByRole("checkbox", { name: /two-channel local/i }),
+    );
+    await studio.screen.findByText("Local Ch 1");
+
+    fireEvent.click(
+      studio.screen.getByRole("button", { name: "Start recording" }),
+    );
+
+    await studio.screen.findByRole("button", { name: "Stop recording" });
+
+    const slotIds = (
+      studio.harness.getPresignedUploadTarget.mock.calls as unknown[][]
+    )
+      .map((call) => (call[4] as { localTrackSlotId?: string } | undefined)?.localTrackSlotId)
+      .filter(Boolean);
+    expect(slotIds).toContain("host-local-ch-1");
+    expect(slotIds).toContain("host-local-ch-2");
+    // One recorder per channel.
+    expect(studio.harness.recorderStart).toHaveBeenCalledTimes(2);
+  });
+
+  it("completes both channel uploads on stop", async () => {
+    const studio = renderHostStudioPage();
+    await studio.join();
+
+    studio.harness.getPresignedUploadTarget.mockImplementation(
+      async (
+        _sessionId: string,
+        _trackId: string,
+        _part: number,
+        _name: string,
+        init?: { localTrackSlotId?: string },
+      ) => ({
+        url: "https://s3.example/0.webm",
+        key: "sessions/session-host/tracks/x/0.webm",
+        recordingToken: `token-${init?.localTrackSlotId ?? "primary"}`,
+        trackId: init?.localTrackSlotId ?? "track-1",
+        segmentId: init?.localTrackSlotId ?? "segment-1",
+      }),
+    );
+
+    fireEvent.click(
+      studio.screen.getByRole("checkbox", { name: /two-channel local/i }),
+    );
+    await studio.screen.findByText("Local Ch 1");
+
+    fireEvent.click(
+      studio.screen.getByRole("button", { name: "Start recording" }),
+    );
+    await studio.screen.findByRole("button", { name: "Stop recording" });
+
+    fireEvent.click(
+      studio.screen.getByRole("button", { name: "Stop recording" }),
+    );
+
+    await waitFor(() => {
+      const completedTracks = (
+        studio.harness.completeUpload.mock.calls as unknown[][]
+      ).map((call) => call[1]);
+      expect(completedTracks).toContain("host-local-ch-1");
+      expect(completedTracks).toContain("host-local-ch-2");
+    });
+  });
+});

--- a/tests/studio-two-channel.test.ts
+++ b/tests/studio-two-channel.test.ts
@@ -1,4 +1,4 @@
-import { fireEvent, waitFor } from "@testing-library/react";
+import { act, fireEvent, waitFor } from "@testing-library/react";
 import { describe, expect, it } from "vitest";
 import { renderGuestStudioPage, renderHostStudioPage } from "./helpers/studio-page";
 
@@ -255,6 +255,82 @@ describe("StudioPage two-channel local mode", () => {
       expect(
         studio.screen.getByRole("button", { name: "Start recording" }),
       ).toBeTruthy();
+    });
+  });
+
+  it("waits for in-flight chunk uploads before completing either channel", async () => {
+    const studio = renderHostStudioPage();
+    await studio.join();
+
+    studio.harness.getPresignedUploadTarget.mockImplementation(
+      async (
+        _sessionId: string,
+        _trackId: string,
+        _part: number,
+        _name: string,
+        init?: { localTrackSlotId?: string },
+      ) => ({
+        url: "https://s3.example/0.webm",
+        key: "sessions/session-host/tracks/x/0.webm",
+        recordingToken: `token-${init?.localTrackSlotId ?? "primary"}`,
+        trackId: init?.localTrackSlotId ?? "track-1",
+        segmentId: init?.localTrackSlotId ?? "segment-1",
+      }),
+    );
+
+    // Hold one specific chunk's upload open. Identify it by blob identity so
+    // the ordering of chunk vs final uploads doesn't matter.
+    const drivenChunk = new Blob(["chunk"], { type: "audio/webm" });
+    let releaseChunk: () => void = () => {};
+    const chunkUpload = new Promise<undefined>((resolve) => {
+      releaseChunk = () => resolve(undefined);
+    });
+    studio.harness.uploadChunk.mockImplementation((async (...args: unknown[]) =>
+      args[1] === drivenChunk ? chunkUpload : undefined) as unknown as () => Promise<undefined>);
+
+    fireEvent.click(
+      studio.screen.getByRole("checkbox", { name: /two-channel local/i }),
+    );
+    await studio.screen.findByText("Local Ch 1");
+
+    fireEvent.click(
+      studio.screen.getByRole("button", { name: "Start recording" }),
+    );
+    await studio.screen.findByRole("button", { name: "Stop recording" });
+
+    // A chunk is captured; drive it and wait until its background PUT is
+    // actually in flight (blocked on our held promise). A plain sync act is
+    // used, not act(async) — the slot meters' rAF loop keeps React perpetually
+    // "busy", so act(async)'s idle-wait would never resolve.
+    act(() => {
+      studio.harness.recorderChunkHandler?.(drivenChunk, 0);
+    });
+    await waitFor(() => {
+      expect(
+        (studio.harness.uploadChunk.mock.calls as unknown[][]).some(
+          (call) => call[1] === drivenChunk,
+        ),
+      ).toBe(true);
+    });
+
+    fireEvent.click(
+      studio.screen.getByRole("button", { name: "Stop recording" }),
+    );
+
+    // Finalization reaches the drain barrier but must NOT complete either
+    // channel while the chunk PUT is outstanding — /complete deletes chunk
+    // objects, so completing early could strand a still-uploading chunk.
+    await new Promise((resolve) => setTimeout(resolve, 30));
+    expect(studio.harness.completeUpload).not.toHaveBeenCalled();
+
+    // Once the chunk upload settles, both channels complete.
+    releaseChunk();
+    await waitFor(() => {
+      const completed = (
+        studio.harness.completeUpload.mock.calls as unknown[][]
+      ).map((call) => call[1]);
+      expect(completed).toContain("host-local-ch-1");
+      expect(completed).toContain("host-local-ch-2");
     });
   });
 });

--- a/tests/studio-two-channel.test.ts
+++ b/tests/studio-two-channel.test.ts
@@ -333,4 +333,65 @@ describe("StudioPage two-channel local mode", () => {
       expect(completed).toContain("host-local-ch-2");
     });
   });
+
+  it("surfaces the recovery panel when a channel's upload fails", async () => {
+    const studio = renderHostStudioPage();
+    await studio.join();
+
+    studio.harness.getPresignedUploadTarget.mockImplementation(
+      async (
+        _sessionId: string,
+        _trackId: string,
+        _part: number,
+        _name: string,
+        init?: { localTrackSlotId?: string },
+      ) => ({
+        url: "https://s3.example/0.webm",
+        key: "sessions/session-host/tracks/x/0.webm",
+        recordingToken: `token-${init?.localTrackSlotId ?? "primary"}`,
+        trackId: init?.localTrackSlotId ?? "track-1",
+        segmentId: init?.localTrackSlotId ?? "segment-1",
+      }),
+    );
+    // Ch 1's final upload fails.
+    studio.harness.getPresignedUploadUrl.mockImplementation((async (
+      ...args: unknown[]
+    ) => {
+      if (args[1] === "host-local-ch-1" && args[2] === 9999) {
+        throw new Error("ch1 final upload failed");
+      }
+      return "https://s3.example/recording.webm";
+    }) as unknown as () => Promise<string>);
+    // The failed backup is kept on disk as a recoverable manifest.
+    studio.harness.recordingBackupStore.markBackupFailed.mockResolvedValue({
+      id: "session-host:host-local-ch-1",
+      sessionId: "session-host",
+      trackId: "host-local-ch-1",
+      segmentId: "host-local-ch-1",
+      participantName: "Local Ch 1",
+      state: "failed",
+      persistentStorage: true,
+      chunks: [{ chunkIndex: 0, byteSize: 100, status: "failed" }],
+    });
+
+    fireEvent.click(
+      studio.screen.getByRole("checkbox", { name: /two-channel local/i }),
+    );
+    await studio.screen.findByText("Local Ch 1");
+
+    fireEvent.click(
+      studio.screen.getByRole("button", { name: "Start recording" }),
+    );
+    await studio.screen.findByRole("button", { name: "Stop recording" });
+
+    fireEvent.click(
+      studio.screen.getByRole("button", { name: "Stop recording" }),
+    );
+
+    // The host gets an in-session recovery affordance (no reload required).
+    await studio.screen.findByText("Local recording backup");
+    expect(
+      studio.screen.getByRole("button", { name: /retry upload/i }),
+    ).toBeTruthy();
+  });
 });

--- a/tests/upload-auth.test.ts
+++ b/tests/upload-auth.test.ts
@@ -485,3 +485,114 @@ describe("recording upload auth", () => {
     expect(mocks.tracks.get("t1")?.status).toBe("recording");
   });
 });
+
+describe("host-owned local track slots", () => {
+  it("creates two local-slot tracks with stable synthetic participant ids", async () => {
+    mocks.resolvePrincipal.mockResolvedValue({ kind: "host", participantId: "host" });
+
+    const ch1 = await presignUpload(
+      postJson("/api/upload/presign", {
+        sessionId: "s1",
+        trackId: "local-1",
+        partNumber: 0,
+        participantName: "Local Ch 1",
+        localTrackSlotId: "host-local-ch-1",
+      }),
+    );
+    const ch2 = await presignUpload(
+      postJson("/api/upload/presign", {
+        sessionId: "s1",
+        trackId: "local-2",
+        partNumber: 0,
+        participantName: "Local Ch 2",
+        localTrackSlotId: "host-local-ch-2",
+      }),
+    );
+
+    expect(ch1.status).toBe(200);
+    expect(ch2.status).toBe(200);
+
+    // Two distinct logical tracks, each with a stable slot-derived participant
+    // id — not the raw "host" principal id, so both channels coexist under the
+    // Track [takeId, participantId] uniqueness constraint.
+    expect(mocks.tracks.get("local-1")).toMatchObject({
+      participantName: "Local Ch 1",
+      participantId: "host-local-ch-1",
+    });
+    expect(mocks.tracks.get("local-2")).toMatchObject({
+      participantName: "Local Ch 2",
+      participantId: "host-local-ch-2",
+    });
+  });
+
+  it("keeps local slot tracks separate from a normal guest track", async () => {
+    mocks.resolvePrincipal.mockResolvedValueOnce({ kind: "host", participantId: "host" });
+    await presignUpload(
+      postJson("/api/upload/presign", {
+        sessionId: "s1",
+        trackId: "local-1",
+        partNumber: 0,
+        participantName: "Local Ch 1",
+        localTrackSlotId: "host-local-ch-1",
+      }),
+    );
+
+    mocks.resolvePrincipal.mockResolvedValueOnce({
+      kind: "guest",
+      sessionId: "s1",
+      name: "Remote Bob",
+      participantId: "guest_bob",
+    });
+    const guest = await presignUpload(
+      postJson("/api/upload/presign", {
+        sessionId: "s1",
+        trackId: "guest-track",
+        partNumber: 0,
+        participantName: "Remote Bob",
+      }),
+    );
+
+    expect(guest.status).toBe(200);
+    expect(mocks.tracks.get("local-1")?.participantId).toBe("host-local-ch-1");
+    expect(mocks.tracks.get("guest-track")?.participantId).toBe("guest_bob");
+  });
+
+  it("rejects a guest attempting to claim a local track slot", async () => {
+    mocks.resolvePrincipal.mockResolvedValue({
+      kind: "guest",
+      sessionId: "s1",
+      name: "Sneaky Guest",
+      participantId: "guest_sneaky",
+    });
+
+    const res = await presignUpload(
+      postJson("/api/upload/presign", {
+        sessionId: "s1",
+        trackId: "local-1",
+        partNumber: 0,
+        participantName: "Local Ch 1",
+        localTrackSlotId: "host-local-ch-1",
+      }),
+    );
+
+    expect(res.status).toBe(403);
+    expect(mocks.tracks.get("local-1")).toBeUndefined();
+  });
+
+  it("rejects an unknown local track slot id", async () => {
+    mocks.resolvePrincipal.mockResolvedValue({ kind: "host", participantId: "host" });
+
+    const res = await presignUpload(
+      postJson("/api/upload/presign", {
+        sessionId: "s1",
+        trackId: "local-9",
+        partNumber: 0,
+        participantName: "Local Ch 9",
+        localTrackSlotId: "host-local-ch-9",
+      }),
+    );
+
+    expect(res.status).toBe(400);
+    expect(mocks.tracks.get("local-9")).toBeUndefined();
+  });
+});


### PR DESCRIPTION
Implements issue #135: host-owned local track slots for two-channel local recording alongside a remote participant.

## What this does
The host can enable a two-channel local mode. Cozytrack splits one selected desktop audio interface into `Local Ch 1` and `Local Ch 2`, and each channel records as a normal logical `Track`/`TrackSegment` — reusing the existing finalize, download, ingest, recovery, and materialization paths (no Prisma migration). The default single-track studio flow is unchanged when two-channel mode is off.

## Changes
- **Server contract** (`src/app/api/upload/presign/route.ts`, `src/lib/auth.ts`, `src/lib/upload.ts`): host-only `localTrackSlotId` (`host-local-ch-1` / `host-local-ch-2`). The server derives a stable synthetic participant id from it so both channels coexist under the `Track [takeId, participantId]` uniqueness constraint. Guest-supplied slot ids are rejected (403); unknown slot ids are rejected (400).
- **Channel splitter** (`src/lib/audio-splitter.ts`): `splitStereoStream` splits one 2-channel input into two mono `MediaStream`s via a `ChannelSplitterNode`. Fails closed with explicit `unsupported` / `missing-channels` states unless the device positively reports ≥2 channels.
- **Studio** (`src/app/studio/[id]/page.tsx`): additive host-only slot path — one recorder per split channel through the slot-scoped upload contract, named slot rows with per-channel meters/statuses, and a fail-closed status row. The single-track machinery is left untouched (lowest-risk reading of "keep the default path unchanged"; the slot array is the general form and single-track is its 1-recorder case).

## Tests (TDD)
- `tests/upload-auth.test.ts`: two local-slot tracks + a normal guest track, stable slot-derived participant ids, guest spoof rejected, unknown slot rejected.
- `tests/audio-splitter.test.ts`: two mono outputs, channel routing, dispose stops destination tracks + closes ctx once, fail-closed for unsupported / missing / undetermined channels.
- `tests/studio-two-channel.test.ts`: host-only toggle, two named slot rows, both channels recorded with distinct slot ids, both channel uploads completed on stop.
- Test harness: mocked LiveKit / remote-audio hooks now return stable identities (matching the real memoized hooks) so a synchronous `setState` can't tip the studio's participant/level effects into a re-render loop.

`npm test` (201 passed), `npm run typecheck`, `npm run lint`, and `npm run build` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)