### PR TITLE
[codex] Refresh roadmap issue reconciliation

### DIFF
--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -1,6 +1,6 @@
 # Cozytrack Roadmap
 
-This roadmap was reconciled against every GitHub issue that was open on July 2, 2026 (47 open issues).
+This roadmap was reconciled against every GitHub issue that was open on July 4, 2026 (46 open issues).
 
 - Every currently open issue appears exactly once as a primary roadmap entry below.
 - No open issues are explicitly excluded right now.
@@ -56,13 +56,12 @@ This roadmap was reconciled against every GitHub issue that was open on July 2, 
 - #117 Finalize/recovery/completion race integration tests: add a small real-service race suite as another `#108` follow-up for the highest-risk lifecycle ordering cases.
 - #63 Deferred multi-participant browser E2E harness: promote this after the narrower integration coverage and reconnect stack stabilize, or sooner if a real LiveKit/multi-participant regression demands it.
 - #109 Simplify recording and recovery code after the recent safety work: do this after the current safety path and its coverage work stabilize so cleanup is guided by proven invariants instead of guesswork.
-- #148 Durable `RecordingTake` terminal state: land this after `#111`, because reconnect auto-resume and release-readiness coverage need an authoritative stop model before they can safely build on recording-state reads.
 - #140 Generate aligned stem artifacts for recording takes: do this after `#7` settles the alignment metadata strategy and after the existing logical-track materialization path, because aligned stems need authoritative marker offsets and a stable cross-track export step.
 - #141 Serve aligned stems by default while preserving raw downloads: land this after `#140`, because the UI and download routes need aligned derived artifacts before they can switch user-facing defaults safely.
 - #142 Optional drift analysis and correction for long takes: keep this after `#140`, because the first aligned-export path should ship with fixed-offset alignment before drift measurement and time-stretch logic add more moving parts.
 - #134 Automated release-readiness gate for live reconnect recording: run this after the active reconnect/materialization work is ready to validate, and before merging or shipping that stack, so recording, reconnect, upload, recovery, and materialization all pass in one repeatable command and CI path.
 - #75 Participant reconnect and resume: pursue this after `#111` locks the reconnect-safe recording model and the active materialization path is stable, so reconnect behavior extends a defined logical-track boundary instead of exposing raw browser blobs downstream.
-- #154 Expire abandoned recording takes with a sweeper: leave this behind the lease-based reconnect follow-up to `#148`, because correctness is already covered by stale-read semantics and start-time reconciliation while the periodic cleanup is only hygiene.
+- #154 Expire abandoned recording takes with a sweeper: leave this behind the lease-based reconnect follow-up to `#111`, because the `#148` lifecycle hardening already covered correctness and the periodic cleanup is only hygiene for abandoned rows.
 
 ## Needs Clarification
 
@@ -71,5 +70,5 @@ This roadmap was reconciled against every GitHub issue that was open on July 2, 
 - #7 Cross-track conversation latency design: clarify which timing metadata is authoritative, where alignment logic should live, and what sync quality threshold is acceptable for MVP versus later export polish.
 - #68 Transcript-driven in-browser audio editor: keep this future-facing until recording reliability, session browsing, and export basics are stable enough to support an editor roadmap.
 - #72 Role-aware guest and cohost studio view: decide whether cohosts ever get dashboard access from inside an active session, or whether non-host participants should always stay inside a simplified studio shell.
-- #111 Reconnect-safe recording architecture plan: settle the remaining architecture choices around participant identity semantics, materialization timing, and how reconnect gaps should be represented after the `#148` lifecycle hardening removes the current stop-state inference gap.
+- #111 Reconnect-safe recording architecture plan: settle the remaining architecture choices around participant identity semantics, materialization timing, and how reconnect gaps should be represented now that `#148` has removed the old stop-state inference gap.
 - #135 Local multichannel recording alongside a remote participant: clarify whether local tracks should appear as separate local participants, host-owned track slots, or a multi-channel capture mode, and how that choice should interact with `#111`, `#72`, and `#75`.


### PR DESCRIPTION
## Summary

- refresh the roadmap audit stamp for the current open-issues set
- remove stale primary roadmap entry `#148` now that the issue is closed
- update the remaining `#111` and `#154` dependency wording so it reflects `#148` as already landed

## Why

The July 2 roadmap still counted 47 open issues and treated `#148` as an open sequenced item. The current repository has 46 open issues, with `#148` closed on July 3, 2026, so the roadmap needed a reconciliation pass to restore exact open-issue coverage.

## Impact

`docs/FEATURES.md` is back to a clean `46/46` mapping of open GitHub issues to roadmap entries, with no missing or duplicate primary entries.

## Validation

- exact set comparison between live open issues and primary roadmap entries: `46/46`
- no missing open issues
- no extra primary roadmap entries
- no duplicate primary roadmap entries
