### PR TITLE
Surface finalized sessions in the studio with a path to a new one

### DIFF
--- a/src/app/studio/[id]/page.tsx
+++ b/src/app/studio/[id]/page.tsx
@@ -72,6 +72,7 @@ import {
   smoothLevel,
 } from "@/lib/audio-meter";
 import { FinishRecordingButton } from "@/components/FinishRecordingButton";
+import { SessionFinalizedPanel } from "@/components/SessionFinalizedPanel";
 import { useUploadProgress } from "@/hooks/useUploadProgress";
 import { useNavigationGuard } from "@/hooks/useNavigationGuard";
 import { UploadProgressBar } from "@/components/UploadProgressBar";
@@ -701,6 +702,8 @@ function RoomContent({
   onMonitorEnabledChange,
   onMonitorVolumeChange,
   isHost,
+  sessionFinalized,
+  onSessionFinalized,
 }: {
   sessionId: string;
   participantName: string;
@@ -714,6 +717,8 @@ function RoomContent({
   onMonitorEnabledChange: (enabled: boolean) => void;
   onMonitorVolumeChange: (volume: number) => void;
   isHost: boolean;
+  sessionFinalized: boolean;
+  onSessionFinalized: () => void;
 }) {
   const remoteParticipants = useRemoteParticipants();
   const { localParticipant } = useLocalParticipant();
@@ -1807,6 +1812,10 @@ function RoomContent({
     ) {
       return;
     }
+    // A finalized session rejects every new take server-side (issue #151).
+    // The REC button is disabled in this state; this guards the
+    // programmatic/devtools path.
+    if (sessionFinalized) return;
 
     // In two-channel mode, refuse to start a take / broadcast to the room until
     // the split capture is proven ready — otherwise we'd blip remote
@@ -1839,9 +1848,14 @@ function RoomContent({
         console.error("Failed to activate recording take:", err);
         // A finalized session rejects new takes (issue #151). Surface the
         // server's explanation so the host knows to start a fresh session
-        // rather than seeing a generic failure.
+        // rather than seeing a generic failure, and flip the studio into its
+        // finalized state so the REC button locks and the start-a-new-session
+        // CTA appears instead of leaving a dead end.
         const finalized =
           err instanceof RecordingStateError && err.status === 409;
+        if (finalized) {
+          onSessionFinalized();
+        }
         showNotification(
           finalized && err.message
             ? err.message
@@ -1894,6 +1908,8 @@ function RoomContent({
     startRecordingLocal,
     twoChannelMode,
     showNotification,
+    sessionFinalized,
+    onSessionFinalized,
   ]);
 
   const handleStopRecording = useCallback(async () => {
@@ -2051,10 +2067,14 @@ function RoomContent({
   const isRecording = studioState === "recording";
   const isFinalizing = studioState === "finalizing";
   // In two-channel mode the host can't start until both split channels are
-  // captured; block the REC button so a click can't create a bad take.
+  // captured; block the REC button so a click can't create a bad take. A
+  // finalized session can never start again, but stop stays reachable in
+  // case the flag flips while a recording is somehow still live.
   const twoChannelNotReady =
     twoChannelMode && slotCaptures.length !== LOCAL_TRACK_SLOTS.length;
-  const startDisabled = isFinalizing || (!isRecording && twoChannelNotReady);
+  const startDisabled =
+    isFinalizing ||
+    (!isRecording && (twoChannelNotReady || sessionFinalized));
 
   const localStatus: Status = isFinalizing
     ? "uploading"
@@ -2311,13 +2331,25 @@ function RoomContent({
 
           {/* Finish recording (post-stop) — surfaces after the local recorder
               has produced at least one track and the studio is no longer in
-              the recording state. Drives the /api/sessions/:id/finalize flow. */}
+              the recording state. Drives the /api/sessions/:id/finalize flow.
+              Stays mounted after finalize so the ingest instructions remain
+              visible alongside the finalized panel below. */}
           {studioState === "connected" && hasRecorded && (
             <div className="flex justify-center mt-3">
               <FinishRecordingButton
                 sessionId={sessionId}
                 waitForUploads={uploadTracker.waitForUploads}
+                onReady={onSessionFinalized}
               />
+            </div>
+          )}
+
+          {/* A finalized session rejects all new takes (issue #151) — say so
+              and give the host a real path to a fresh session instead of a
+              REC button that can only 409. */}
+          {studioState === "connected" && sessionFinalized && (
+            <div className="flex justify-center mt-3">
+              <SessionFinalizedPanel isHost={isHost} />
             </div>
           )}
         </div>
@@ -2351,11 +2383,17 @@ function RoomContent({
                       ? "Finalizing previous recording"
                       : isRecording
                       ? "Stop recording"
+                      : sessionFinalized
+                      ? "Session finalized"
                       : "Start recording"
                   }
                   title={
                     isFinalizing
                       ? "Finalizing previous recording…"
+                      : isRecording
+                      ? undefined
+                      : sessionFinalized
+                      ? "Session finalized — start a new session to record again"
                       : twoChannelNotReady
                       ? "Waiting for two-channel capture…"
                       : undefined
@@ -2474,6 +2512,36 @@ export default function StudioPage() {
   // arriving via /join have their display name recorded in the cookie; we
   // use it to prefill the prejoin form.
   const [isHost, setIsHost] = useState(false);
+  // A finalized (status "ready") session can never be recorded into again
+  // (issue #151). Fetched on mount so a reopened studio URL knows right away,
+  // and flipped by RoomContent when finalize completes in this tab or the
+  // server rejects a take with the finalized 409.
+  const [sessionFinalized, setSessionFinalized] = useState(false);
+  const handleSessionFinalized = useCallback(() => {
+    setSessionFinalized(true);
+  }, []);
+
+  useEffect(() => {
+    let cancelled = false;
+    async function loadSessionStatus() {
+      try {
+        const res = await fetch(
+          `/api/sessions/${encodeURIComponent(sessionId)}`,
+        );
+        if (!res.ok) return;
+        const body: { status?: string } = await res.json();
+        if (!cancelled && body.status === "ready") {
+          setSessionFinalized(true);
+        }
+      } catch {
+        // Fail open — the server still rejects takes on finalized sessions.
+      }
+    }
+    void loadSessionStatus();
+    return () => {
+      cancelled = true;
+    };
+  }, [sessionId]);
 
   useEffect(() => {
     setMonitorEnabled(getStoredMonitorEnabled());
@@ -2653,6 +2721,14 @@ export default function StudioPage() {
               Session {sessionId.slice(0, 8)}…
             </p>
 
+            {/* Surface a finalized session before the user joins a room they
+                can't record into; hosts can hop to a fresh session from here. */}
+            {sessionFinalized && (
+              <div className="w-full mt-5 flex justify-center">
+                <SessionFinalizedPanel isHost={isHost} />
+              </div>
+            )}
+
             <div className="w-full mt-7 space-y-4">
               <div>
                 <label className="block font-sans text-[11px] font-medium text-text-3 uppercase tracking-[0.08em] mb-2">
@@ -2763,6 +2839,8 @@ export default function StudioPage() {
           onMonitorEnabledChange={setMonitorEnabled}
           onMonitorVolumeChange={setMonitorVolume}
           isHost={isHost}
+          sessionFinalized={sessionFinalized}
+          onSessionFinalized={handleSessionFinalized}
         />
       </LiveKitRoom>
     </StudioFrame>

--- a/src/components/SessionFinalizedPanel.tsx
+++ b/src/components/SessionFinalizedPanel.tsx
@@ -1,0 +1,74 @@
+"use client";
+
+import { useState } from "react";
+import { Button } from "@/components/ui/Button";
+
+/**
+ * Shown when the studio's session is finalized (status "ready"). A finalized
+ * session rejects every new take server-side (issue #151), so without this
+ * panel the studio is a dead end: the REC button can only 409 and the toast's
+ * "Start a new session" advice has no button to click. Hosts get a one-click
+ * create-and-go; guests are told to ask the host (only hosts can create
+ * sessions).
+ */
+export function SessionFinalizedPanel({ isHost }: { isHost: boolean }) {
+  const [creating, setCreating] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  async function handleStartNewSession() {
+    if (creating) return;
+    setCreating(true);
+    setError(null);
+    try {
+      const res = await fetch("/api/sessions", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          name: `Session ${new Date().toLocaleDateString()}`,
+        }),
+      });
+      if (!res.ok) throw new Error(`Failed to create session (HTTP ${res.status})`);
+      const session: { id: string } = await res.json();
+      // Full document navigation on purpose: pushing /studio/[newId] via the
+      // app router reuses this page instance (Next keeps dynamic-route pages
+      // mounted across param changes), which would carry the old LiveKit
+      // room, device streams, and recording state into the new session. A
+      // fresh load guarantees a clean studio.
+      window.location.assign(`/studio/${session.id}`);
+    } catch (err) {
+      console.error("Failed to create session:", err);
+      setError("Couldn't create a new session — try again.");
+      setCreating(false);
+    }
+  }
+
+  return (
+    <div
+      className="flex flex-col items-center gap-2.5 px-5 py-4 rounded-lg border text-center max-w-[360px]"
+      style={{ background: "var(--card)", borderColor: "var(--border)" }}
+    >
+      <p className="text-[13px] font-semibold text-text">Session finalized</p>
+      <p className="text-[12px] text-text-3 leading-relaxed">
+        This session can no longer be recorded into.
+        {isHost
+          ? " Start a new session to keep recording."
+          : " Ask the host to start a new session."}
+      </p>
+      {isHost && (
+        <Button
+          variant="primary"
+          size="md"
+          onClick={handleStartNewSession}
+          disabled={creating}
+        >
+          {creating ? "Creating…" : "Start a new session"}
+        </Button>
+      )}
+      {error && (
+        <p className="text-[12px]" style={{ color: "var(--rec)" }}>
+          {error}
+        </p>
+      )}
+    </div>
+  );
+}

--- a/tests/browser/recording-smoke.spec.ts
+++ b/tests/browser/recording-smoke.spec.ts
@@ -405,12 +405,16 @@ test("recovers an unfinished active take before finalizing", async ({ page }) =>
     db.track.count({ where: { sessionId } }),
     db.trackSegment.count({ where: { track: { sessionId } } }),
   ]);
-  await page.getByRole("button", { name: "Start recording" }).click();
-  await expect(
-    page.getByText(
-      "This session is finalized and can no longer be recorded into. Start a new session.",
-    ),
-  ).toBeVisible();
+  // Finalizing locks the studio in place: the REC button disables with an
+  // explanation and the panel offers a fresh session instead of a click that
+  // can only 409.
+  const recButton = page.getByRole("button", { name: "Session finalized" });
+  await expect(recButton).toBeVisible();
+  await expect(recButton).toBeDisabled();
+  const startNewSession = page.getByRole("button", {
+    name: "Start a new session",
+  });
+  await expect(startNewSession).toBeVisible();
   await page.waitForTimeout(500);
   await expect(
     Promise.all([
@@ -419,6 +423,23 @@ test("recovers an unfinished active take before finalizing", async ({ page }) =>
       db.trackSegment.count({ where: { track: { sessionId } } }),
     ]),
   ).resolves.toEqual(beforeRetry);
+
+  // The CTA creates a fresh session and lands the host on its prejoin.
+  await startNewSession.click();
+  await page.waitForURL(
+    (url) =>
+      url.pathname.startsWith("/studio/") && !url.pathname.includes(sessionId),
+    { timeout: 15_000 },
+  );
+  await expect(
+    page.getByRole("heading", { name: "Join Studio" }),
+  ).toBeVisible();
+  const newSessionId = new URL(page.url()).pathname.split("/").pop()!;
+  expect(newSessionId).not.toBe(sessionId);
+  const freshSession = await db.session.findUniqueOrThrow({
+    where: { id: newSessionId },
+  });
+  expect(freshSession.status).toBe("recording");
 });
 
 test("recovers a failed final upload from the local browser backup", async ({

--- a/tests/helpers/studio-page.ts
+++ b/tests/helpers/studio-page.ts
@@ -12,6 +12,12 @@ const studioPageHarness = vi.hoisted(() => ({
   route: {
     sessionId: "session-guest",
   },
+  // Route-specific bodies for the global fetch stub. `sessionResponse` is
+  // null by default so the stub can fall back to a fresh non-finalized
+  // session for whatever sessionId the test rendered with.
+  sessionResponse: null as { id: string; status: string } | null,
+  createSessionResponse: { id: "session-new" },
+  finalizeResponse: {} as Record<string, unknown>,
   getToken: vi.fn(async () => "livekit-token"),
   sendControlMessage: vi.fn(async (_message: { type: string }) => undefined),
   onControlMessage: vi.fn(() => vi.fn()),
@@ -50,6 +56,11 @@ const studioPageHarness = vi.hoisted(() => ({
     buildRecordingBlob: vi.fn(),
   },
 }));
+
+// Exposed so tests can configure route-level responses (e.g. a finalized
+// session) before rendering, including for the guest helper which doesn't
+// return the harness.
+export { studioPageHarness };
 
 vi.mock("next/navigation", () => ({
   useParams: () => ({ id: studioPageHarness.route.sessionId }),
@@ -94,12 +105,20 @@ vi.mock("@/lib/transport", () => {
   };
 });
 
-vi.mock("@/lib/recording-state", () => ({
-  startRecordingTake: studioPageHarness.startRecordingTake,
-  stopRecordingTake: studioPageHarness.stopRecordingTake,
-  reportRecordingTakeParticipantStatus:
-    studioPageHarness.reportRecordingTakeParticipantStatus,
-}));
+vi.mock("@/lib/recording-state", async (importOriginal) => {
+  // Keep the real RecordingStateError class so `err instanceof
+  // RecordingStateError` in the studio page works against errors that tests
+  // construct via the same import.
+  const actual =
+    await importOriginal<typeof import("@/lib/recording-state")>();
+  return {
+    RecordingStateError: actual.RecordingStateError,
+    startRecordingTake: studioPageHarness.startRecordingTake,
+    stopRecordingTake: studioPageHarness.stopRecordingTake,
+    reportRecordingTakeParticipantStatus:
+      studioPageHarness.reportRecordingTakeParticipantStatus,
+  };
+});
 
 vi.mock("@/lib/upload", () => ({
   getPresignedUploadTarget: studioPageHarness.getPresignedUploadTarget,
@@ -296,10 +315,41 @@ beforeEach(() => {
     dispose: studioPageHarness.splitterDispose,
   }));
 
+  studioPageHarness.sessionResponse = null;
+  studioPageHarness.createSessionResponse = { id: "session-new" };
+  studioPageHarness.finalizeResponse = {};
+
   vi.stubGlobal("AudioContext", FakeAudioContext);
   vi.stubGlobal(
     "fetch",
-    vi.fn(async () => Response.json(studioPageHarness.authMeResponse)),
+    vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url =
+        typeof input === "string"
+          ? input
+          : input instanceof URL
+            ? input.toString()
+            : input.url;
+      const path = url.split("?")[0];
+
+      if (path === "/api/sessions" && init?.method === "POST") {
+        return Response.json(studioPageHarness.createSessionResponse, {
+          status: 201,
+        });
+      }
+      if (/^\/api\/sessions\/[^/]+\/finalize$/.test(path)) {
+        return Response.json(studioPageHarness.finalizeResponse);
+      }
+      if (/^\/api\/sessions\/[^/]+$/.test(path)) {
+        return Response.json(
+          studioPageHarness.sessionResponse ?? {
+            id: studioPageHarness.route.sessionId,
+            status: "recording",
+          },
+        );
+      }
+      // Everything else (notably /api/auth/me) keeps the original behavior.
+      return Response.json(studioPageHarness.authMeResponse);
+    }),
   );
   vi.stubGlobal("localStorage", {
     getItem: vi.fn(() => null),

--- a/tests/studio-finalized-session.test.ts
+++ b/tests/studio-finalized-session.test.ts
@@ -1,0 +1,159 @@
+import { fireEvent, waitFor } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { RecordingStateError } from "@/lib/recording-state";
+import {
+  renderGuestStudioPage,
+  renderHostStudioPage,
+  studioPageHarness,
+} from "./helpers/studio-page";
+
+// A finalized session must never dead-end the studio: the REC button is
+// guaranteed to 409 server-side (issue #151), so the page has to surface the
+// finalized state and hand the host a real path to a fresh session.
+describe("StudioPage finalized session", () => {
+  it("shows the finalized notice on prejoin and disables recording after join when the session is already finalized", async () => {
+    studioPageHarness.sessionResponse = {
+      id: "session-host",
+      status: "ready",
+    };
+
+    const studio = renderHostStudioPage();
+
+    // Prejoin: the mount-time status fetch surfaces the notice + host CTA
+    // before the user pays the cost of joining a dead room.
+    await studio.screen.findByText("Session finalized");
+    expect(
+      studio.screen.getByRole("button", { name: "Start a new session" }),
+    ).toBeTruthy();
+
+    await studio.join();
+
+    const recButton = await studio.screen.findByRole("button", {
+      name: "Session finalized",
+    });
+    expect((recButton as HTMLButtonElement).disabled).toBe(true);
+    expect(
+      studio.screen.getByRole("button", { name: "Start a new session" }),
+    ).toBeTruthy();
+  });
+
+  it("flips into the finalized state when starting a take is rejected with a finalized 409", async () => {
+    const studio = renderHostStudioPage();
+    await studio.join();
+
+    expect(
+      studio.screen.queryByRole("button", { name: "Start a new session" }),
+    ).toBeNull();
+
+    studio.harness.startRecordingTake.mockRejectedValueOnce(
+      new RecordingStateError(
+        "This session is finalized and can no longer be recorded into. Start a new session.",
+        409,
+      ),
+    );
+
+    fireEvent.click(
+      studio.screen.getByRole("button", { name: "Start recording" }),
+    );
+
+    await studio.screen.findByRole("button", { name: "Start a new session" });
+    const recButton = studio.screen.getByRole("button", {
+      name: "Session finalized",
+    });
+    expect((recButton as HTMLButtonElement).disabled).toBe(true);
+  });
+
+  it("does not treat a generic start failure as a finalized session", async () => {
+    const studio = renderHostStudioPage();
+    await studio.join();
+
+    studio.harness.startRecordingTake.mockRejectedValueOnce(
+      new Error("network blip"),
+    );
+
+    fireEvent.click(
+      studio.screen.getByRole("button", { name: "Start recording" }),
+    );
+
+    await studio.screen.findByText("Couldn't update recording state");
+    expect(
+      studio.screen.queryByRole("button", { name: "Start a new session" }),
+    ).toBeNull();
+    const recButton = studio.screen.getByRole("button", {
+      name: "Start recording",
+    });
+    expect((recButton as HTMLButtonElement).disabled).toBe(false);
+  });
+
+  it("surfaces the start-a-new-session CTA after finishing a recording", async () => {
+    const studio = renderHostStudioPage();
+    await studio.join();
+
+    fireEvent.click(
+      studio.screen.getByRole("button", { name: "Start recording" }),
+    );
+    await studio.screen.findByRole("button", { name: "Stop recording" });
+    fireEvent.click(
+      studio.screen.getByRole("button", { name: "Stop recording" }),
+    );
+
+    fireEvent.click(
+      await studio.screen.findByRole("button", { name: "Finish recording" }),
+    );
+    await studio.screen.findByText("Ready for ingest");
+
+    // The ingest instructions stay visible; the finalized CTA appears
+    // alongside them and the REC button locks.
+    await studio.screen.findByRole("button", { name: "Start a new session" });
+    const recButton = studio.screen.getByRole("button", {
+      name: "Session finalized",
+    });
+    expect((recButton as HTMLButtonElement).disabled).toBe(true);
+  });
+
+  it("creates a fresh session and navigates to it from the CTA", async () => {
+    studioPageHarness.sessionResponse = {
+      id: "session-host",
+      status: "ready",
+    };
+    studioPageHarness.createSessionResponse = { id: "session-fresh" };
+
+    const studio = renderHostStudioPage();
+    const cta = await studio.screen.findByRole("button", {
+      name: "Start a new session",
+    });
+
+    const assign = vi.fn();
+    Object.defineProperty(window.location, "assign", {
+      configurable: true,
+      value: assign,
+    });
+
+    fireEvent.click(cta);
+
+    await waitFor(() => {
+      expect(assign).toHaveBeenCalledWith("/studio/session-fresh");
+    });
+    const fetchMock = window.fetch as ReturnType<typeof vi.fn>;
+    const createCall = fetchMock.mock.calls.find(
+      ([input, init]) =>
+        input === "/api/sessions" &&
+        (init as RequestInit | undefined)?.method === "POST",
+    );
+    expect(createCall).toBeTruthy();
+  });
+
+  it("shows the finalized notice to guests without the create CTA", async () => {
+    studioPageHarness.sessionResponse = {
+      id: "session-guest",
+      status: "ready",
+    };
+
+    const studio = renderGuestStudioPage();
+
+    await studio.screen.findByText("Session finalized");
+    expect(
+      studio.screen.queryByRole("button", { name: "Start a new session" }),
+    ).toBeNull();
+  });
+});


### PR DESCRIPTION
## Problem

After finishing a recording, pressing REC in the studio fails with `409 Conflict` — `RecordingStateError: This session is finalized and can no longer be recorded into. Start a new session.` The server is behaving as designed (the #151 finalize guard), but the studio page never learns the session is finalized:

- After "Finish recording" completes, `studioState` stays `connected` and the REC button re-enables — every visible record affordance leads straight into the 409.
- `FinishRecordingButton` has an `onReady` callback built for this transition, but the studio rendered it without one.
- The page never fetched `session.status`, so reopening a finalized session's studio URL was the same trap.
- The toast says "Start a new session," but the studio had no such button and no navigation at all.

## Fix

The studio now tracks a `sessionFinalized` flag fed from three sources:
1. a mount-time fetch of `GET /api/sessions/:id` status (covers reopened URLs, including at prejoin),
2. `FinishRecordingButton`'s `onReady` (covers finishing in this tab),
3. the finalized-409 catch in `handleStartRecording` (covers finalize racing from elsewhere, e.g. a stale tab).

When set, the REC button disables in place (relabeled "Session finalized") and a new `SessionFinalizedPanel` renders on both the prejoin screen and in-studio: it explains the state and gives hosts a one-click **Start a new session** (POST `/api/sessions` + navigate). Guests see the notice without the CTA. The navigation is a full document load on purpose — an app-router push between `/studio/[id]` params reuses the mounted page and would carry the old LiveKit room and recording state into the new session.

## Tests

- New `tests/studio-finalized-session.test.ts` (6 tests, written first per TDD): prejoin notice + disabled REC for a finalized session, 409 flips the state, generic failures don't, finish flow surfaces the CTA, CTA creates + navigates, guest sees notice without CTA.
- Harness changes are additive only: URL-routed fetch stub (old behavior preserved as fallback), real `RecordingStateError` re-exported from the mock.
- Browser smoke: the tail of `recovers an unfinished active take before finalizing` asserted the old dead end (click REC → 409 toast); with sign-off it now asserts the locked button + unchanged DB row counts, then drives the CTA through to a fresh session's prejoin. All 5 browser tests pass against the full local stack.
- `npm test` 261 passed · `tsc --noEmit` clean · `next lint` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)