### PR TITLE
Unify the recording lifecycle into one slot controller (#135)

### DIFF
--- a/src/app/studio/[id]/page.tsx
+++ b/src/app/studio/[id]/page.tsx
@@ -25,7 +25,6 @@ import {
   useRemoteParticipants,
   useLocalParticipant,
 } from "@livekit/components-react";
-import { v4 as uuidv4 } from "uuid";
 import { CozyRecorder } from "@/lib/recorder";
 import { forceMonoStream, getTrackChannelCount } from "@/lib/audio-downmix";
 import { splitStereoStream } from "@/lib/audio-splitter";
@@ -42,9 +41,12 @@ import {
 } from "@/lib/recording-state";
 import {
   browserRecordingBackupStore,
-  recordingBackupId,
   type RecordingBackupManifest,
 } from "@/lib/recording-backup";
+import {
+  RecordingLifecycleController,
+  type RecordingSlotSpec,
+} from "@/lib/recording-lifecycle";
 import { retryLocalRecordingBackupUpload } from "@/lib/recording-backup-upload";
 import { getToken, LIVEKIT_URL } from "@/lib/livekit";
 import {
@@ -131,17 +133,6 @@ type SlotCapture = {
   slotId: LocalTrackSlotId;
   label: string;
   stream: MediaStream;
-};
-
-// A slot with an active recorder + upload identity mid-take.
-type ActiveSlot = {
-  slotId: LocalTrackSlotId;
-  label: string;
-  recorder: CozyRecorder;
-  trackId: string;
-  segmentId: string;
-  uploadToken?: string;
-  backupId: string | null;
 };
 
 // ---------- Helpers ----------
@@ -742,10 +733,6 @@ function RoomContent({
     (identity: string) => remoteParticipantNames.get(identity) ?? identity,
     [remoteParticipantNames],
   );
-  const recorderRef = useRef<CozyRecorder | null>(null);
-  const trackIdRef = useRef<string>("");
-  const segmentIdRef = useRef<string>("");
-  const recordingUploadTokenRef = useRef<string | undefined>(undefined);
   // Raw stream straight from getUserMedia — retained so we can stop the
   // underlying device tracks on teardown.
   const rawStreamRef = useRef<MediaStream | null>(null);
@@ -769,7 +756,6 @@ function RoomContent({
     useState<TwoChannelStatus>("idle");
   const [slotCaptures, setSlotCaptures] = useState<SlotCapture[]>([]);
   const slotCapturesRef = useRef<SlotCapture[]>([]);
-  const slotRecordersRef = useRef<ActiveSlot[]>([]);
   const [slotLevels, setSlotLevels] = useState<Map<string, number>>(new Map());
   const splitterDisposeRef = useRef<(() => void) | null>(null);
   const splitRawStreamRef = useRef<MediaStream | null>(null);
@@ -805,7 +791,6 @@ function RoomContent({
   const [localClipping, setLocalClipping] = useState(false);
   const analyserRef = useRef<AnalyserNode | null>(null);
   const animFrameRef = useRef<number>(0);
-  const recordingStartRef = useRef<number>(0);
   const localLevelRef = useRef(0);
   // Tracks consecutive clip frames + remaining hold ticks for the local meter,
   // so a transient peak still flashes instead of vanishing in one rAF.
@@ -1420,18 +1405,131 @@ function RoomContent({
     };
   }, [studioState]);
 
+  // ---- Unified slot recording lifecycle (issue #135 refactor) ----
+  // One controller drives every local recording, whatever the mode: the
+  // single-track mic is the degenerate 1-slot case, two-channel local mode
+  // passes 2 slots. The controller owns the per-slot pipeline (presign →
+  // recorder → chunked upload → crash-safe local backup → finalize); the
+  // studio keeps orchestration — takes, control messages, confirmation,
+  // timer, preview quality, and UI state. It is a plain object rather than a
+  // hook so the pipeline stays unit-testable despite the meters' rAF loops
+  // keeping React perpetually busy (see tests/recording-lifecycle.test.ts).
+  const recordingLifecycle = useMemo(
+    () =>
+      new RecordingLifecycleController({
+        sessionId,
+        uploadApi: {
+          getPresignedUploadTarget,
+          getPresignedUploadUrl,
+          uploadChunk,
+          completeUpload,
+        },
+        backupStore: browserRecordingBackupStore,
+        tracker: {
+          reset: trackerReset,
+          onChunkRecorded: trackerOnChunkRecorded,
+          trackUpload: trackerTrackUpload,
+          freezeRecorded: trackerFreezeRecorded,
+          waitForUploads: trackerWaitForUploads,
+        },
+        createRecorder: (stream) => new CozyRecorder(stream),
+        callbacks: {
+          onRecoveryBackup: setRecoveryBackupSync,
+          onBackupError: setBackupError,
+          onBackupUnavailable: () =>
+            showNotification("Local backup unavailable - remote upload only"),
+          onTiming: (event) => {
+            if (!timingDebug) return;
+            console.log(
+              "[TIMING]",
+              JSON.stringify({ ...event, perfNow: performance.now() }),
+            );
+          },
+        },
+      }),
+    [
+      sessionId,
+      setRecoveryBackupSync,
+      showNotification,
+      timingDebug,
+      trackerFreezeRecorded,
+      trackerOnChunkRecorded,
+      trackerReset,
+      trackerTrackUpload,
+      trackerWaitForUploads,
+    ],
+  );
+
+  // Which channels the next take records. Two-channel mode maps each split
+  // capture to its named host slot; otherwise the primary mic stream is the
+  // single slot.
+  const buildRecordingSlotSpecs = useCallback(():
+    | { ok: true; specs: RecordingSlotSpec[] }
+    | { ok: false; reason: string } => {
+    if (isHost && twoChannelMode) {
+      const captures = slotCapturesRef.current;
+      if (captures.length !== LOCAL_TRACK_SLOTS.length) {
+        return { ok: false, reason: "two-channel capture unavailable" };
+      }
+      return {
+        ok: true,
+        specs: captures.map((capture) => ({
+          localTrackSlotId: capture.slotId,
+          participantName: capture.label,
+          stream: capture.stream,
+          deviceInfo: {
+            deviceLabel: selectedMicLabel
+              ? `${capture.label} · ${selectedMicLabel}`
+              : capture.label,
+            deviceId: selectedMic,
+            isBuiltInMic: selectedMicIsBuiltIn,
+          },
+        })),
+      };
+    }
+    if (!streamRef.current) {
+      return { ok: false, reason: "microphone stream unavailable" };
+    }
+    return {
+      ok: true,
+      specs: [
+        {
+          participantName,
+          stream: streamRef.current,
+          deviceInfo: {
+            deviceLabel: selectedMicLabel,
+            deviceId: selectedMic,
+            isBuiltInMic: selectedMicIsBuiltIn,
+          },
+        },
+      ],
+    };
+  }, [
+    isHost,
+    participantName,
+    selectedMic,
+    selectedMicIsBuiltIn,
+    selectedMicLabel,
+    twoChannelMode,
+  ]);
+
   // Core recording start. Idempotent against double-invocation: if we're
   // already recording (our own click echoed via a later remote message, or the
   // button pressed twice), this is a no-op.
   const startRecordingLocal = useCallback(
-    async (sessionStartedAtIso: string, takeId?: string | null) => {
+    async (
+      sessionStartedAtIso: string,
+      takeId?: string | null,
+    ): Promise<boolean> => {
       const effectiveTakeId = takeId ?? recordingTakeIdRef.current;
       if (effectiveTakeId) recordingTakeIdRef.current = effectiveTakeId;
       // Hard invariant from issue #61: cannot start a new recording while a
       // previous one is finalizing. Enforced here so both local and remote
       // (control-message) start paths honor the invariant.
       if (studioStateRef.current === "finalizing") {
-        console.warn("Ignoring recording_start: currently finalizing previous recording");
+        console.warn(
+          "Ignoring recording_start: currently finalizing previous recording",
+        );
         void broadcastRecordingStatus(
           "failed",
           sessionStartedAtIso,
@@ -1440,7 +1538,7 @@ function RoomContent({
         );
         return false;
       }
-      if (studioStateRef.current === "recording" || recorderRef.current) {
+      if (studioStateRef.current === "recording" || recordingLifecycle.active) {
         void broadcastRecordingStatus(
           "recording",
           recordingSessionStartedAtRef.current ?? sessionStartedAtIso,
@@ -1450,192 +1548,42 @@ function RoomContent({
         return true;
       }
 
-      if (!streamRef.current) {
-        console.warn("Cannot start recording: microphone stream unavailable");
+      const slotSpecs = buildRecordingSlotSpecs();
+      if (!slotSpecs.ok) {
+        console.warn(`Cannot start recording: ${slotSpecs.reason}`);
         clearRecordingConfirmationState();
         void broadcastRecordingStatus(
           "failed",
           sessionStartedAtIso,
-          "microphone stream unavailable",
+          slotSpecs.reason,
           effectiveTakeId,
         );
         return false;
       }
 
-      const requestedTrackId = uuidv4();
-      trackIdRef.current = requestedTrackId;
-      segmentIdRef.current = requestedTrackId;
-      let trackId = requestedTrackId;
-      let segmentId = requestedTrackId;
-      recordingUploadTokenRef.current = undefined;
-
-      try {
-        const initialUpload = await getPresignedUploadTarget(
-          sessionId,
-          requestedTrackId,
-          0,
-          participantName,
-          {
-            deviceInfo: {
-              deviceLabel: selectedMicLabel,
-              deviceId: selectedMic,
-              isBuiltInMic: selectedMicIsBuiltIn,
-            },
-            sessionStartedAt: sessionStartedAtIso,
-            takeId: effectiveTakeId ?? undefined,
-          },
-        );
-        trackId = initialUpload.trackId ?? requestedTrackId;
-        segmentId = initialUpload.segmentId ?? requestedTrackId;
-        trackIdRef.current = trackId;
-        segmentIdRef.current = segmentId;
-        recordingUploadTokenRef.current = initialUpload.recordingToken;
-        try {
-          const backup = await browserRecordingBackupStore.startBackup({
-            sessionId,
-            trackId,
-            segmentId,
-            participantName,
-            recordingToken: initialUpload.recordingToken,
-          });
-          setRecoveryBackupSync(backup);
-          setBackupError(null);
-        } catch (backupErr) {
-          console.error("Failed to initialize local recording backup:", backupErr);
-          setRecoveryBackupSync(null);
-          setBackupError(backupErrorMessage(backupErr));
-          showNotification("Local backup unavailable - remote upload only");
-        }
-      } catch (err) {
-        console.error("Failed to initialize upload:", err);
-        clearRecordingConfirmationState();
-        void broadcastRecordingStatus(
-          "failed",
-          sessionStartedAtIso,
-          "upload initialization failed",
-          effectiveTakeId,
-        );
-        return false;
-      }
-
-      trackerReset();
-
-      const recorder = new CozyRecorder(streamRef.current);
-
-      recorder.onChunk((chunk, index) => {
-        const byteLength = chunk.size;
-        trackerOnChunkRecorded(byteLength);
-
-        if (timingDebug) {
-          console.log(
-            "[TIMING]",
-            JSON.stringify({
-              event: "chunk",
-              t: Date.now(),
-              perfNow: performance.now(),
-              trackId,
-              chunkIndex: index,
-              chunkBytes: byteLength,
-            }),
-          );
-        }
-
-        const capturedAt = new Date();
-        const backupSave = browserRecordingBackupStore
-          .saveChunk({
-            sessionId,
-            trackId,
-            segmentId,
-            chunkIndex: index,
-            chunk,
-            capturedAt,
-          })
-          .then((backup) => {
-            setRecoveryBackupSync(backup);
-            setBackupError(null);
-            return backup;
-          })
-          .catch((backupErr) => {
-            console.error("Failed to write local recording backup:", backupErr);
-            setBackupError(backupErrorMessage(backupErr));
-            return null;
-          });
-
-        const uploadPromise = (async () => {
-          const savedBackup = await backupSave;
-          try {
-            const url = await getPresignedUploadUrl(
-              sessionId,
-              trackId,
-              index,
-              undefined,
-              { segmentId },
-              recordingUploadTokenRef.current,
-            );
-            await uploadChunk(url, chunk);
-          } catch (uploadErr) {
-            if (savedBackup) {
-              try {
-                const backup = await browserRecordingBackupStore.markChunkFailed(
-                  sessionId,
-                  trackId,
-                  index,
-                  uploadErr,
-                  segmentId,
-                );
-                setRecoveryBackupSync(backup);
-              } catch (backupErr) {
-                console.error("Failed to mark local backup chunk failed:", backupErr);
-              }
-            }
-            throw uploadErr;
-          }
-          if (savedBackup) {
-            try {
-              const backup = await browserRecordingBackupStore.markChunkUploaded(
-                sessionId,
-                trackId,
-                index,
-                segmentId,
-              );
-              setRecoveryBackupSync(backup);
-            } catch (backupErr) {
-              console.error("Failed to mark local backup chunk uploaded:", backupErr);
-              setBackupError(backupErrorMessage(backupErr));
-            }
-          }
-        })();
-
-        void trackerTrackUpload(byteLength, uploadPromise);
+      const result = await recordingLifecycle.start(slotSpecs.specs, {
+        sessionStartedAt: sessionStartedAtIso,
+        takeId: effectiveTakeId,
       });
-
-      recorderRef.current = recorder;
-      recordingStartRef.current = Date.now();
-
-      if (timingDebug) {
-        console.log(
-          "[TIMING]",
-          JSON.stringify({
-            event: "record-start",
-            t: recordingStartRef.current,
-            perfNow: performance.now(),
-            sessionStartedAt: sessionStartedAtIso,
-            trackId,
-            participant: participantName,
-          }),
-        );
-      }
-
-      try {
-        await recorder.start(5000);
-      } catch (err) {
-        console.error("Failed to start recorder:", err);
-        recorderRef.current = null;
+      if (!result.ok) {
+        if (result.stage === "already-active") {
+          // Lost a race against a concurrent start path — treat it like the
+          // idempotent early-return above.
+          void broadcastRecordingStatus(
+            "recording",
+            recordingSessionStartedAtRef.current ?? sessionStartedAtIso,
+            undefined,
+            effectiveTakeId,
+          );
+          return true;
+        }
         clearRecordingConfirmationState();
         void broadcastRecordingStatus(
           "failed",
           sessionStartedAtIso,
-          "recorder failed to start",
+          result.stage === "presign"
+            ? "upload initialization failed"
+            : "recorder failed to start",
           effectiveTakeId,
         );
         return false;
@@ -1662,26 +1610,18 @@ function RoomContent({
     },
     [
       broadcastRecordingStatus,
+      buildRecordingSlotSpecs,
       clearRecordingConfirmationState,
-      participantName,
+      recordingLifecycle,
       scheduleRecordingConfirmationCheck,
-      selectedMic,
-      selectedMicIsBuiltIn,
-      selectedMicLabel,
-      sessionId,
       setRecordingSessionStartedAtSync,
-      setRecoveryBackupSync,
       setStudioStateSync,
       showNotification,
       switchAudioQuality,
-      trackerOnChunkRecorded,
-      trackerReset,
-      trackerTrackUpload,
-      timingDebug,
     ],
   );
 
-  // Core recording stop. Idempotent: no-op when we have no active recorder or
+  // Core recording stop. Idempotent: no-op when we have no active recording or
   // we're already finalizing.
   const stopRecordingLocal = useCallback(async () => {
     const sessionStartedAtForStatus =
@@ -1690,7 +1630,7 @@ function RoomContent({
     if (studioStateRef.current === "finalizing") return;
     clearRecordingConfirmationState(false);
 
-    if (!recorderRef.current) {
+    if (!recordingLifecycle.active) {
       setRecordingSessionStartedAtSync(null);
       recordingTakeIdRef.current = null;
       void broadcastRecordingStatus(
@@ -1702,17 +1642,11 @@ function RoomContent({
       return;
     }
 
-    // Snapshot per-recording state into local consts BEFORE any await so a
-    // hypothetical concurrent attempt to re-record (blocked by the
-    // finalizing-state gate, but defended in depth here) cannot overwrite the
-    // values mid-finalize. Also transition synchronously so the elapsed timer
-    // tears down immediately — even if the upload pipeline below hangs.
-    const recorder = recorderRef.current;
-    const trackId = trackIdRef.current;
-    const segmentId = segmentIdRef.current || trackId;
-    const backupId = segmentId ? recordingBackupId(sessionId, segmentId) : null;
-    const recordingUploadToken = recordingUploadTokenRef.current;
-    const startedAt = recordingStartRef.current;
+    // Transition synchronously so the elapsed timer tears down immediately —
+    // even if the upload pipeline hangs. The controller snapshots its own
+    // per-slot state, so a hypothetical concurrent re-record (blocked by the
+    // finalizing-state gate, but defended in depth there) cannot corrupt the
+    // finalize.
     setStudioStateSync("finalizing");
     void broadcastRecordingStatus(
       "finalizing",
@@ -1722,108 +1656,12 @@ function RoomContent({
     );
 
     try {
-      const blob = await recorder.stop();
-      const durationMs = Date.now() - startedAt;
-
-      if (timingDebug) {
-        console.log(
-          "[TIMING]",
-          JSON.stringify({
-            event: "record-stop",
-            t: Date.now(),
-            perfNow: performance.now(),
-            trackId,
-            startedAt,
-            durationMs,
-            finalBlobBytes: blob.size,
-          }),
-        );
-      }
-
-      // Freeze denominator — recording is done, no more chunks will arrive.
-      trackerFreezeRecorded();
-      if (backupId) {
-        try {
-          const backup = await browserRecordingBackupStore.markBackupAvailable(
-            backupId,
-            durationMs,
-          );
-          setRecoveryBackupSync(backup);
-        } catch (backupErr) {
-          console.error("Failed to mark local backup available:", backupErr);
-        }
-      }
-
-      // The final recording.webm upload is critical: if it fails, we must
-      // NOT call completeUpload (which marks the track complete and lets
-      // the server delete chunk files). Use rethrow so a failure surfaces
-      // here, lastError is set in the tracker (visible in the UI), and
-      // completeUpload is skipped.
-      const finalBytes = blob.size;
-      trackerOnChunkRecorded(finalBytes);
-      const finalUpload = (async () => {
-        const url = await getPresignedUploadUrl(
-          sessionId,
-          trackId,
-          9999,
-          undefined,
-          { segmentId },
-          recordingUploadToken,
-        );
-        await uploadChunk(url, blob);
-      })();
-      await trackerTrackUpload(finalBytes, finalUpload, { rethrow: true });
-
-      // Wait for any background chunk uploads still settling.
-      await trackerWaitForUploads();
-      await completeUpload(
-        sessionId,
-        trackId,
-        durationMs,
-        recordingUploadToken,
-        segmentId,
-      );
-
-      setHasRecorded(true);
-      if (backupId) {
-        try {
-          await browserRecordingBackupStore.clearBackup(backupId, "verified-upload");
-          setRecoveryBackupSync(null);
-          setBackupError(null);
-        } catch (backupErr) {
-          console.error("Failed to clear uploaded local backup:", backupErr);
-          setBackupError(backupErrorMessage(backupErr));
-        }
-      }
-    } catch (err) {
-      // Final upload (or stop()) failed. lastError is already populated by
-      // trackUpload's rethrow path; the recording stays incomplete.
-      console.error("Failed to stop recording:", err);
-      if (backupId) {
-        try {
-          const backup = await browserRecordingBackupStore.markBackupFailed(
-            backupId,
-            err,
-          );
-          setRecoveryBackupSync(backup);
-          setBackupError(null);
-        } catch (backupErr) {
-          console.error("Failed to mark local backup failed:", backupErr);
-          setBackupError(backupErrorMessage(backupErr));
-        }
-      }
+      const result = await recordingLifecycle.stop();
+      if (result.anyCompleted) setHasRecorded(true);
     } finally {
-      recorderRef.current = null;
-      segmentIdRef.current = "";
-      recordingUploadTokenRef.current = undefined;
-      // Hard invariant from issue #61: do not leave `finalizing` until the
-      // chunk-upload promise set is drained, regardless of error path. If the
-      // happy path above already drained, this is effectively a no-op.
-      try {
-        await trackerWaitForUploads();
-      } catch (drainErr) {
-        console.error("Failed while draining chunk uploads:", drainErr);
-      }
+      // The controller does not resolve until the chunk-upload promise set is
+      // drained (issue #61's finalizing invariant), so leaving `finalizing`
+      // here is safe on every path.
       setStudioStateSync("connected");
       setRecordingSessionStartedAtSync(null);
       recordingTakeIdRef.current = null;
@@ -1842,419 +1680,10 @@ function RoomContent({
   }, [
     broadcastRecordingStatus,
     clearRecordingConfirmationState,
-    sessionId,
-    setRecordingSessionStartedAtSync,
-    setRecoveryBackupSync,
-    setStudioStateSync,
-    switchAudioQuality,
-    trackerFreezeRecorded,
-    trackerOnChunkRecorded,
-    trackerTrackUpload,
-    trackerWaitForUploads,
-    timingDebug,
-  ]);
-
-  // ---- Two-channel slot recorders ----
-  // Set up one recorder for a single split channel: presign a slot-scoped
-  // track, wire chunk uploads (with crash-safe local backup) through the shared
-  // upload tracker, and start capturing. Throws on failure so the caller can
-  // roll back the whole two-channel start.
-  const beginSlotRecorder = useCallback(
-    async (
-      capture: SlotCapture,
-      sessionStartedAtIso: string,
-      takeId: string | null,
-    ): Promise<ActiveSlot> => {
-      const requestedTrackId = uuidv4();
-      const initialUpload = await getPresignedUploadTarget(
-        sessionId,
-        requestedTrackId,
-        0,
-        capture.label,
-        {
-          deviceInfo: {
-            deviceLabel: selectedMicLabel
-              ? `${capture.label} · ${selectedMicLabel}`
-              : capture.label,
-            deviceId: selectedMic,
-            isBuiltInMic: selectedMicIsBuiltIn,
-          },
-          sessionStartedAt: sessionStartedAtIso,
-          takeId: takeId ?? undefined,
-          localTrackSlotId: capture.slotId,
-        },
-      );
-      const trackId = initialUpload.trackId ?? requestedTrackId;
-      const segmentId = initialUpload.segmentId ?? requestedTrackId;
-      const uploadToken = initialUpload.recordingToken;
-
-      let backupId: string | null = null;
-      try {
-        await browserRecordingBackupStore.startBackup({
-          sessionId,
-          trackId,
-          segmentId,
-          participantName: capture.label,
-          recordingToken: uploadToken,
-        });
-        backupId = recordingBackupId(sessionId, segmentId);
-      } catch (backupErr) {
-        console.error("Failed to init local slot backup:", backupErr);
-      }
-
-      const recorder = new CozyRecorder(capture.stream);
-      recorder.onChunk((chunk, index) => {
-        const byteLength = chunk.size;
-        trackerOnChunkRecorded(byteLength);
-        const capturedAt = new Date();
-        const backupSave = backupId
-          ? browserRecordingBackupStore
-              .saveChunk({
-                sessionId,
-                trackId,
-                segmentId,
-                chunkIndex: index,
-                chunk,
-                capturedAt,
-              })
-              .catch((backupErr) => {
-                console.error("Failed to write local slot backup:", backupErr);
-                return null;
-              })
-          : Promise.resolve(null);
-
-        const uploadPromise = (async () => {
-          await backupSave;
-          const url = await getPresignedUploadUrl(
-            sessionId,
-            trackId,
-            index,
-            undefined,
-            { segmentId },
-            uploadToken,
-          );
-          await uploadChunk(url, chunk);
-          if (backupId) {
-            try {
-              await browserRecordingBackupStore.markChunkUploaded(
-                sessionId,
-                trackId,
-                index,
-                segmentId,
-              );
-            } catch (backupErr) {
-              console.error("Failed to mark slot chunk uploaded:", backupErr);
-            }
-          }
-        })();
-
-        void trackerTrackUpload(byteLength, uploadPromise);
-      });
-
-      await recorder.start(5000);
-      return {
-        slotId: capture.slotId,
-        label: capture.label,
-        recorder,
-        trackId,
-        segmentId,
-        uploadToken,
-        backupId,
-      };
-    },
-    [
-      sessionId,
-      selectedMic,
-      selectedMicLabel,
-      selectedMicIsBuiltIn,
-      trackerOnChunkRecorded,
-      trackerTrackUpload,
-    ],
-  );
-
-  // Finalize one slot's track: upload the final recording.webm, mark the track
-  // complete, and clear its backup. Each slot is independent — a failure here
-  // is contained (backup kept + marked failed) so it can never prevent a
-  // sibling channel from finalizing. Returns true iff the track completed.
-  const finalizeSlot = useCallback(
-    async (slot: ActiveSlot, blob: Blob, durationMs: number): Promise<boolean> => {
-      const finalBytes = blob.size;
-      trackerOnChunkRecorded(finalBytes);
-      const finalUpload = (async () => {
-        const url = await getPresignedUploadUrl(
-          sessionId,
-          slot.trackId,
-          9999,
-          undefined,
-          { segmentId: slot.segmentId },
-          slot.uploadToken,
-        );
-        await uploadChunk(url, blob);
-      })();
-      try {
-        await trackerTrackUpload(finalBytes, finalUpload, { rethrow: true });
-        // Drain every in-flight upload (both channels' background chunk PUTs
-        // and final blobs) before completing. /complete deletes the temporary
-        // chunk objects, so a slow chunk PUT that lands afterwards would leave
-        // stale objects — the single-track path waits here for the same reason.
-        await trackerWaitForUploads();
-        await completeUpload(
-          sessionId,
-          slot.trackId,
-          durationMs,
-          slot.uploadToken,
-          slot.segmentId,
-        );
-        if (slot.backupId) {
-          try {
-            await browserRecordingBackupStore.clearBackup(
-              slot.backupId,
-              "verified-upload",
-            );
-          } catch (backupErr) {
-            console.error("Failed to clear slot backup:", backupErr);
-          }
-        }
-        return true;
-      } catch (err) {
-        console.error(`Failed to finalize slot ${slot.slotId}:`, err);
-        if (slot.backupId) {
-          try {
-            // Surface the failed backup into React state — same as the
-            // single-track path — so the recovery panel (Retry/Download/Clear)
-            // renders in-session. Without this the backup is kept on disk but
-            // invisible until a reload re-runs listBackups(). We only surface on
-            // *failure*, not on startBackup, so a successful two-channel take
-            // never leaves a stale panel behind.
-            const failedBackup = await browserRecordingBackupStore.markBackupFailed(
-              slot.backupId,
-              err,
-            );
-            setRecoveryBackupSync(failedBackup);
-            setBackupError(null);
-          } catch (backupErr) {
-            console.error("Failed to mark slot backup failed:", backupErr);
-            setBackupError(backupErrorMessage(backupErr));
-          }
-        } else {
-          // No local backup for this channel — at least tell the host the
-          // upload failed rather than failing silently.
-          setBackupError(backupErrorMessage(err));
-        }
-        return false;
-      }
-    },
-    [
-      sessionId,
-      setBackupError,
-      setRecoveryBackupSync,
-      trackerOnChunkRecorded,
-      trackerTrackUpload,
-      trackerWaitForUploads,
-    ],
-  );
-
-  // Start both channel recorders as a single logical "start". Mirrors the
-  // orchestration in startRecordingLocal (state, confirmation, broadcast,
-  // preview-quality switch) but drives the slot array instead of one recorder.
-  const startLocalSlots = useCallback(
-    async (
-      sessionStartedAtIso: string,
-      takeId?: string | null,
-    ): Promise<boolean> => {
-      const effectiveTakeId = takeId ?? recordingTakeIdRef.current;
-      if (effectiveTakeId) recordingTakeIdRef.current = effectiveTakeId;
-      if (studioStateRef.current === "finalizing") {
-        void broadcastRecordingStatus(
-          "failed",
-          sessionStartedAtIso,
-          "still finalizing previous recording",
-          effectiveTakeId,
-        );
-        return false;
-      }
-      if (
-        studioStateRef.current === "recording" ||
-        slotRecordersRef.current.length > 0
-      ) {
-        void broadcastRecordingStatus(
-          "recording",
-          recordingSessionStartedAtRef.current ?? sessionStartedAtIso,
-          undefined,
-          effectiveTakeId,
-        );
-        return true;
-      }
-
-      const captures = slotCapturesRef.current;
-      if (captures.length !== LOCAL_TRACK_SLOTS.length) {
-        clearRecordingConfirmationState();
-        void broadcastRecordingStatus(
-          "failed",
-          sessionStartedAtIso,
-          "two-channel capture unavailable",
-          effectiveTakeId,
-        );
-        return false;
-      }
-
-      trackerReset();
-      recordingStartRef.current = Date.now();
-
-      const started: ActiveSlot[] = [];
-      try {
-        for (const capture of captures) {
-          started.push(
-            await beginSlotRecorder(capture, sessionStartedAtIso, effectiveTakeId),
-          );
-        }
-      } catch (err) {
-        console.error("Failed to start two-channel recorders:", err);
-        // Two-channel start is all-or-nothing. Any slot that DID start already
-        // created a server track/segment — finalize it through the normal path
-        // so it doesn't linger in `recording` waiting on recovery. Best-effort:
-        // stop the recorder, then run finalizeSlot with whatever it captured.
-        const durationMs = Date.now() - recordingStartRef.current;
-        trackerFreezeRecorded();
-        await Promise.all(
-          started.map(async (slot) => {
-            let blob: Blob | null = null;
-            try {
-              blob = await slot.recorder.stop();
-            } catch (stopErr) {
-              console.error("Failed to stop partial slot recorder:", stopErr);
-            }
-            if (blob) await finalizeSlot(slot, blob, durationMs);
-          }),
-        );
-        try {
-          await trackerWaitForUploads();
-        } catch (drainErr) {
-          console.error("Failed while draining partial slot uploads:", drainErr);
-        }
-        slotRecordersRef.current = [];
-        clearRecordingConfirmationState();
-        void broadcastRecordingStatus(
-          "failed",
-          sessionStartedAtIso,
-          "recorder failed to start",
-          effectiveTakeId,
-        );
-        return false;
-      }
-
-      slotRecordersRef.current = started;
-      setRecordingSessionStartedAtSync(sessionStartedAtIso);
-      scheduleRecordingConfirmationCheck(sessionStartedAtIso);
-      setStudioStateSync("recording");
-      void broadcastRecordingStatus(
-        "recording",
-        sessionStartedAtIso,
-        undefined,
-        effectiveTakeId,
-      );
-
-      const switched = await switchAudioQuality("bandwidth-saving");
-      if (switched) {
-        showNotification("Preview quality reduced — local recording is unaffected");
-      } else {
-        showNotification("Couldn't switch audio quality — check console");
-      }
-      return true;
-    },
-    [
-      beginSlotRecorder,
-      broadcastRecordingStatus,
-      clearRecordingConfirmationState,
-      finalizeSlot,
-      scheduleRecordingConfirmationCheck,
-      setRecordingSessionStartedAtSync,
-      setStudioStateSync,
-      showNotification,
-      switchAudioQuality,
-      trackerFreezeRecorded,
-      trackerReset,
-      trackerWaitForUploads,
-    ],
-  );
-
-  // Stop both channel recorders, finalize each track, then return to connected.
-  const stopLocalSlots = useCallback(async () => {
-    const sessionStartedAtForStatus =
-      recordingSessionStartedAtRef.current ?? undefined;
-    const takeIdForStatus = recordingTakeIdRef.current;
-    if (studioStateRef.current === "finalizing") return;
-    clearRecordingConfirmationState(false);
-
-    const slots = slotRecordersRef.current;
-    if (slots.length === 0) {
-      setRecordingSessionStartedAtSync(null);
-      recordingTakeIdRef.current = null;
-      void broadcastRecordingStatus(
-        "connected",
-        sessionStartedAtForStatus,
-        undefined,
-        takeIdForStatus,
-      );
-      return;
-    }
-
-    slotRecordersRef.current = [];
-    const startedAt = recordingStartRef.current;
-    setStudioStateSync("finalizing");
-    void broadcastRecordingStatus(
-      "finalizing",
-      sessionStartedAtForStatus,
-      undefined,
-      takeIdForStatus,
-    );
-
-    try {
-      const stopped = await Promise.all(
-        slots.map(async (slot) => ({ slot, blob: await slot.recorder.stop() })),
-      );
-      const durationMs = Date.now() - startedAt;
-      trackerFreezeRecorded();
-
-      // Finalize channels independently: each slot's final upload + complete is
-      // self-contained, so one channel failing (kept + marked failed in its
-      // backup) can never strand a sibling channel that finalized cleanly.
-      const outcomes = await Promise.all(
-        stopped.map(({ slot, blob }) => finalizeSlot(slot, blob, durationMs)),
-      );
-      await trackerWaitForUploads();
-
-      if (outcomes.some(Boolean)) setHasRecorded(true);
-    } catch (err) {
-      console.error("Failed to stop two-channel recording:", err);
-    } finally {
-      try {
-        await trackerWaitForUploads();
-      } catch (drainErr) {
-        console.error("Failed while draining slot uploads:", drainErr);
-      }
-      setStudioStateSync("connected");
-      setRecordingSessionStartedAtSync(null);
-      recordingTakeIdRef.current = null;
-      void broadcastRecordingStatus(
-        "connected",
-        sessionStartedAtForStatus,
-        undefined,
-        takeIdForStatus,
-      );
-      void switchAudioQuality("full").catch((err) => {
-        console.error("Failed to restore audio quality:", err);
-      });
-    }
-  }, [
-    broadcastRecordingStatus,
-    clearRecordingConfirmationState,
-    finalizeSlot,
+    recordingLifecycle,
     setRecordingSessionStartedAtSync,
     setStudioStateSync,
     switchAudioQuality,
-    trackerFreezeRecorded,
-    trackerWaitForUploads,
   ]);
 
   const handleRetryLocalBackupUpload = useCallback(async () => {
@@ -2361,17 +1790,16 @@ function RoomContent({
       startingRef.current ||
       studioStateRef.current === "recording" ||
       studioStateRef.current === "finalizing" ||
-      recorderRef.current ||
-      slotRecordersRef.current.length > 0
+      recordingLifecycle.active
     ) {
       return;
     }
 
     // In two-channel mode, refuse to start a take / broadcast to the room until
     // the split capture is proven ready — otherwise we'd blip remote
-    // participants and create a throwaway take that startLocalSlots then has to
-    // roll back. The REC button is also disabled in this state; this guards the
-    // programmatic/devtools path.
+    // participants and create a throwaway take that the lifecycle controller
+    // then has to roll back. The REC button is also disabled in this state;
+    // this guards the programmatic/devtools path.
     if (
       twoChannelMode &&
       slotCapturesRef.current.length !== LOCAL_TRACK_SLOTS.length
@@ -2418,9 +1846,7 @@ function RoomContent({
         return;
       }
 
-      const started = twoChannelMode
-        ? await startLocalSlots(sessionStartedAt, takeId)
-        : await startRecordingLocal(sessionStartedAt, takeId);
+      const started = await startRecordingLocal(sessionStartedAt, takeId);
       if (!started) {
         showNotification("Couldn't start your recorder — stopping the room");
         try {
@@ -2442,8 +1868,8 @@ function RoomContent({
     isHost,
     sessionId,
     transport,
+    recordingLifecycle,
     startRecordingLocal,
-    startLocalSlots,
     twoChannelMode,
     showNotification,
   ]);
@@ -2469,11 +1895,7 @@ function RoomContent({
         console.error("Failed to broadcast recording_stop:", err);
         showNotification("Couldn't tell the room to stop recording");
       }
-      if (twoChannelMode) {
-        await stopLocalSlots();
-      } else {
-        await stopRecordingLocal();
-      }
+      await stopRecordingLocal();
     } finally {
       stoppingRef.current = false;
     }
@@ -2482,8 +1904,6 @@ function RoomContent({
     sessionId,
     transport,
     stopRecordingLocal,
-    stopLocalSlots,
-    twoChannelMode,
     showNotification,
   ]);
 

--- a/src/app/studio/[id]/page.tsx
+++ b/src/app/studio/[id]/page.tsx
@@ -1589,6 +1589,15 @@ function RoomContent({
         return false;
       }
 
+      if (result.stopPending || !recordingLifecycle.recording) {
+        // A stop arrived while the recorders were still starting. It is
+        // already waiting inside the controller and will finalize the started
+        // slots; the stop path owns studio state from here, so flipping to
+        // `recording` now would resurrect the UI/status after the room
+        // stopped. The recorders did start, so this is not a start failure.
+        return true;
+      }
+
       setRecordingSessionStartedAtSync(sessionStartedAtIso);
       scheduleRecordingConfirmationCheck(sessionStartedAtIso);
       setStudioStateSync("recording");
@@ -1646,7 +1655,10 @@ function RoomContent({
     // even if the upload pipeline hangs. The controller snapshots its own
     // per-slot state, so a hypothetical concurrent re-record (blocked by the
     // finalizing-state gate, but defended in depth there) cannot corrupt the
-    // finalize.
+    // finalize. If the take is still starting, controller.stop() waits for
+    // startup to settle and then stops whatever started — the paired
+    // stopPending signal keeps the start path from flipping back to
+    // `recording`.
     setStudioStateSync("finalizing");
     void broadcastRecordingStatus(
       "finalizing",

--- a/src/lib/recording-lifecycle.ts
+++ b/src/lib/recording-lifecycle.ts
@@ -455,9 +455,41 @@ export class RecordingLifecycleController {
       await recorder.start(timeSliceMs);
     } catch (err) {
       console.error("Failed to start recorder:", err);
+      // The presign above already created a server track for this slot, and a
+      // slot that never reaches `started` is skipped by the rollback. Conclude
+      // it here so the row can't sit in `recording` forever.
+      await this.concludeAbandonedSlot(slot);
       throw new SlotStartError("recorder-start", err);
     }
     return slot;
+  }
+
+  /**
+   * Converge the server track of a slot that presigned but never recorded:
+   * completing with no uploaded artifact drives materialization to mark the
+   * track failed, which — unlike a row stuck in `recording` — does not block
+   * session finalize. Only safe for slots with no recording data; a slot that
+   * captured anything keeps its track open so the uploaded chunks and local
+   * backup stay recoverable (/complete deletes the segment's chunk objects).
+   */
+  private async concludeAbandonedSlot(slot: SlotState): Promise<void> {
+    try {
+      // Nothing of this slot's can be in flight, but the drain-before-complete
+      // invariant is cheap to keep uniform across every completeUpload.
+      await this.deps.tracker.waitForUploads();
+      await this.deps.uploadApi.completeUpload(
+        this.deps.sessionId,
+        slot.trackId,
+        undefined,
+        slot.uploadToken,
+        slot.segmentId,
+      );
+    } catch (concludeErr) {
+      console.error(
+        `Failed to conclude abandoned slot ${slot.key} server-side:`,
+        concludeErr,
+      );
+    }
   }
 
   /**
@@ -476,6 +508,12 @@ export class RecordingLifecycleController {
           blob = await slot.recorder.stop();
         } catch (stopErr) {
           console.error("Failed to stop partial slot recorder:", stopErr);
+          // No blob to finalize, but data may already be at risk (uploaded
+          // chunks + local backup), so the server track deliberately stays
+          // open for recovery — concluding it would let /complete delete the
+          // chunk objects. Keep + surface the backup so the recovery panel
+          // can re-drive the track in-session.
+          await this.handleSlotFailure(slot, stopErr);
         }
         if (blob) {
           await this.finalizeSlot(slot, blob, this.now() - slot.startedAtMs);

--- a/src/lib/recording-lifecycle.ts
+++ b/src/lib/recording-lifecycle.ts
@@ -177,7 +177,15 @@ export type RecordingStartFailureStage =
   | "recorder-start";
 
 export type RecordingStartResult =
-  | { ok: true }
+  | {
+      ok: true;
+      /**
+       * A stop() arrived while the slots were still starting. It is already
+       * waiting inside the controller and will finalize the take; the caller
+       * must NOT treat the studio as recording.
+       */
+      stopPending?: boolean;
+    }
   | { ok: false; stage: RecordingStartFailureStage };
 
 export interface RecordingStopResult {
@@ -218,6 +226,10 @@ function backupErrorMessage(error: unknown): string {
 export class RecordingLifecycleController {
   private phase: "idle" | "starting" | "recording" | "stopping" = "idle";
   private slots: SlotState[] = [];
+  // The in-flight start attempt (never rejects), so a stop() that lands
+  // mid-start can wait for startup to settle instead of being dropped.
+  private startAttempt: Promise<unknown> | null = null;
+  private stopRequestedWhileStarting = false;
   // Monotonic sequence for backup surfacing so aggregation can order state
   // changes without trusting manifest timestamps.
   private surfaceSeq = 0;
@@ -234,6 +246,11 @@ export class RecordingLifecycleController {
     return this.phase !== "idle";
   }
 
+  /** True only while slots are actually capturing (start settled, stop not begun). */
+  get recording(): boolean {
+    return this.phase === "recording";
+  }
+
   async start(
     specs: RecordingSlotSpec[],
     options: RecordingStartOptions,
@@ -241,6 +258,34 @@ export class RecordingLifecycleController {
     if (this.phase !== "idle") return { ok: false, stage: "already-active" };
     if (specs.length === 0) return { ok: false, stage: "no-slots" };
     this.phase = "starting";
+    this.stopRequestedWhileStarting = false;
+
+    const attempt = this.beginAllSlots(specs, options);
+    // Held for stop(): a stop that lands mid-start waits on this (the derived
+    // promise never rejects) and then stops whatever actually started.
+    this.startAttempt = attempt.then(
+      () => undefined,
+      () => undefined,
+    );
+    try {
+      const result = await attempt;
+      if (result.ok && this.stopRequestedWhileStarting) {
+        // Deterministic signal regardless of microtask ordering: the stop was
+        // requested before startup settled, so the caller must not flip into
+        // the recording state — the waiting stop() finalizes the take.
+        return { ok: true, stopPending: true };
+      }
+      return result;
+    } finally {
+      this.startAttempt = null;
+      this.stopRequestedWhileStarting = false;
+    }
+  }
+
+  private async beginAllSlots(
+    specs: RecordingSlotSpec[],
+    options: RecordingStartOptions,
+  ): Promise<RecordingStartResult> {
     this.deps.tracker.reset();
     this.slotManifests.clear();
     this.slotErrors.clear();
@@ -264,12 +309,21 @@ export class RecordingLifecycleController {
       };
     }
 
+    // The phase must flip before this promise resolves so a stop() waiting on
+    // the attempt observes "recording" and proceeds.
     this.slots = started;
     this.phase = "recording";
     return { ok: true };
   }
 
   async stop(): Promise<RecordingStopResult> {
+    // A stop that lands while the take is still starting must not be dropped:
+    // wait for startup to settle, then stop whatever actually started. The
+    // start() caller is told via stopPending that this stop owns the take.
+    if (this.phase === "starting") {
+      this.stopRequestedWhileStarting = true;
+      if (this.startAttempt) await this.startAttempt;
+    }
     if (this.phase !== "recording") {
       return { stopped: false, anyCompleted: false };
     }

--- a/src/lib/recording-lifecycle.ts
+++ b/src/lib/recording-lifecycle.ts
@@ -1,0 +1,691 @@
+"use client";
+
+// Unified slot recording lifecycle (issue #135 refactor).
+//
+// One recording take = N independent "slots", each owning a stream → recorder
+// → chunked upload → local backup pipeline against its own server track.
+// Single-track mode is the degenerate 1-slot case; two-channel local mode
+// passes 2 slots. Both studio modes drive this controller so the pipeline can
+// never diverge between them again (the failure mode PR #159 review kept
+// finding).
+//
+// This is deliberately a plain object, NOT a React hook: the studio's level
+// meters run continuous rAF loops that keep React perpetually "busy", so
+// hook-based lifecycles can't be exercised with act(async) in tests. All
+// React state surfacing goes through injected callbacks instead.
+//
+// Invariants owned here:
+//  1. Per-channel independence at every stage — stop, drain, final upload,
+//     complete, and backup ops are settled per slot, so one channel's failure
+//     never aborts a sibling.
+//  2. Every in-flight upload drains before any completeUpload (/complete
+//     deletes the temporary chunk objects server-side).
+//  3. markBackupAvailable(durationMs) lands before the final upload, so a
+//     crash mid-upload still recovers with a correct duration.
+//  4. Every backup state change surfaces through the recovery callbacks so
+//     the studio's recovery panel can render in-session.
+//  5. Partial-start rollback finalizes already-started slots — no server
+//     track is left recording after a failed start.
+//  6. Crash-safe backup order: startBackup → saveChunk →
+//     markChunkUploaded/Failed → markBackupAvailable(duration) →
+//     clearBackup/markBackupFailed.
+
+import { v4 as uuidv4 } from "uuid";
+import {
+  recordingBackupId,
+  type RecordingBackupManifest,
+  type RecordingBackupClearReason,
+  type StartRecordingBackupInput,
+} from "@/lib/recording-backup";
+import type { DeviceInfo, PresignedUploadTarget, TrackInitInfo } from "@/lib/upload";
+
+/** The final merged recording.webm is uploaded under this part number. */
+export const FINAL_RECORDING_PART_NUMBER = 9999;
+
+const DEFAULT_TIME_SLICE_MS = 5000;
+
+export interface RecorderLike {
+  onChunk(callback: (chunk: Blob, index: number) => void): void;
+  start(timeSliceMs?: number): Promise<void>;
+  stop(): Promise<Blob>;
+}
+
+export interface RecordingUploadApi {
+  getPresignedUploadTarget(
+    sessionId: string,
+    trackId: string,
+    partNumber: number,
+    participantName?: string,
+    trackInit?: TrackInitInfo,
+    recordingToken?: string,
+  ): Promise<PresignedUploadTarget>;
+  getPresignedUploadUrl(
+    sessionId: string,
+    trackId: string,
+    partNumber: number,
+    participantName?: string,
+    trackInit?: TrackInitInfo,
+    recordingToken?: string,
+  ): Promise<string>;
+  uploadChunk(url: string, chunk: Blob): Promise<void>;
+  completeUpload(
+    sessionId: string,
+    trackId: string,
+    durationMs?: number,
+    recordingToken?: string,
+    segmentId?: string,
+  ): Promise<void>;
+}
+
+export interface RecordingBackupStoreLike {
+  startBackup(input: StartRecordingBackupInput): Promise<RecordingBackupManifest>;
+  saveChunk(input: {
+    sessionId: string;
+    trackId: string;
+    segmentId?: string;
+    chunkIndex: number;
+    chunk: Blob;
+    capturedAt?: Date;
+  }): Promise<RecordingBackupManifest>;
+  markChunkUploaded(
+    sessionId: string,
+    trackId: string,
+    chunkIndex: number,
+    segmentId?: string,
+  ): Promise<RecordingBackupManifest>;
+  markChunkFailed(
+    sessionId: string,
+    trackId: string,
+    chunkIndex: number,
+    error: unknown,
+    segmentId?: string,
+  ): Promise<RecordingBackupManifest>;
+  markBackupAvailable(
+    id: string,
+    durationMs?: number,
+  ): Promise<RecordingBackupManifest>;
+  markBackupFailed(id: string, error: unknown): Promise<RecordingBackupManifest>;
+  clearBackup(id: string, reason: RecordingBackupClearReason): Promise<void>;
+}
+
+/**
+ * The subset of useUploadProgress the lifecycle drives. All callbacks are
+ * identity-stable in the real hook, so a controller built once can hold them.
+ */
+export interface RecordingUploadTrackerLike {
+  reset(): void;
+  onChunkRecorded(byteLength: number): void;
+  trackUpload(
+    byteLength: number,
+    uploadPromise: Promise<void>,
+    options?: { rethrow?: boolean },
+  ): Promise<void>;
+  freezeRecorded(): void;
+  waitForUploads(): Promise<void>;
+}
+
+/** One channel to record: a stream plus the identity its track is filed under. */
+export interface RecordingSlotSpec {
+  /**
+   * Host-local channel slot id (two-channel mode). Omitted for the primary
+   * single-track mic recording.
+   */
+  localTrackSlotId?: string;
+  /** Participant name recorded on the server track and backup manifest. */
+  participantName: string;
+  stream: MediaStream;
+  deviceInfo: DeviceInfo;
+}
+
+export interface RecordingLifecycleCallbacks {
+  /**
+   * Latest recovery-relevant backup manifest across all slots, or null when
+   * none remains. Failed manifests win over the latest state change so one
+   * slot's verified-upload clear can never hide a sibling's kept backup.
+   */
+  onRecoveryBackup?(manifest: RecordingBackupManifest | null): void;
+  /** Latest backup error message across all slots, or null when cleared. */
+  onBackupError?(message: string | null): void;
+  /** A slot's local backup could not be initialized; recording continues remote-only. */
+  onBackupUnavailable?(spec: RecordingSlotSpec): void;
+  /** Structured timing diagnostics (issue #7's ?timing=1 instrumentation). */
+  onTiming?(event: Record<string, unknown>): void;
+}
+
+export interface RecordingLifecycleDeps {
+  sessionId: string;
+  uploadApi: RecordingUploadApi;
+  backupStore: RecordingBackupStoreLike;
+  tracker: RecordingUploadTrackerLike;
+  createRecorder(stream: MediaStream): RecorderLike;
+  generateTrackId?(): string;
+  now?(): number;
+  callbacks?: RecordingLifecycleCallbacks;
+}
+
+export interface RecordingStartOptions {
+  /** ISO8601 originator clock shared by every track in the take. */
+  sessionStartedAt: string;
+  takeId?: string | null;
+  timeSliceMs?: number;
+}
+
+export type RecordingStartFailureStage =
+  | "already-active"
+  | "no-slots"
+  | "presign"
+  | "recorder-start";
+
+export type RecordingStartResult =
+  | { ok: true }
+  | { ok: false; stage: RecordingStartFailureStage };
+
+export interface RecordingStopResult {
+  /** False when there was nothing to stop (idle or already stopping). */
+  stopped: boolean;
+  /** True when at least one slot's track fully completed. */
+  anyCompleted: boolean;
+}
+
+type SlotState = {
+  /** Stable key for backup-surfacing maps; "primary" for single-track. */
+  key: string;
+  spec: RecordingSlotSpec;
+  recorder: RecorderLike;
+  trackId: string;
+  segmentId: string;
+  uploadToken: string | undefined;
+  /** Null when startBackup failed — every backup op is skipped for the slot. */
+  backupId: string | null;
+  /** Stamped immediately before recorder.start(). */
+  startedAtMs: number;
+};
+
+/** Tags a start failure with the pipeline stage that caused it. */
+class SlotStartError extends Error {
+  constructor(
+    readonly stage: "presign" | "recorder-start",
+    cause: unknown,
+  ) {
+    super(`Recording slot failed to start at ${stage}`, { cause });
+  }
+}
+
+function backupErrorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : "Local recording backup failed";
+}
+
+export class RecordingLifecycleController {
+  private phase: "idle" | "starting" | "recording" | "stopping" = "idle";
+  private slots: SlotState[] = [];
+  // Monotonic sequence for backup surfacing so aggregation can order state
+  // changes without trusting manifest timestamps.
+  private surfaceSeq = 0;
+  private slotManifests = new Map<
+    string,
+    { seq: number; manifest: RecordingBackupManifest | null }
+  >();
+  private slotErrors = new Map<string, { seq: number; message: string | null }>();
+
+  constructor(private readonly deps: RecordingLifecycleDeps) {}
+
+  /** True from the moment a start is attempted until the take fully settles. */
+  get active(): boolean {
+    return this.phase !== "idle";
+  }
+
+  async start(
+    specs: RecordingSlotSpec[],
+    options: RecordingStartOptions,
+  ): Promise<RecordingStartResult> {
+    if (this.phase !== "idle") return { ok: false, stage: "already-active" };
+    if (specs.length === 0) return { ok: false, stage: "no-slots" };
+    this.phase = "starting";
+    this.deps.tracker.reset();
+    this.slotManifests.clear();
+    this.slotErrors.clear();
+
+    const timeSliceMs = options.timeSliceMs ?? DEFAULT_TIME_SLICE_MS;
+    const started: SlotState[] = [];
+    try {
+      // Sequential on purpose: slot ordering is part of the server contract
+      // (deterministic track creation order) and a failure must roll back only
+      // the slots that actually started.
+      for (const spec of specs) {
+        started.push(await this.beginSlot(spec, options, timeSliceMs));
+      }
+    } catch (err) {
+      console.error("Failed to start recording slots:", err);
+      await this.rollbackPartialStart(started);
+      this.phase = "idle";
+      return {
+        ok: false,
+        stage: err instanceof SlotStartError ? err.stage : "recorder-start",
+      };
+    }
+
+    this.slots = started;
+    this.phase = "recording";
+    return { ok: true };
+  }
+
+  async stop(): Promise<RecordingStopResult> {
+    if (this.phase !== "recording") {
+      return { stopped: false, anyCompleted: false };
+    }
+    this.phase = "stopping";
+    const slots = this.slots;
+    this.slots = [];
+
+    try {
+      // Stop every recorder independently — one channel dying mid-stop must
+      // not cost the sibling its capture.
+      const stopResults = await Promise.allSettled(
+        slots.map((slot) => slot.recorder.stop()),
+      );
+      const stoppedAtMs = this.now();
+      // Recording is done: freeze the progress denominator (the final merged
+      // blobs below still grow it explicitly).
+      this.deps.tracker.freezeRecorded();
+
+      const outcomes = await Promise.allSettled(
+        slots.map((slot, index) => {
+          const stopResult = stopResults[index];
+          if (stopResult.status === "rejected") {
+            console.error(
+              `Failed to stop recorder for slot ${slot.key}:`,
+              stopResult.reason,
+            );
+            return this.handleSlotFailure(slot, stopResult.reason).then(
+              () => false,
+            );
+          }
+          return this.finalizeSlot(
+            slot,
+            stopResult.value,
+            stoppedAtMs - slot.startedAtMs,
+          );
+        }),
+      );
+      return {
+        stopped: true,
+        anyCompleted: outcomes.some(
+          (outcome) => outcome.status === "fulfilled" && outcome.value === true,
+        ),
+      };
+    } finally {
+      // Do not report idle until the chunk-upload promise set is drained,
+      // regardless of error path (issue #61's finalizing invariant).
+      try {
+        await this.deps.tracker.waitForUploads();
+      } catch (drainErr) {
+        console.error("Failed while draining chunk uploads:", drainErr);
+      }
+      this.phase = "idle";
+    }
+  }
+
+  // ---- Start pipeline ----
+
+  private async beginSlot(
+    spec: RecordingSlotSpec,
+    options: RecordingStartOptions,
+    timeSliceMs: number,
+  ): Promise<SlotState> {
+    const key = spec.localTrackSlotId ?? "primary";
+    const requestedTrackId = this.generateTrackId();
+
+    let target: PresignedUploadTarget;
+    try {
+      target = await this.deps.uploadApi.getPresignedUploadTarget(
+        this.deps.sessionId,
+        requestedTrackId,
+        0,
+        spec.participantName,
+        {
+          deviceInfo: spec.deviceInfo,
+          sessionStartedAt: options.sessionStartedAt,
+          takeId: options.takeId ?? undefined,
+          localTrackSlotId: spec.localTrackSlotId,
+        },
+      );
+    } catch (err) {
+      console.error("Failed to initialize upload:", err);
+      throw new SlotStartError("presign", err);
+    }
+    const trackId = target.trackId ?? requestedTrackId;
+    const segmentId = target.segmentId ?? requestedTrackId;
+    const uploadToken = target.recordingToken;
+
+    let backupId: string | null = null;
+    try {
+      const backup = await this.deps.backupStore.startBackup({
+        sessionId: this.deps.sessionId,
+        trackId,
+        segmentId,
+        participantName: spec.participantName,
+        recordingToken: uploadToken,
+      });
+      backupId = recordingBackupId(this.deps.sessionId, segmentId);
+      this.surfaceManifest(key, backup ?? null);
+      this.surfaceError(key, null);
+    } catch (backupErr) {
+      console.error("Failed to initialize local recording backup:", backupErr);
+      this.surfaceManifest(key, null);
+      this.surfaceError(key, backupErrorMessage(backupErr));
+      this.deps.callbacks?.onBackupUnavailable?.(spec);
+    }
+
+    const recorder = this.deps.createRecorder(spec.stream);
+    const slot: SlotState = {
+      key,
+      spec,
+      recorder,
+      trackId,
+      segmentId,
+      uploadToken,
+      backupId,
+      startedAtMs: 0,
+    };
+    recorder.onChunk((chunk, index) => this.handleChunk(slot, chunk, index));
+
+    slot.startedAtMs = this.now();
+    this.deps.callbacks?.onTiming?.({
+      event: "record-start",
+      t: slot.startedAtMs,
+      sessionStartedAt: options.sessionStartedAt,
+      trackId,
+      participant: spec.participantName,
+    });
+    try {
+      await recorder.start(timeSliceMs);
+    } catch (err) {
+      console.error("Failed to start recorder:", err);
+      throw new SlotStartError("recorder-start", err);
+    }
+    return slot;
+  }
+
+  /**
+   * A slot failed to start after siblings already began: stop and finalize
+   * each started slot through the normal path so no server track lingers in
+   * `recording` waiting on recovery. Best-effort — a slot whose recorder
+   * cannot even stop has nothing to finalize.
+   */
+  private async rollbackPartialStart(started: SlotState[]): Promise<void> {
+    if (started.length === 0) return;
+    this.deps.tracker.freezeRecorded();
+    await Promise.allSettled(
+      started.map(async (slot) => {
+        let blob: Blob | null = null;
+        try {
+          blob = await slot.recorder.stop();
+        } catch (stopErr) {
+          console.error("Failed to stop partial slot recorder:", stopErr);
+        }
+        if (blob) {
+          await this.finalizeSlot(slot, blob, this.now() - slot.startedAtMs);
+        }
+      }),
+    );
+    try {
+      await this.deps.tracker.waitForUploads();
+    } catch (drainErr) {
+      console.error("Failed while draining partial slot uploads:", drainErr);
+    }
+  }
+
+  // ---- Chunk pipeline ----
+
+  private handleChunk(slot: SlotState, chunk: Blob, index: number): void {
+    const byteLength = chunk.size;
+    this.deps.tracker.onChunkRecorded(byteLength);
+    this.deps.callbacks?.onTiming?.({
+      event: "chunk",
+      t: this.now(),
+      trackId: slot.trackId,
+      chunkIndex: index,
+      chunkBytes: byteLength,
+    });
+
+    const capturedAt = new Date();
+    // Crash safety: the local write is sequenced before the remote PUT so a
+    // tab crash mid-upload still has the chunk on disk.
+    const backupSave: Promise<RecordingBackupManifest | null> = slot.backupId
+      ? this.deps.backupStore
+          .saveChunk({
+            sessionId: this.deps.sessionId,
+            trackId: slot.trackId,
+            segmentId: slot.segmentId,
+            chunkIndex: index,
+            chunk,
+            capturedAt,
+          })
+          .then((backup) => {
+            this.surfaceManifest(slot.key, backup ?? null);
+            this.surfaceError(slot.key, null);
+            return backup ?? null;
+          })
+          .catch((backupErr) => {
+            console.error("Failed to write local recording backup:", backupErr);
+            this.surfaceError(slot.key, backupErrorMessage(backupErr));
+            return null;
+          })
+      : Promise.resolve(null);
+
+    const uploadPromise = (async () => {
+      const savedBackup = await backupSave;
+      try {
+        const url = await this.deps.uploadApi.getPresignedUploadUrl(
+          this.deps.sessionId,
+          slot.trackId,
+          index,
+          undefined,
+          { segmentId: slot.segmentId },
+          slot.uploadToken,
+        );
+        await this.deps.uploadApi.uploadChunk(url, chunk);
+      } catch (uploadErr) {
+        if (savedBackup) {
+          try {
+            const backup = await this.deps.backupStore.markChunkFailed(
+              this.deps.sessionId,
+              slot.trackId,
+              index,
+              uploadErr,
+              slot.segmentId,
+            );
+            this.surfaceManifest(slot.key, backup ?? null);
+          } catch (backupErr) {
+            console.error("Failed to mark local backup chunk failed:", backupErr);
+          }
+        }
+        throw uploadErr;
+      }
+      if (savedBackup) {
+        try {
+          const backup = await this.deps.backupStore.markChunkUploaded(
+            this.deps.sessionId,
+            slot.trackId,
+            index,
+            slot.segmentId,
+          );
+          this.surfaceManifest(slot.key, backup ?? null);
+        } catch (backupErr) {
+          console.error("Failed to mark local backup chunk uploaded:", backupErr);
+          this.surfaceError(slot.key, backupErrorMessage(backupErr));
+        }
+      }
+    })();
+
+    void this.deps.tracker.trackUpload(byteLength, uploadPromise);
+  }
+
+  // ---- Stop pipeline ----
+
+  /**
+   * Finalize one slot's track: hand the backup its duration, upload the final
+   * recording.webm, drain, mark the track complete, and clear the backup.
+   * Contained per slot — a failure here (backup kept + marked failed) can
+   * never prevent a sibling channel from finalizing. Returns true iff the
+   * track completed.
+   */
+  private async finalizeSlot(
+    slot: SlotState,
+    blob: Blob,
+    durationMs: number,
+  ): Promise<boolean> {
+    this.deps.callbacks?.onTiming?.({
+      event: "record-stop",
+      t: this.now(),
+      trackId: slot.trackId,
+      startedAt: slot.startedAtMs,
+      durationMs,
+      finalBlobBytes: blob.size,
+    });
+
+    // Before the final upload, so a crash mid-upload still recovers this
+    // track with a correct duration instead of null.
+    if (slot.backupId) {
+      try {
+        const backup = await this.deps.backupStore.markBackupAvailable(
+          slot.backupId,
+          durationMs,
+        );
+        this.surfaceManifest(slot.key, backup ?? null);
+      } catch (backupErr) {
+        console.error("Failed to mark local backup available:", backupErr);
+      }
+    }
+
+    // The final recording.webm upload is critical: if it fails, we must NOT
+    // call completeUpload (which lets the server delete chunk files). The
+    // rethrow surfaces the failure here so completeUpload is skipped and the
+    // tracker's lastError feeds the UI.
+    const finalBytes = blob.size;
+    this.deps.tracker.onChunkRecorded(finalBytes);
+    const finalUpload = (async () => {
+      const url = await this.deps.uploadApi.getPresignedUploadUrl(
+        this.deps.sessionId,
+        slot.trackId,
+        FINAL_RECORDING_PART_NUMBER,
+        undefined,
+        { segmentId: slot.segmentId },
+        slot.uploadToken,
+      );
+      await this.deps.uploadApi.uploadChunk(url, blob);
+    })();
+
+    try {
+      await this.deps.tracker.trackUpload(finalBytes, finalUpload, {
+        rethrow: true,
+      });
+      // Drain every in-flight upload (all slots' background chunk PUTs and
+      // final blobs) before completing — /complete deletes the temporary
+      // chunk objects, so a slow chunk PUT landing afterwards would strand
+      // stale objects.
+      await this.deps.tracker.waitForUploads();
+      await this.deps.uploadApi.completeUpload(
+        this.deps.sessionId,
+        slot.trackId,
+        durationMs,
+        slot.uploadToken,
+        slot.segmentId,
+      );
+      if (slot.backupId) {
+        try {
+          await this.deps.backupStore.clearBackup(
+            slot.backupId,
+            "verified-upload",
+          );
+          this.surfaceManifest(slot.key, null);
+          this.surfaceError(slot.key, null);
+        } catch (backupErr) {
+          console.error("Failed to clear uploaded local backup:", backupErr);
+          this.surfaceError(slot.key, backupErrorMessage(backupErr));
+        }
+      }
+      return true;
+    } catch (err) {
+      console.error(`Failed to finalize recording slot ${slot.key}:`, err);
+      await this.handleSlotFailure(slot, err);
+      return false;
+    }
+  }
+
+  /** Keep the slot's backup for recovery and surface the failure in-session. */
+  private async handleSlotFailure(slot: SlotState, err: unknown): Promise<void> {
+    if (slot.backupId) {
+      try {
+        const backup = await this.deps.backupStore.markBackupFailed(
+          slot.backupId,
+          err,
+        );
+        this.surfaceManifest(slot.key, backup ?? null);
+        this.surfaceError(slot.key, null);
+      } catch (backupErr) {
+        console.error("Failed to mark local backup failed:", backupErr);
+        this.surfaceError(slot.key, backupErrorMessage(backupErr));
+      }
+    } else {
+      // No local backup for this channel — at least tell the host the upload
+      // failed rather than failing silently.
+      this.surfaceError(slot.key, backupErrorMessage(err));
+    }
+  }
+
+  // ---- Backup surfacing ----
+  //
+  // The studio renders ONE recovery panel, so N slots project onto a single
+  // manifest + error. Each slot's latest state is kept per-slot and aggregated
+  // on every change: failed manifests beat the most recent update, so a
+  // sibling's verified-upload clear can never hide a kept backup.
+
+  private surfaceManifest(
+    key: string,
+    manifest: RecordingBackupManifest | null,
+  ): void {
+    this.surfaceSeq += 1;
+    this.slotManifests.set(key, { seq: this.surfaceSeq, manifest });
+    this.deps.callbacks?.onRecoveryBackup?.(this.aggregateManifest());
+  }
+
+  private aggregateManifest(): RecordingBackupManifest | null {
+    const present = Array.from(this.slotManifests.values()).filter(
+      (entry): entry is { seq: number; manifest: RecordingBackupManifest } =>
+        entry.manifest !== null,
+    );
+    if (present.length === 0) return null;
+    const failed = present.filter((entry) => entry.manifest.state === "failed");
+    const pool = failed.length > 0 ? failed : present;
+    return pool.reduce((latest, entry) =>
+      entry.seq > latest.seq ? entry : latest,
+    ).manifest;
+  }
+
+  private surfaceError(key: string, message: string | null): void {
+    this.surfaceSeq += 1;
+    this.slotErrors.set(key, { seq: this.surfaceSeq, message });
+    const present = Array.from(this.slotErrors.values()).filter(
+      (entry): entry is { seq: number; message: string } =>
+        entry.message !== null,
+    );
+    const aggregate =
+      present.length > 0
+        ? present.reduce((latest, entry) =>
+            entry.seq > latest.seq ? entry : latest,
+          ).message
+        : null;
+    this.deps.callbacks?.onBackupError?.(aggregate);
+  }
+
+  // ---- Small injectable utilities ----
+
+  private generateTrackId(): string {
+    return this.deps.generateTrackId?.() ?? uuidv4();
+  }
+
+  private now(): number {
+    return this.deps.now?.() ?? Date.now();
+  }
+}

--- a/src/lib/track-materialization.ts
+++ b/src/lib/track-materialization.ts
@@ -302,6 +302,30 @@ export async function materializeTrack(
 
     if (sourceKeys.length === 1) {
       const [sourceKey] = sourceKeys;
+      // A segment can complete with no artifact ever uploaded — e.g. a slot
+      // concluded after its recorder failed to start. The default segment
+      // shares the logical output key, so the no-copy fast path below would
+      // otherwise mark the track complete with a nonexistent recording
+      // (phantom-complete). The multi-segment path self-checks: a missing
+      // source makes the remux read throw into the failure handler.
+      if (
+        !(await trackSegmentRecordingExists(
+          track.sessionId,
+          trackId,
+          sourceSegments[0]!.id,
+        ))
+      ) {
+        console.error(
+          `[materialize] track=${trackId} lone segment has no uploaded artifact; marking failed`,
+        );
+        return await markTrackFailed({
+          trackId,
+          currentS3Key: track.s3Key,
+          finalKey,
+          segmentCount: sourceSegments.length,
+          latestSegmentIndex: latestSegment.segmentIndex,
+        });
+      }
       if (sourceKey !== finalKey) {
         const readObjectBytes = deps.readObjectBytes ?? getObjectBytes;
         const writeObjectBytes = deps.writeObjectBytes ?? putObjectBytes;

--- a/tests/recording-lifecycle.test.ts
+++ b/tests/recording-lifecycle.test.ts
@@ -91,9 +91,12 @@ function manifest(
   };
 }
 
-function makeHarness(options: { failRecorderStartAt?: number } = {}) {
+function makeHarness(
+  options: { failRecorderStartAt?: number; gateRecorderStartAt?: number } = {},
+) {
   const log: string[] = [];
   const recorders: FakeRecorder[] = [];
+  const recorderStartGate = deferred<void>();
   const events = {
     recovery: [] as (RecordingBackupManifest | null)[],
     errors: [] as (string | null)[],
@@ -252,6 +255,9 @@ function makeHarness(options: { failRecorderStartAt?: number } = {}) {
       if (recorders.length === options.failRecorderStartAt) {
         recorder.startError = new Error("recorder start failed");
       }
+      if (recorders.length === options.gateRecorderStartAt) {
+        recorder.startGate = recorderStartGate.promise;
+      }
       recorders.push(recorder);
       return recorder;
     },
@@ -276,6 +282,7 @@ function makeHarness(options: { failRecorderStartAt?: number } = {}) {
     advance: (ms: number) => {
       clock += ms;
     },
+    releaseRecorderStart: () => recorderStartGate.resolve(),
   };
 }
 
@@ -880,25 +887,17 @@ describe("RecordingLifecycleController stop", () => {
   });
 
   it("holds a stop that lands while a recorder is still starting", async () => {
-    const h = makeHarness();
-    const startGate = deferred<void>();
     // Slot 2's recorder blocks in start(); slot 1 is already capturing.
-    const armGate = setInterval(() => {
-      if (h.recorders.length === 2 && !h.recorders[1].started) {
-        h.recorders[1].startGate = startGate.promise;
-        clearInterval(armGate);
-      }
-    }, 0);
+    const h = makeHarness({ gateRecorderStartAt: 1 });
 
     const startPromise = h.controller.start([slotSpec(1), slotSpec(2)], START_OPTS);
     await settle();
-    clearInterval(armGate);
 
     const stopPromise = h.controller.stop();
     await settle();
     expect(h.recorders[0].stopped).toBe(false);
 
-    startGate.resolve();
+    h.releaseRecorderStart();
     const [startResult, stopResult] = await Promise.all([
       startPromise,
       stopPromise,

--- a/tests/recording-lifecycle.test.ts
+++ b/tests/recording-lifecycle.test.ts
@@ -47,6 +47,7 @@ class FakeRecorder implements RecorderLike {
   started = false;
   stopped = false;
   startTimeSlice: number | undefined;
+  startGate: Promise<void> | null = null;
   startError: Error | null = null;
   stopError: Error | null = null;
   stopBlob = new Blob(["final-recording"], { type: "audio/webm" });
@@ -57,6 +58,7 @@ class FakeRecorder implements RecorderLike {
 
   async start(timeSliceMs?: number): Promise<void> {
     this.startTimeSlice = timeSliceMs;
+    if (this.startGate) await this.startGate;
     if (this.startError) throw this.startError;
     this.started = true;
   }
@@ -833,6 +835,134 @@ describe("RecordingLifecycleController stop", () => {
     expect(eventNames).toContain("record-start");
     expect(eventNames).toContain("chunk");
     expect(eventNames).toContain("record-stop");
+  });
+
+  it("holds a stop that lands mid-start until startup settles, then stops the slots", async () => {
+    const h = makeHarness();
+    const presignGate = deferred<void>();
+    h.uploadApi.getPresignedUploadTarget.mockImplementationOnce((async () => {
+      await presignGate.promise;
+      return {
+        url: "https://s3.test/primary/0.webm",
+        recordingToken: "token-primary",
+        trackId: "track-primary",
+        segmentId: "segment-primary",
+      };
+    }) as never);
+
+    const startPromise = h.controller.start([primarySpec()], START_OPTS);
+    await settle();
+    expect(h.controller.active).toBe(true);
+
+    // The room stops while our start is still blocked in presign. The stop
+    // must not be dropped — and the eventual start must not resurrect the
+    // recording after the room stopped (Codex P1 on PR #165).
+    const stopPromise = h.controller.stop();
+    await settle();
+    expect(h.uploadApi.completeUpload).not.toHaveBeenCalled();
+
+    presignGate.resolve();
+    const [startResult, stopResult] = await Promise.all([
+      startPromise,
+      stopPromise,
+    ]);
+
+    // The caller is told a stop is already pending so it must not flip the
+    // studio into the recording state.
+    expect(startResult).toEqual({ ok: true, stopPending: true });
+    expect(h.controller.recording).toBe(false);
+    // The slot really started, then the held stop finalized it.
+    expect(stopResult).toEqual({ stopped: true, anyCompleted: true });
+    expect(h.recorders[0].started).toBe(true);
+    expect(h.recorders[0].stopped).toBe(true);
+    expect(h.uploadApi.completeUpload).toHaveBeenCalledTimes(1);
+    expect(h.controller.active).toBe(false);
+  });
+
+  it("holds a stop that lands while a recorder is still starting", async () => {
+    const h = makeHarness();
+    const startGate = deferred<void>();
+    // Slot 2's recorder blocks in start(); slot 1 is already capturing.
+    const armGate = setInterval(() => {
+      if (h.recorders.length === 2 && !h.recorders[1].started) {
+        h.recorders[1].startGate = startGate.promise;
+        clearInterval(armGate);
+      }
+    }, 0);
+
+    const startPromise = h.controller.start([slotSpec(1), slotSpec(2)], START_OPTS);
+    await settle();
+    clearInterval(armGate);
+
+    const stopPromise = h.controller.stop();
+    await settle();
+    expect(h.recorders[0].stopped).toBe(false);
+
+    startGate.resolve();
+    const [startResult, stopResult] = await Promise.all([
+      startPromise,
+      stopPromise,
+    ]);
+
+    expect(startResult).toEqual({ ok: true, stopPending: true });
+    expect(stopResult).toEqual({ stopped: true, anyCompleted: true });
+    expect(h.recorders.every((recorder) => recorder.stopped)).toBe(true);
+    const completed = h.uploadApi.completeUpload.mock.calls.map(
+      (call) => call[1],
+    );
+    expect(completed).toContain("track-host-local-ch-1");
+    expect(completed).toContain("track-host-local-ch-2");
+    expect(h.controller.active).toBe(false);
+  });
+
+  it("resolves a mid-start stop as a no-op when the start itself fails", async () => {
+    const h = makeHarness();
+    const presignGate = deferred<void>();
+    h.uploadApi.getPresignedUploadTarget.mockImplementationOnce((async () => {
+      await presignGate.promise;
+      throw new Error("presign failed");
+    }) as never);
+
+    const startPromise = h.controller.start([primarySpec()], START_OPTS);
+    await settle();
+    const stopPromise = h.controller.stop();
+    presignGate.resolve();
+
+    const [startResult, stopResult] = await Promise.all([
+      startPromise,
+      stopPromise,
+    ]);
+
+    expect(startResult).toEqual({ ok: false, stage: "presign" });
+    expect(stopResult).toEqual({ stopped: false, anyCompleted: false });
+    expect(h.controller.active).toBe(false);
+  });
+
+  it("only one of two stops racing a mid-flight start performs the stop", async () => {
+    const h = makeHarness();
+    const presignGate = deferred<void>();
+    h.uploadApi.getPresignedUploadTarget.mockImplementationOnce((async () => {
+      await presignGate.promise;
+      return {
+        url: "https://s3.test/primary/0.webm",
+        recordingToken: "token-primary",
+        trackId: "track-primary",
+        segmentId: "segment-primary",
+      };
+    }) as never);
+
+    const startPromise = h.controller.start([primarySpec()], START_OPTS);
+    await settle();
+    const firstStop = h.controller.stop();
+    const secondStop = h.controller.stop();
+    presignGate.resolve();
+
+    const [first, second] = await Promise.all([firstStop, secondStop]);
+    await startPromise;
+
+    const performed = [first, second].filter((result) => result.stopped);
+    expect(performed).toHaveLength(1);
+    expect(h.uploadApi.completeUpload).toHaveBeenCalledTimes(1);
   });
 
   it("allows a fresh start after a completed stop", async () => {

--- a/tests/recording-lifecycle.test.ts
+++ b/tests/recording-lifecycle.test.ts
@@ -478,6 +478,28 @@ describe("RecordingLifecycleController start", () => {
     );
   });
 
+  it("concludes the failed slot's server track when its recorder refuses to start", async () => {
+    // The presign already created a server track before recorder.start()
+    // rejected. With no recording data anywhere, the slot must still be
+    // completed server-side so materialization converges the track to failed
+    // instead of leaving it stuck in `recording`, which would 409-block
+    // session finalize forever (Codex P1 #2 on PR #165).
+    const h = makeHarness({ failRecorderStartAt: 0 });
+
+    const result = await h.controller.start([primarySpec()], START_OPTS);
+
+    expect(result).toEqual({ ok: false, stage: "recorder-start" });
+    expect(h.controller.active).toBe(false);
+    expect(h.uploadApi.completeUpload).toHaveBeenCalledTimes(1);
+    expect(h.uploadApi.completeUpload).toHaveBeenCalledWith(
+      "session-1",
+      "track-primary",
+      undefined,
+      "token-primary",
+      "segment-primary",
+    );
+  });
+
   it("rolls back when a later slot's recorder fails to start", async () => {
     // The second recorder created refuses to start.
     const h = makeHarness({ failRecorderStartAt: 1 });
@@ -487,10 +509,21 @@ describe("RecordingLifecycleController start", () => {
     expect(result).toEqual({ ok: false, stage: "recorder-start" });
     expect(h.controller.active).toBe(false);
     expect(h.recorders[0].stopped).toBe(true);
-    expect(h.uploadApi.completeUpload).toHaveBeenCalledTimes(1);
-    expect(h.uploadApi.completeUpload.mock.calls[0][1]).toBe(
-      "track-host-local-ch-1",
-    );
+    // Both server tracks converge: the failing slot is concluded with no
+    // recording (duration undefined), the started sibling finalizes normally.
+    const completions = h.uploadApi.completeUpload.mock.calls.map((call) => ({
+      trackId: call[1],
+      durationMs: call[2],
+    }));
+    expect(completions).toHaveLength(2);
+    expect(completions).toContainEqual({
+      trackId: "track-host-local-ch-2",
+      durationMs: undefined,
+    });
+    expect(
+      completions.find((entry) => entry.trackId === "track-host-local-ch-1")
+        ?.durationMs,
+    ).toEqual(expect.any(Number));
   });
 
   it("survives a rollback where the started slot's recorder refuses to stop", async () => {
@@ -515,8 +548,16 @@ describe("RecordingLifecycleController start", () => {
 
     expect(result).toEqual({ ok: false, stage: "presign" });
     expect(h.controller.active).toBe(false);
-    // Nothing to finalize (no blob), but the rollback must not throw.
+    // Nothing to finalize (no blob), but the rollback must not throw — and
+    // the slot's server track stays open on purpose: chunks may already be
+    // uploaded, and /complete would delete them. The local backup is kept and
+    // marked failed so the recovery panel can re-drive the track.
     expect(h.uploadApi.completeUpload).not.toHaveBeenCalled();
+    expect(h.backupStore.markBackupFailed).toHaveBeenCalledWith(
+      "session-1:segment-host-local-ch-1",
+      expect.anything(),
+    );
+    expect(h.events.recovery.at(-1)?.state).toBe("failed");
   });
 });
 

--- a/tests/recording-lifecycle.test.ts
+++ b/tests/recording-lifecycle.test.ts
@@ -1,0 +1,849 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  RecordingLifecycleController,
+  type RecorderLike,
+  type RecordingSlotSpec,
+} from "@/lib/recording-lifecycle";
+import type { RecordingBackupManifest } from "@/lib/recording-backup";
+
+// Unit tests for the unified slot recording lifecycle (issue #135 refactor).
+// The controller is a plain object — no React — so these tests drive it
+// directly with fake deps and assert the invariants both studio modes rely on:
+//
+//  1. Per-channel independence at every stage (stop/finalize/backup ops).
+//  2. All in-flight uploads drain before any completeUpload.
+//  3. markBackupAvailable(durationMs) lands before the final upload.
+//  4. Every backup state change surfaces through the recovery callbacks.
+//  5. Partial-start rollback finalizes already-started slots.
+//  6. Resources are torn down on every error/cancel path.
+//  7. Crash-safe backup ordering: startBackup → saveChunk →
+//     markChunkUploaded/Failed → markBackupAvailable → clearBackup/markBackupFailed.
+
+type Deferred<T> = {
+  promise: Promise<T>;
+  resolve: (value: T) => void;
+  reject: (err: unknown) => void;
+};
+
+function deferred<T = void>(): Deferred<T> {
+  let resolve!: (value: T) => void;
+  let reject!: (err: unknown) => void;
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return { promise, resolve, reject };
+}
+
+/** Let queued microtasks and zero-delay timers run a few rounds. */
+async function settle(rounds = 6): Promise<void> {
+  for (let i = 0; i < rounds; i += 1) {
+    await new Promise((resolve) => setTimeout(resolve, 0));
+  }
+}
+
+class FakeRecorder implements RecorderLike {
+  handler: ((chunk: Blob, index: number) => void) | null = null;
+  started = false;
+  stopped = false;
+  startTimeSlice: number | undefined;
+  startError: Error | null = null;
+  stopError: Error | null = null;
+  stopBlob = new Blob(["final-recording"], { type: "audio/webm" });
+
+  onChunk(callback: (chunk: Blob, index: number) => void): void {
+    this.handler = callback;
+  }
+
+  async start(timeSliceMs?: number): Promise<void> {
+    this.startTimeSlice = timeSliceMs;
+    if (this.startError) throw this.startError;
+    this.started = true;
+  }
+
+  async stop(): Promise<Blob> {
+    this.stopped = true;
+    if (this.stopError) throw this.stopError;
+    return this.stopBlob;
+  }
+
+  emit(chunk: Blob, index: number): void {
+    this.handler?.(chunk, index);
+  }
+}
+
+function manifest(
+  overrides: Partial<RecordingBackupManifest> = {},
+): RecordingBackupManifest {
+  return {
+    id: "session-1:segment",
+    sessionId: "session-1",
+    trackId: "track",
+    participantName: "P",
+    createdAt: "2026-07-09T00:00:00.000Z",
+    updatedAt: "2026-07-09T00:00:00.000Z",
+    state: "recording",
+    persistentStorage: true,
+    chunks: [],
+    ...overrides,
+  };
+}
+
+function makeHarness(options: { failRecorderStartAt?: number } = {}) {
+  const log: string[] = [];
+  const recorders: FakeRecorder[] = [];
+  const events = {
+    recovery: [] as (RecordingBackupManifest | null)[],
+    errors: [] as (string | null)[],
+    unavailable: [] as string[],
+    timing: [] as Record<string, unknown>[],
+  };
+  let clock = 1_000;
+  let trackSeq = 0;
+
+  // Mini tracker with the real drain semantics of useUploadProgress:
+  // trackUpload never rejects unless rethrow, waitForUploads loops until the
+  // in-flight set is empty.
+  const inflight = new Set<Promise<void>>();
+  const tracker = {
+    reset: vi.fn(() => {
+      log.push("tracker.reset");
+    }),
+    onChunkRecorded: vi.fn(),
+    freezeRecorded: vi.fn(() => {
+      log.push("freezeRecorded");
+    }),
+    trackUpload: vi.fn(
+      (
+        _byteLength: number,
+        uploadPromise: Promise<void>,
+        options?: { rethrow?: boolean },
+      ): Promise<void> => {
+        const settledResult = uploadPromise.then(
+          () => ({ ok: true as const }),
+          (err: unknown) => ({ ok: false as const, err }),
+        );
+        const tracked: Promise<void> = settledResult
+          .then(() => undefined)
+          .finally(() => {
+            inflight.delete(tracked);
+          });
+        inflight.add(tracked);
+        if (options?.rethrow) {
+          return tracked.then(async () => {
+            const result = await settledResult;
+            if (!result.ok) throw result.err;
+          });
+        }
+        return tracked;
+      },
+    ),
+    waitForUploads: vi.fn(async () => {
+      while (inflight.size > 0) {
+        await Promise.allSettled(Array.from(inflight));
+      }
+    }),
+  };
+
+  const uploadApi = {
+    getPresignedUploadTarget: vi.fn(
+      async (
+        _sessionId: string,
+        _trackId: string,
+        _partNumber: number,
+        _participantName?: string,
+        trackInit?: { localTrackSlotId?: string },
+      ) => {
+        const key = trackInit?.localTrackSlotId ?? "primary";
+        log.push(`presignTarget:${key}`);
+        return {
+          url: `https://s3.test/${key}/0.webm`,
+          recordingToken: `token-${key}`,
+          trackId: `track-${key}`,
+          segmentId: `segment-${key}`,
+        };
+      },
+    ),
+    getPresignedUploadUrl: vi.fn(
+      async (_sessionId: string, trackId: string, partNumber: number) => {
+        log.push(`presignUrl:${trackId}:${partNumber}`);
+        return `https://s3.test/${trackId}/${partNumber}.webm`;
+      },
+    ),
+    uploadChunk: vi.fn(async (url: string) => {
+      log.push(`uploadChunk:${url}`);
+    }),
+    completeUpload: vi.fn(
+      async (
+        _sessionId: string,
+        trackId: string,
+        _durationMs?: number,
+        _recordingToken?: string,
+        _segmentId?: string,
+      ) => {
+        log.push(`complete:${trackId}`);
+      },
+    ),
+  };
+
+  const backupStore = {
+    startBackup: vi.fn(
+      async (input: { sessionId: string; segmentId?: string; trackId: string }) => {
+        log.push(`startBackup:${input.segmentId}`);
+        return manifest({
+          id: `${input.sessionId}:${input.segmentId}`,
+          trackId: input.trackId,
+          segmentId: input.segmentId,
+          state: "recording",
+        });
+      },
+    ),
+    saveChunk: vi.fn(
+      async (input: { segmentId?: string; chunkIndex: number }) => {
+        log.push(`saveChunk:${input.segmentId}:${input.chunkIndex}`);
+        return manifest({ segmentId: input.segmentId, state: "recording" });
+      },
+    ),
+    markChunkUploaded: vi.fn(
+      async (
+        _sessionId: string,
+        _trackId: string,
+        chunkIndex: number,
+        segmentId?: string,
+      ) => {
+        log.push(`markChunkUploaded:${segmentId}:${chunkIndex}`);
+        return manifest({ segmentId });
+      },
+    ),
+    markChunkFailed: vi.fn(
+      async (
+        _sessionId: string,
+        _trackId: string,
+        chunkIndex: number,
+        _error: unknown,
+        segmentId?: string,
+      ) => {
+        log.push(`markChunkFailed:${segmentId}:${chunkIndex}`);
+        return manifest({ segmentId, state: "failed" });
+      },
+    ),
+    markBackupAvailable: vi.fn(async (id: string, durationMs?: number) => {
+      log.push(`markBackupAvailable:${id}:${durationMs}`);
+      return manifest({ id, state: "available", durationMs });
+    }),
+    markBackupFailed: vi.fn(async (id: string) => {
+      log.push(`markBackupFailed:${id}`);
+      return manifest({ id, state: "failed" });
+    }),
+    clearBackup: vi.fn(async (id: string, reason: string) => {
+      log.push(`clearBackup:${id}:${reason}`);
+    }),
+  };
+
+  const controller = new RecordingLifecycleController({
+    sessionId: "session-1",
+    uploadApi,
+    backupStore,
+    tracker,
+    createRecorder: () => {
+      const recorder = new FakeRecorder();
+      if (recorders.length === options.failRecorderStartAt) {
+        recorder.startError = new Error("recorder start failed");
+      }
+      recorders.push(recorder);
+      return recorder;
+    },
+    generateTrackId: () => `requested-${(trackSeq += 1)}`,
+    now: () => clock,
+    callbacks: {
+      onRecoveryBackup: (m) => events.recovery.push(m),
+      onBackupError: (message) => events.errors.push(message),
+      onBackupUnavailable: (spec) => events.unavailable.push(spec.participantName),
+      onTiming: (event) => events.timing.push(event),
+    },
+  });
+
+  return {
+    controller,
+    recorders,
+    uploadApi,
+    backupStore,
+    tracker,
+    log,
+    events,
+    advance: (ms: number) => {
+      clock += ms;
+    },
+  };
+}
+
+const START_OPTS = {
+  sessionStartedAt: "2026-07-09T12:00:00.000Z",
+  takeId: "take-1",
+};
+
+function primarySpec(): RecordingSlotSpec {
+  return {
+    participantName: "Pasha",
+    stream: {} as MediaStream,
+    deviceInfo: {
+      deviceLabel: "Shure MV7",
+      deviceId: "usb-mic",
+      isBuiltInMic: false,
+    },
+  };
+}
+
+function slotSpec(n: 1 | 2): RecordingSlotSpec {
+  return {
+    localTrackSlotId: `host-local-ch-${n}`,
+    participantName: `Local Ch ${n}`,
+    stream: {} as MediaStream,
+    deviceInfo: {
+      deviceLabel: `Local Ch ${n} · Interface`,
+      deviceId: "usb-interface",
+      isBuiltInMic: false,
+    },
+  };
+}
+
+describe("RecordingLifecycleController start", () => {
+  it("starts a single primary slot: presign, backup, recorder — in order", async () => {
+    const h = makeHarness();
+
+    const result = await h.controller.start([primarySpec()], START_OPTS);
+
+    expect(result).toEqual({ ok: true });
+    expect(h.controller.active).toBe(true);
+    expect(h.uploadApi.getPresignedUploadTarget).toHaveBeenCalledWith(
+      "session-1",
+      "requested-1",
+      0,
+      "Pasha",
+      {
+        deviceInfo: {
+          deviceLabel: "Shure MV7",
+          deviceId: "usb-mic",
+          isBuiltInMic: false,
+        },
+        sessionStartedAt: START_OPTS.sessionStartedAt,
+        takeId: "take-1",
+        localTrackSlotId: undefined,
+      },
+    );
+    // Backup is keyed to the server-corrected segment id and carries the token.
+    expect(h.backupStore.startBackup).toHaveBeenCalledWith({
+      sessionId: "session-1",
+      trackId: "track-primary",
+      segmentId: "segment-primary",
+      participantName: "Pasha",
+      recordingToken: "token-primary",
+    });
+    expect(h.recorders).toHaveLength(1);
+    expect(h.recorders[0].started).toBe(true);
+    expect(h.recorders[0].startTimeSlice).toBe(5000);
+    expect(h.log.indexOf("presignTarget:primary")).toBeLessThan(
+      h.log.indexOf("startBackup:segment-primary"),
+    );
+    // The tracker resets exactly once per take.
+    expect(h.tracker.reset).toHaveBeenCalledTimes(1);
+  });
+
+  it("starts two channel slots with their distinct slot ids", async () => {
+    const h = makeHarness();
+
+    const result = await h.controller.start([slotSpec(1), slotSpec(2)], START_OPTS);
+
+    expect(result).toEqual({ ok: true });
+    const slotIds = h.uploadApi.getPresignedUploadTarget.mock.calls.map(
+      (call) => (call[4] as { localTrackSlotId?: string }).localTrackSlotId,
+    );
+    expect(slotIds).toEqual(["host-local-ch-1", "host-local-ch-2"]);
+    expect(h.recorders).toHaveLength(2);
+    expect(h.recorders.every((recorder) => recorder.started)).toBe(true);
+    expect(h.tracker.reset).toHaveBeenCalledTimes(1);
+  });
+
+  it("falls back to the requested track id when presign returns none", async () => {
+    const h = makeHarness();
+    h.uploadApi.getPresignedUploadTarget.mockResolvedValueOnce({
+      url: "https://s3.test/plain/0.webm",
+    } as never);
+
+    await h.controller.start([primarySpec()], START_OPTS);
+
+    expect(h.backupStore.startBackup).toHaveBeenCalledWith(
+      expect.objectContaining({
+        trackId: "requested-1",
+        segmentId: "requested-1",
+        recordingToken: undefined,
+      }),
+    );
+  });
+
+  it("refuses to start while already active", async () => {
+    const h = makeHarness();
+    await h.controller.start([primarySpec()], START_OPTS);
+
+    const second = await h.controller.start([primarySpec()], START_OPTS);
+
+    expect(second).toEqual({ ok: false, stage: "already-active" });
+    expect(h.recorders).toHaveLength(1);
+  });
+
+  it("refuses to start with no slots", async () => {
+    const h = makeHarness();
+
+    const result = await h.controller.start([], START_OPTS);
+
+    expect(result).toEqual({ ok: false, stage: "no-slots" });
+    expect(h.controller.active).toBe(false);
+  });
+
+  it("continues without a backup when startBackup fails", async () => {
+    const h = makeHarness();
+    h.backupStore.startBackup.mockRejectedValueOnce(new Error("no storage"));
+
+    const result = await h.controller.start([primarySpec()], START_OPTS);
+
+    expect(result).toEqual({ ok: true });
+    expect(h.events.unavailable).toEqual(["Pasha"]);
+    expect(h.events.recovery.at(-1)).toBeNull();
+    expect(h.events.errors.at(-1)).toBe("no storage");
+
+    // Chunk saves are skipped (no manifest to attach them to), but the remote
+    // upload still runs.
+    h.recorders[0].emit(new Blob(["chunk-a"], { type: "audio/webm" }), 0);
+    await settle();
+    expect(h.backupStore.saveChunk).not.toHaveBeenCalled();
+    expect(h.uploadApi.uploadChunk).toHaveBeenCalledTimes(1);
+
+    // And stop-time backup ops are skipped too.
+    const stop = await h.controller.stop();
+    expect(stop.anyCompleted).toBe(true);
+    expect(h.backupStore.markBackupAvailable).not.toHaveBeenCalled();
+    expect(h.backupStore.clearBackup).not.toHaveBeenCalled();
+  });
+
+  it("rolls back an already-started slot when a later slot's presign fails", async () => {
+    const h = makeHarness();
+    h.uploadApi.getPresignedUploadTarget.mockImplementation(
+      (async (
+        _sessionId: string,
+        _trackId: string,
+        _part: number,
+        _name?: string,
+        trackInit?: { localTrackSlotId?: string },
+      ) => {
+        if (trackInit?.localTrackSlotId === "host-local-ch-2") {
+          throw new Error("ch2 presign failed");
+        }
+        h.log.push("presignTarget:host-local-ch-1");
+        return {
+          url: "https://s3.test/ch1/0.webm",
+          recordingToken: "token-ch1",
+          trackId: "track-host-local-ch-1",
+          segmentId: "segment-host-local-ch-1",
+        };
+      }) as never,
+    );
+
+    const result = await h.controller.start([slotSpec(1), slotSpec(2)], START_OPTS);
+
+    expect(result).toEqual({ ok: false, stage: "presign" });
+    expect(h.controller.active).toBe(false);
+    // The started channel is stopped and finalized so no server track is left
+    // recording — including its duration-stamped backup handoff.
+    expect(h.recorders[0].stopped).toBe(true);
+    expect(h.uploadApi.completeUpload).toHaveBeenCalledTimes(1);
+    expect(h.uploadApi.completeUpload.mock.calls[0][1]).toBe(
+      "track-host-local-ch-1",
+    );
+    expect(h.backupStore.markBackupAvailable).toHaveBeenCalledWith(
+      "session-1:segment-host-local-ch-1",
+      expect.any(Number),
+    );
+    expect(h.backupStore.clearBackup).toHaveBeenCalledWith(
+      "session-1:segment-host-local-ch-1",
+      "verified-upload",
+    );
+  });
+
+  it("rolls back when a later slot's recorder fails to start", async () => {
+    // The second recorder created refuses to start.
+    const h = makeHarness({ failRecorderStartAt: 1 });
+
+    const result = await h.controller.start([slotSpec(1), slotSpec(2)], START_OPTS);
+
+    expect(result).toEqual({ ok: false, stage: "recorder-start" });
+    expect(h.controller.active).toBe(false);
+    expect(h.recorders[0].stopped).toBe(true);
+    expect(h.uploadApi.completeUpload).toHaveBeenCalledTimes(1);
+    expect(h.uploadApi.completeUpload.mock.calls[0][1]).toBe(
+      "track-host-local-ch-1",
+    );
+  });
+
+  it("survives a rollback where the started slot's recorder refuses to stop", async () => {
+    const h = makeHarness();
+    h.uploadApi.getPresignedUploadTarget
+      .mockImplementationOnce((async () => {
+        h.log.push("presignTarget:host-local-ch-1");
+        return {
+          url: "https://s3.test/ch1/0.webm",
+          recordingToken: "token-ch1",
+          trackId: "track-host-local-ch-1",
+          segmentId: "segment-host-local-ch-1",
+        };
+      }) as never)
+      .mockImplementationOnce((async () => {
+        // Give the first recorder a failing stop before slot 2 fails.
+        h.recorders[0].stopError = new Error("stop failed");
+        throw new Error("ch2 presign failed");
+      }) as never);
+
+    const result = await h.controller.start([slotSpec(1), slotSpec(2)], START_OPTS);
+
+    expect(result).toEqual({ ok: false, stage: "presign" });
+    expect(h.controller.active).toBe(false);
+    // Nothing to finalize (no blob), but the rollback must not throw.
+    expect(h.uploadApi.completeUpload).not.toHaveBeenCalled();
+  });
+});
+
+describe("RecordingLifecycleController chunk pipeline", () => {
+  it("runs the crash-safe order: saveChunk → presign → upload → markChunkUploaded", async () => {
+    const h = makeHarness();
+    await h.controller.start([primarySpec()], START_OPTS);
+
+    h.recorders[0].emit(new Blob(["chunk-a"], { type: "audio/webm" }), 0);
+    await settle();
+
+    const saveIndex = h.log.indexOf("saveChunk:segment-primary:0");
+    const presignIndex = h.log.indexOf("presignUrl:track-primary:0");
+    const uploadIndex = h.log.findIndex((entry) =>
+      entry.startsWith("uploadChunk:https://s3.test/track-primary/0"),
+    );
+    const markIndex = h.log.indexOf("markChunkUploaded:segment-primary:0");
+    expect(saveIndex).toBeGreaterThanOrEqual(0);
+    expect(saveIndex).toBeLessThan(presignIndex);
+    expect(presignIndex).toBeLessThan(uploadIndex);
+    expect(uploadIndex).toBeLessThan(markIndex);
+
+    // The tracker saw the bytes and the upload.
+    expect(h.tracker.onChunkRecorded).toHaveBeenCalledWith(7);
+    expect(h.tracker.trackUpload).toHaveBeenCalledTimes(1);
+    // Chunk presign carries the slot's segment and token.
+    expect(h.uploadApi.getPresignedUploadUrl).toHaveBeenCalledWith(
+      "session-1",
+      "track-primary",
+      0,
+      undefined,
+      { segmentId: "segment-primary" },
+      "token-primary",
+    );
+    // Backup state changes surfaced along the way.
+    expect(h.events.recovery.length).toBeGreaterThanOrEqual(2);
+  });
+
+  it("marks the chunk failed in the backup when its upload fails", async () => {
+    const h = makeHarness();
+    await h.controller.start([primarySpec()], START_OPTS);
+    h.uploadApi.uploadChunk.mockRejectedValueOnce(new Error("PUT failed"));
+
+    h.recorders[0].emit(new Blob(["chunk-a"], { type: "audio/webm" }), 0);
+    await settle();
+
+    expect(h.backupStore.markChunkFailed).toHaveBeenCalledTimes(1);
+    expect(h.backupStore.markChunkUploaded).not.toHaveBeenCalled();
+    // The failed-chunk manifest surfaced to the recovery callback.
+    expect(h.events.recovery.at(-1)?.state).toBe("failed");
+  });
+
+  it("still uploads the chunk remotely when the local backup write fails", async () => {
+    const h = makeHarness();
+    await h.controller.start([primarySpec()], START_OPTS);
+    h.backupStore.saveChunk.mockRejectedValueOnce(new Error("disk full"));
+
+    h.recorders[0].emit(new Blob(["chunk-a"], { type: "audio/webm" }), 0);
+    await settle();
+
+    expect(h.uploadApi.uploadChunk).toHaveBeenCalledTimes(1);
+    expect(h.events.errors.at(-1)).toBe("disk full");
+    // No manifest entry to mark uploaded.
+    expect(h.backupStore.markChunkUploaded).not.toHaveBeenCalled();
+  });
+});
+
+describe("RecordingLifecycleController stop", () => {
+  it("finalizes a single slot: available → final upload → drain → complete → clear", async () => {
+    const h = makeHarness();
+    await h.controller.start([primarySpec()], START_OPTS);
+    h.advance(60_000);
+
+    const result = await h.controller.stop();
+
+    expect(result).toEqual({ stopped: true, anyCompleted: true });
+    expect(h.controller.active).toBe(false);
+
+    // markBackupAvailable carries the measured duration and lands BEFORE the
+    // final upload, so a mid-upload crash still recovers with a duration.
+    expect(h.backupStore.markBackupAvailable).toHaveBeenCalledWith(
+      "session-1:segment-primary",
+      60_000,
+    );
+    const availableIndex = h.log.indexOf(
+      "markBackupAvailable:session-1:segment-primary:60000",
+    );
+    const finalPresignIndex = h.log.indexOf("presignUrl:track-primary:9999");
+    const completeIndex = h.log.indexOf("complete:track-primary");
+    const clearIndex = h.log.indexOf(
+      "clearBackup:session-1:segment-primary:verified-upload",
+    );
+    expect(availableIndex).toBeGreaterThanOrEqual(0);
+    expect(availableIndex).toBeLessThan(finalPresignIndex);
+    expect(finalPresignIndex).toBeLessThan(completeIndex);
+    expect(completeIndex).toBeLessThan(clearIndex);
+
+    expect(h.uploadApi.completeUpload).toHaveBeenCalledWith(
+      "session-1",
+      "track-primary",
+      60_000,
+      "token-primary",
+      "segment-primary",
+    );
+    // A fully verified upload leaves no surfaced backup or error behind.
+    expect(h.events.recovery.at(-1)).toBeNull();
+    expect(h.events.errors.at(-1)).toBeNull();
+  });
+
+  it("is a no-op when nothing is recording", async () => {
+    const h = makeHarness();
+
+    const result = await h.controller.stop();
+
+    expect(result).toEqual({ stopped: false, anyCompleted: false });
+  });
+
+  it("no-ops a second stop while the first is still finalizing", async () => {
+    const h = makeHarness();
+    await h.controller.start([primarySpec()], START_OPTS);
+
+    const first = h.controller.stop();
+    const second = await h.controller.stop();
+    expect(second).toEqual({ stopped: false, anyCompleted: false });
+    const firstResult = await first;
+    expect(firstResult.stopped).toBe(true);
+    expect(h.uploadApi.completeUpload).toHaveBeenCalledTimes(1);
+  });
+
+  it("drains in-flight chunk uploads before completing any slot", async () => {
+    const h = makeHarness();
+    await h.controller.start([slotSpec(1), slotSpec(2)], START_OPTS);
+
+    const gate = deferred<void>();
+    const heldChunk = new Blob(["held-chunk"], { type: "audio/webm" });
+    h.uploadApi.uploadChunk.mockImplementation((async (
+      _url: string,
+      blob: Blob,
+    ) => {
+      if (blob === heldChunk) await gate.promise;
+    }) as never);
+
+    h.recorders[0].emit(heldChunk, 0);
+    await settle();
+
+    const stopPromise = h.controller.stop();
+    await settle(10);
+
+    // /complete deletes chunk objects server-side; completing while a chunk
+    // PUT is still in flight would strand it.
+    expect(h.uploadApi.completeUpload).not.toHaveBeenCalled();
+
+    gate.resolve();
+    const result = await stopPromise;
+    expect(result.anyCompleted).toBe(true);
+    const completed = h.uploadApi.completeUpload.mock.calls.map(
+      (call) => call[1],
+    );
+    expect(completed).toContain("track-host-local-ch-1");
+    expect(completed).toContain("track-host-local-ch-2");
+  });
+
+  it("still finalizes the sibling when one recorder's stop() rejects", async () => {
+    const h = makeHarness();
+    await h.controller.start([slotSpec(1), slotSpec(2)], START_OPTS);
+    h.recorders[0].stopError = new Error("ch1 stop failed");
+
+    const result = await h.controller.stop();
+
+    // Ch 2 completed even though Ch 1's recorder died mid-stop.
+    expect(result).toEqual({ stopped: true, anyCompleted: true });
+    const completed = h.uploadApi.completeUpload.mock.calls.map(
+      (call) => call[1],
+    );
+    expect(completed).toEqual(["track-host-local-ch-2"]);
+    // Ch 1's backup is kept and marked failed for recovery.
+    expect(h.backupStore.markBackupFailed).toHaveBeenCalledWith(
+      "session-1:segment-host-local-ch-1",
+      expect.anything(),
+    );
+    expect(h.backupStore.clearBackup).toHaveBeenCalledTimes(1);
+    expect(h.backupStore.clearBackup).toHaveBeenCalledWith(
+      "session-1:segment-host-local-ch-2",
+      "verified-upload",
+    );
+  });
+
+  it("still completes the healthy channel when the other's final upload fails", async () => {
+    const h = makeHarness();
+    await h.controller.start([slotSpec(1), slotSpec(2)], START_OPTS);
+    h.uploadApi.getPresignedUploadUrl.mockImplementation((async (
+      _sessionId: string,
+      trackId: string,
+      partNumber: number,
+    ) => {
+      if (trackId === "track-host-local-ch-1" && partNumber === 9999) {
+        throw new Error("ch1 final upload failed");
+      }
+      h.log.push(`presignUrl:${trackId}:${partNumber}`);
+      return `https://s3.test/${trackId}/${partNumber}.webm`;
+    }) as never);
+
+    const result = await h.controller.stop();
+
+    expect(result.anyCompleted).toBe(true);
+    const completed = h.uploadApi.completeUpload.mock.calls.map(
+      (call) => call[1],
+    );
+    expect(completed).toContain("track-host-local-ch-2");
+    expect(completed).not.toContain("track-host-local-ch-1");
+    expect(h.backupStore.markBackupFailed).toHaveBeenCalledWith(
+      "session-1:segment-host-local-ch-1",
+      expect.anything(),
+    );
+  });
+
+  it("keeps a failed slot's backup surfaced even when the sibling clears afterwards", async () => {
+    const h = makeHarness();
+    await h.controller.start([slotSpec(1), slotSpec(2)], START_OPTS);
+
+    // Ch 1's final upload fails; Ch 2's verified-upload clear is held until
+    // Ch 1's failed manifest has already surfaced. The failed manifest must
+    // win over the sibling's later clear-to-null.
+    const ch1Failed = deferred<void>();
+    h.uploadApi.getPresignedUploadUrl.mockImplementation((async (
+      _sessionId: string,
+      trackId: string,
+      partNumber: number,
+    ) => {
+      if (trackId === "track-host-local-ch-1" && partNumber === 9999) {
+        throw new Error("ch1 final upload failed");
+      }
+      return `https://s3.test/${trackId}/${partNumber}.webm`;
+    }) as never);
+    h.backupStore.markBackupFailed.mockImplementation(async (id: string) => {
+      ch1Failed.resolve();
+      return manifest({ id, state: "failed" });
+    });
+    h.backupStore.clearBackup.mockImplementation(async (id: string) => {
+      await ch1Failed.promise;
+      h.log.push(`clearBackup:${id}`);
+    });
+
+    await h.controller.stop();
+
+    const lastRecovery = h.events.recovery.at(-1);
+    expect(lastRecovery?.state).toBe("failed");
+    expect(lastRecovery?.id).toBe("session-1:segment-host-local-ch-1");
+  });
+
+  it("keeps the backup when completeUpload fails", async () => {
+    const h = makeHarness();
+    await h.controller.start([primarySpec()], START_OPTS);
+    h.uploadApi.completeUpload.mockRejectedValueOnce(new Error("complete 500"));
+
+    const result = await h.controller.stop();
+
+    expect(result).toEqual({ stopped: true, anyCompleted: false });
+    expect(h.backupStore.clearBackup).not.toHaveBeenCalled();
+    expect(h.backupStore.markBackupFailed).toHaveBeenCalledWith(
+      "session-1:segment-primary",
+      expect.anything(),
+    );
+    expect(h.events.recovery.at(-1)?.state).toBe("failed");
+  });
+
+  it("surfaces a clear failure without dropping the manifest", async () => {
+    const h = makeHarness();
+    await h.controller.start([primarySpec()], START_OPTS);
+    h.backupStore.clearBackup.mockRejectedValueOnce(new Error("clear failed"));
+
+    const result = await h.controller.stop();
+
+    // The track itself completed; only the local cleanup failed.
+    expect(result).toEqual({ stopped: true, anyCompleted: true });
+    expect(h.events.errors.at(-1)).toBe("clear failed");
+    // The last surfaced manifest is still the available one, not null.
+    expect(h.events.recovery.at(-1)).not.toBeNull();
+  });
+
+  it("surfaces an upload error even when the slot never had a backup", async () => {
+    const h = makeHarness();
+    h.backupStore.startBackup.mockRejectedValueOnce(new Error("no storage"));
+    await h.controller.start([primarySpec()], START_OPTS);
+    h.uploadApi.completeUpload.mockRejectedValueOnce(new Error("complete 500"));
+
+    const result = await h.controller.stop();
+
+    expect(result.anyCompleted).toBe(false);
+    expect(h.backupStore.markBackupFailed).not.toHaveBeenCalled();
+    expect(h.events.errors.at(-1)).toBe("complete 500");
+  });
+
+  it("computes per-slot durations from recorder start to stop", async () => {
+    const h = makeHarness();
+    await h.controller.start([slotSpec(1), slotSpec(2)], START_OPTS);
+    h.advance(45_000);
+
+    await h.controller.stop();
+
+    for (const segment of [
+      "segment-host-local-ch-1",
+      "segment-host-local-ch-2",
+    ]) {
+      const call = h.backupStore.markBackupAvailable.mock.calls.find(
+        ([id]) => id === `session-1:${segment}`,
+      );
+      expect(call?.[1]).toBe(45_000);
+    }
+    for (const call of h.uploadApi.completeUpload.mock.calls) {
+      expect(call[2]).toBe(45_000);
+    }
+  });
+
+  it("emits timing events across the take", async () => {
+    const h = makeHarness();
+    await h.controller.start([primarySpec()], START_OPTS);
+    h.recorders[0].emit(new Blob(["chunk-a"], { type: "audio/webm" }), 0);
+    await settle();
+    await h.controller.stop();
+
+    const eventNames = h.events.timing.map((event) => event.event);
+    expect(eventNames).toContain("record-start");
+    expect(eventNames).toContain("chunk");
+    expect(eventNames).toContain("record-stop");
+  });
+
+  it("allows a fresh start after a completed stop", async () => {
+    const h = makeHarness();
+    await h.controller.start([primarySpec()], START_OPTS);
+    await h.controller.stop();
+
+    const again = await h.controller.start([primarySpec()], START_OPTS);
+
+    expect(again).toEqual({ ok: true });
+    expect(h.recorders).toHaveLength(2);
+    expect(h.tracker.reset).toHaveBeenCalledTimes(2);
+  });
+});

--- a/tests/track-materialization.test.ts
+++ b/tests/track-materialization.test.ts
@@ -195,6 +195,27 @@ describe("materializeTrack", () => {
     expect(mocks.remuxSegments).not.toHaveBeenCalled();
   });
 
+  it("marks the track failed when the lone segment completed without an uploaded artifact", async () => {
+    // A slot concluded after its recorder never started completes its segment
+    // with no recording.webm ever uploaded. The default segment shares the
+    // logical output key, so the no-copy fast path above would otherwise mark
+    // the track complete with a nonexistent artifact (phantom-complete).
+    seedTrack();
+    seedSegment({ id: "track-1", durationMs: null });
+    mocks.trackSegmentRecordingExists.mockResolvedValue(false);
+
+    const result = await materializeTrack("track-1", {
+      readObjectBytes: mocks.readObjectBytes,
+      writeObjectBytes: mocks.writeObjectBytes,
+      remuxSegments: mocks.remuxSegments,
+    });
+
+    expect(result).toMatchObject({ status: "failed" });
+    expect(mocks.tracks.get("track-1")).toMatchObject({ status: "failed" });
+    expect(mocks.writeObjectBytes).not.toHaveBeenCalled();
+    expect(mocks.remuxSegments).not.toHaveBeenCalled();
+  });
+
   it("remuxes multiple completed segments into the logical track artifact", async () => {
     seedTrack();
     seedSegment({ id: "track-1", segmentIndex: 0, durationMs: 1000 });

--- a/tests/upload-auth.test.ts
+++ b/tests/upload-auth.test.ts
@@ -205,6 +205,9 @@ vi.mock("@/lib/s3", () => ({
     segmentId === trackId
       ? `sessions/${sessionId}/tracks/${trackId}/recording.webm`
       : `sessions/${sessionId}/tracks/${trackId}/segments/${segmentId}/recording.webm`,
+  // These flows upload the final recording before completing, so the
+  // materialization artifact-existence check always sees it present.
+  trackSegmentRecordingExists: vi.fn(async () => true),
 }));
 
 vi.mock("@/lib/auth", async () => {


### PR DESCRIPTION
## Summary

Root-cause refactor for the divergence Codex kept finding on #159: the studio had two copies of the recording lifecycle (single-track and two-channel), and every review round caught the two-channel copy trailing the single-track copy at the next pipeline stage.

This PR extracts one reusable slot lifecycle — [src/lib/recording-lifecycle.ts](../blob/claude/unify-recording-lifecycle-60fd30/src/lib/recording-lifecycle.ts) — and drives **both** modes through it: single-track is the degenerate 1-slot case, two-channel passes 2 slots. The pipeline can no longer diverge between modes because there is only one of it.

**Stacked on #159** (base = `claude/youthful-cori-d500ee`); merging #159 will retarget this to `main` automatically.

## The controller

A plain, unit-testable object (not a hook — the slot meters' continuous rAF keeps React "busy," so `act(async)` hangs; a plain controller sidesteps that). Deps are constructor-injected: upload API, backup store, upload-progress tracker callbacks, recorder factory, clock. React surfacing goes through callbacks (`onRecoveryBackup` / `onBackupError` / `onBackupUnavailable` / `onTiming`).

Invariants it owns (distilled from all 4 review rounds):

1. **Per-channel independence** — recorder stops and slot finalization are `Promise.allSettled`; one channel's failure never aborts a sibling. *(absorbs round-4 finding a: `stopLocalSlots` used `Promise.all`)*
2. **Drain before complete** — every in-flight upload settles before any `completeUpload` (`/complete` deletes chunk objects).
3. **`markBackupAvailable(backupId, durationMs)` before the final upload** — recovered tracks retry with a correct duration. *(absorbs round-4 finding b: `finalizeSlot` skipped it)*
4. **Backup surfacing** — every backup state change projects into the recovery panel; per-slot state is aggregated so a failed slot's kept backup always beats a sibling's verified-upload clear.
5. **Partial-start rollback** — a failed multi-slot start stops and finalizes already-started slots; no server track is left recording.
6. **Full teardown on error paths** — the splitter/stream acquisition stays in the studio and still fails closed.
7. **Crash-safe backup order** — startBackup → saveChunk → markChunkUploaded/Failed → markBackupAvailable(duration) → clearBackup/markBackupFailed (two-channel previously skipped `markChunkFailed`).

The studio keeps orchestration: takes, control messages, confirmation scheduling, elapsed timer, preview quality, notifications, UI.

## Behavior notes

- **Single-track behavior is unchanged** (same broadcast reasons, same ordering, same backup semantics).
- Two-channel stays **host-only, off by default**; it gains the invariants above.
- Control-message start/stop are now mode-aware (previously hard-wired to the single-track path), so a remote stop can no longer strand active slot recorders while broadcasting `connected`.

## Testing

- New: `tests/recording-lifecycle.test.ts` — 25 unit tests on the controller covering all 7 invariants with fake deps (including both round-4 findings, the drain gate, rollback stages, and the failed-beats-clear aggregation race).
- Existing guardrails untouched and green: `studio-page`, `studio-two-channel`, `recording-backup`, `recovery`, `upload-auth`, `audio-splitter`.
- Full suite: **232 passed** (207 baseline + 25 new). Typecheck, lint, and `next build` clean.

Closes the refactor follow-up from #159 review rounds; part of #135.

🤖 Generated with [Claude Code](https://claude.com/claude-code)