### PR TITLE
Pin Codex review model to gpt-5.5

### DIFF
--- a/.github/workflows/codex-review.yml
+++ b/.github/workflows/codex-review.yml
@@ -123,6 +123,7 @@ jobs:
         uses: openai/codex-action@v1
         with:
           openai-api-key: ${{ secrets.OPENAI_API_KEY }}
+          model: gpt-5.5
           sandbox: read-only
           prompt: |
             Review this pull request for bugs, regressions, security issues, and missing tests.


### PR DESCRIPTION
Summary: Pin the Codex review workflow to gpt-5.5 instead of relying on the Codex Action default model. This avoids the current gpt-5.6-sol limited-preview failure seen in run 29069289813. Verification: git diff --check.