### PR TITLE
Co-host departure notifications + exit-guard fix for unconfirmed uploads

### DIFF
--- a/src/app/studio/[id]/page.tsx
+++ b/src/app/studio/[id]/page.tsx
@@ -151,6 +151,11 @@ function formatParticipantList(names: string[]): string {
   return `${names.slice(0, -1).join(", ")}, and ${names[names.length - 1]}`;
 }
 
+function departureBannerMessage(names: string[]): string {
+  const tracks = names.length === 1 ? "their track" : "their tracks";
+  return `${formatParticipantList(names)} left during recording — ${tracks} may be incomplete.`;
+}
+
 function displayNameFromMetadata(metadata: string | undefined): string | undefined {
   return parseParticipantMetadata(metadata)?.displayName;
 }
@@ -890,6 +895,80 @@ function RoomContent({
       if (notificationTimerRef.current) clearTimeout(notificationTimerRef.current);
     };
   }, []);
+
+  // ---- Participant presence (departures / rejoins) ----
+  //
+  // LiveKit absorbs brief network blips server-side before dropping someone
+  // from `remoteParticipants`, so a disappearance here means they genuinely
+  // left the room. Departures outside a take get a transient toast; mid-take
+  // departures get the persistent banner below (their track is at risk).
+  // Names are captured at departure time because the participant — and their
+  // display name — is gone from the room afterwards.
+  //
+  // `departedParticipants` accumulates for the finalize flow: a finalize poll
+  // stuck on a departed participant's track should say "left the session",
+  // not "still uploading". A rejoin removes them again.
+  const [departedParticipants, setDepartedParticipants] = useState<
+    Map<string, string>
+  >(new Map());
+  const departedParticipantsRef = useRef<Map<string, string>>(new Map());
+  const [midRecordingDepartures, setMidRecordingDepartures] = useState<
+    Map<string, string>
+  >(new Map());
+  // Null until the first observation so the initial roster (everyone already
+  // in the room when we join) never reads as a wave of rejoins.
+  const prevRemoteParticipantsRef = useRef<Map<string, string> | null>(null);
+
+  useEffect(() => {
+    const current = new Map<string, string>();
+    for (const participant of remoteParticipants) {
+      current.set(
+        participant.identity,
+        remoteParticipantNames.get(participant.identity) ??
+          participant.identity,
+      );
+    }
+    const prev = prevRemoteParticipantsRef.current;
+    prevRemoteParticipantsRef.current = current;
+    if (prev === null) return;
+
+    for (const [identity, name] of prev) {
+      if (current.has(identity)) continue;
+      const departed = new Map(departedParticipantsRef.current);
+      departed.set(identity, name);
+      departedParticipantsRef.current = departed;
+      setDepartedParticipants(departed);
+      if (studioStateRef.current === "recording") {
+        setMidRecordingDepartures((m) => new Map(m).set(identity, name));
+      } else {
+        showNotification(`${name} left the session`);
+      }
+    }
+
+    for (const [identity, name] of current) {
+      if (prev.has(identity)) continue;
+      if (!departedParticipantsRef.current.has(identity)) continue;
+      const departed = new Map(departedParticipantsRef.current);
+      departed.delete(identity);
+      departedParticipantsRef.current = departed;
+      setDepartedParticipants(departed);
+      setMidRecordingDepartures((m) => {
+        if (!m.has(identity)) return m;
+        const next = new Map(m);
+        next.delete(identity);
+        return next;
+      });
+      showNotification(`${name} rejoined`);
+    }
+  }, [remoteParticipants, remoteParticipantNames, showNotification]);
+
+  // The banner warns about the take in progress; once that take stops the
+  // finalize flow owns the messaging (via departedParticipants above).
+  useEffect(() => {
+    if (studioState !== "recording") {
+      setMidRecordingDepartures((m) => (m.size === 0 ? m : new Map()));
+    }
+  }, [studioState]);
 
   useEffect(() => {
     let cancelled = false;
@@ -2006,18 +2085,32 @@ function RoomContent({
   ]);
 
 
-  // Block accidental navigation while recording, finalizing, or uploading.
-  // Covers tab close (beforeunload), browser back/forward (popstate), in-app
-  // <a>/Link clicks, and form submits (e.g. the topbar sign-out POST). See
-  // #73 for the live-test repro and #49 for the original tab-close warning
-  // this supersedes.
+  // A slot whose upload never confirmed always surfaces as a recoverable
+  // backup manifest or a backup error (see handleSlotFailure in
+  // recording-lifecycle) — so this doubles as "my audio isn't safely on the
+  // server yet". Derived from surfaced state rather than a flag so it also
+  // covers unrecovered audio found on mount after a crash.
+  const hasUnconfirmedUpload =
+    Boolean(backupError) || isRecoverableBackup(recoveryBackup);
+
+  // Block accidental navigation while recording, finalizing, uploading, or
+  // sitting on audio that never confirmed upload. Covers tab close
+  // (beforeunload), browser back/forward (popstate), in-app <a>/Link clicks,
+  // and form submits (e.g. the topbar sign-out POST). See #73 for the
+  // live-test repro and #49 for the original tab-close warning this
+  // supersedes. A failed upload settles the in-flight count, so
+  // hasInflight alone would disarm exactly when leaving loses audio —
+  // hasUnconfirmedUpload keeps the guard up until the server confirms.
   useNavigationGuard({
     when:
       studioState === "recording" ||
       studioState === "finalizing" ||
-      uploadTracker.hasInflight,
+      uploadTracker.hasInflight ||
+      hasUnconfirmedUpload,
     message:
-      "Recording is in progress and may be lost if you leave. Leave anyway?",
+      studioState === "recording"
+        ? "Recording is in progress and may be lost if you leave. Leave anyway?"
+        : "Your audio hasn't finished uploading and may be lost if you leave. Leave anyway?",
   });
 
   useEffect(() => {
@@ -2148,6 +2241,32 @@ function RoomContent({
           </span>
           <button
             onClick={() => setBannerDismissed(true)}
+            className="text-[11px] text-warn/70 hover:text-warn underline font-sans"
+          >
+            dismiss
+          </button>
+        </div>
+      )}
+
+      {/* Mid-recording departure banner — a departed participant's track may
+          be incomplete, which is consequential enough to outlast a 4s toast.
+          Cleared on dismiss, on rejoin, or when the take stops. */}
+      {midRecordingDepartures.size > 0 && (
+        <div
+          className="flex items-center gap-2.5 py-2.5 px-5 border-b"
+          style={{
+            background: "rgba(232,168,48,0.07)",
+            borderBottomColor: "rgba(232,168,48,0.18)",
+          }}
+        >
+          <IcoAlert size={14} color="var(--warn)" />
+          <span className="text-[12px] text-warn flex-1">
+            {departureBannerMessage(
+              Array.from(midRecordingDepartures.values()),
+            )}
+          </span>
+          <button
+            onClick={() => setMidRecordingDepartures(new Map())}
             className="text-[11px] text-warn/70 hover:text-warn underline font-sans"
           >
             dismiss
@@ -2317,6 +2436,9 @@ function RoomContent({
               <FinishRecordingButton
                 sessionId={sessionId}
                 waitForUploads={uploadTracker.waitForUploads}
+                departedParticipantNames={Array.from(
+                  departedParticipants.values(),
+                )}
               />
             </div>
           )}
@@ -2448,6 +2570,22 @@ function RoomContent({
             progress={uploadTracker.progress}
             recordingStopped={studioState !== "recording"}
           />
+          {/* Positive all-clear: guests otherwise have to guess when leaving
+              stops risking their track. Host wording drops the close-tab cue —
+              their next step is finalizing, not leaving. */}
+          {hasRecorded &&
+            studioState === "connected" &&
+            !uploadTracker.hasInflight &&
+            !hasUnconfirmedUpload && (
+              <span
+                className="font-sans text-[10px] text-center px-1 pt-2 max-w-[110px] leading-tight"
+                style={{ color: "var(--ok)" }}
+              >
+                {isHost
+                  ? "All audio uploaded"
+                  : "All audio uploaded — safe to close this tab"}
+              </span>
+            )}
         </div>
       </div>
     </div>

--- a/src/components/FinishRecordingButton.tsx
+++ b/src/components/FinishRecordingButton.tsx
@@ -13,7 +13,7 @@ type FinishState =
   | { kind: "polling"; pendingName?: string }
   | { kind: "active_take"; activeTake: ActiveTake; message: string }
   | { kind: "ready" }
-  | { kind: "timeout" }
+  | { kind: "timeout"; pendingName?: string }
   | { kind: "error"; message: string };
 
 interface PendingTrack {
@@ -29,10 +29,19 @@ export function FinishRecordingButton({
   sessionId,
   waitForUploads,
   onReady,
+  departedParticipantNames,
 }: {
   sessionId: string;
   waitForUploads: () => Promise<void>;
   onReady?: () => void;
+  /**
+   * Display names of participants who left the studio while this page was
+   * open. Best-effort, client-side knowledge: it exists so a finalize blocked
+   * on a departed participant's track says "Bob left" instead of implying the
+   * upload is still progressing. Lost on refresh; superseded once the server
+   * tracks abandoned takes itself (#154).
+   */
+  departedParticipantNames?: string[];
 }) {
   const [state, setState] = useState<FinishState>({ kind: "idle" });
   const [copied, setCopied] = useState(false);
@@ -71,6 +80,8 @@ export function FinishRecordingButton({
     if (controller.signal.aborted || !isMountedRef.current) return;
 
     const deadline = Date.now() + POLL_TIMEOUT_MS;
+    // Carried into the timeout state so it can name who the poll was stuck on.
+    let lastPendingName: string | undefined;
 
     while (Date.now() <= deadline) {
       if (controller.signal.aborted || !isMountedRef.current) return;
@@ -121,6 +132,7 @@ export function FinishRecordingButton({
           });
           return;
         }
+        lastPendingName = pendingName ?? lastPendingName;
         safeSetState({ kind: "polling", pendingName });
         await sleep(POLL_INTERVAL_MS, controller.signal);
         continue;
@@ -131,7 +143,7 @@ export function FinishRecordingButton({
       return;
     }
 
-    safeSetState({ kind: "timeout" });
+    safeSetState({ kind: "timeout", pendingName: lastPendingName });
   }, [sessionId, waitForUploads, onReady, safeSetState]);
 
   const recoverActiveTake = useCallback(async () => {
@@ -193,10 +205,15 @@ export function FinishRecordingButton({
   }
 
   if (state.kind === "timeout") {
+    const departed =
+      state.pendingName !== undefined &&
+      departedParticipantNames?.includes(state.pendingName);
     return (
       <div className="flex flex-col items-center gap-3 p-4 rounded-xl bg-cozy-900 border border-yellow-700">
         <p className="text-yellow-400 text-sm text-center">
-          Some tracks haven&apos;t uploaded yet — check your network and retry.
+          {departed
+            ? `${state.pendingName} left before their track finished uploading — retry to recover what they already uploaded.`
+            : "Some tracks haven't uploaded yet — check your network and retry."}
         </p>
         <button
           onClick={runFinalize}
@@ -240,9 +257,14 @@ export function FinishRecordingButton({
   }
 
   if (state.kind === "polling") {
-    const label = state.pendingName
-      ? `Still uploading track: ${state.pendingName}…`
-      : "Finalizing…";
+    const departed =
+      state.pendingName !== undefined &&
+      departedParticipantNames?.includes(state.pendingName);
+    const label = departed
+      ? `${state.pendingName} left the session — recovering their uploaded audio…`
+      : state.pendingName
+        ? `Still uploading track: ${state.pendingName}…`
+        : "Finalizing…";
     return (
       <div className="flex flex-col items-center gap-2 p-4 rounded-xl bg-cozy-900 border border-cozy-700">
         <p className="text-gray-300 text-sm animate-pulse">{label}</p>

--- a/tests/finish-recording-button.test.ts
+++ b/tests/finish-recording-button.test.ts
@@ -37,11 +37,12 @@ afterEach(() => {
   vi.unstubAllGlobals();
 });
 
-function renderButton() {
+function renderButton(props: { departedParticipantNames?: string[] } = {}) {
   render(
     React.createElement(FinishRecordingButton, {
       sessionId: "session-1",
       waitForUploads: async () => undefined,
+      ...props,
     }),
   );
 }
@@ -109,5 +110,83 @@ describe("FinishRecordingButton unfinished-take recovery", () => {
     });
     await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(2));
     expect(screen.getByText("Ready for ingest")).toBeTruthy();
+  });
+});
+
+describe("FinishRecordingButton departed participants", () => {
+  function pendingResponse(participantName: string): Response {
+    return response(
+      {
+        pending: [
+          { trackId: "track-9", participantName, status: "uploading" },
+        ],
+      },
+      409,
+    );
+  }
+
+  it("names the departed participant while their track blocks finalize", async () => {
+    fetchMock.mockResolvedValue(pendingResponse("Bob"));
+    renderButton({ departedParticipantNames: ["Bob"] });
+
+    fireEvent.click(screen.getByRole("button", { name: "Finish recording" }));
+
+    expect(
+      await screen.findByText(
+        "Bob left the session — recovering their uploaded audio…",
+      ),
+    ).toBeTruthy();
+  });
+
+  it("keeps the plain uploading label for participants still present", async () => {
+    fetchMock.mockResolvedValue(pendingResponse("Alice"));
+    renderButton({ departedParticipantNames: ["Bob"] });
+
+    fireEvent.click(screen.getByRole("button", { name: "Finish recording" }));
+
+    expect(
+      await screen.findByText("Still uploading track: Alice…"),
+    ).toBeTruthy();
+  });
+
+  it("explains a departed participant's stuck track when polling times out", async () => {
+    vi.useFakeTimers();
+    try {
+      fetchMock.mockResolvedValue(pendingResponse("Bob"));
+      renderButton({ departedParticipantNames: ["Bob"] });
+
+      fireEvent.click(screen.getByRole("button", { name: "Finish recording" }));
+
+      await vi.advanceTimersByTimeAsync(31_000);
+
+      expect(
+        screen.getByText(
+          "Bob left before their track finished uploading — retry to recover what they already uploaded.",
+        ),
+      ).toBeTruthy();
+      expect(screen.getByRole("button", { name: "Retry" })).toBeTruthy();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("keeps the generic timeout message when the stuck participant is still present", async () => {
+    vi.useFakeTimers();
+    try {
+      fetchMock.mockResolvedValue(pendingResponse("Alice"));
+      renderButton({ departedParticipantNames: ["Bob"] });
+
+      fireEvent.click(screen.getByRole("button", { name: "Finish recording" }));
+
+      await vi.advanceTimersByTimeAsync(31_000);
+
+      expect(
+        screen.getByText(
+          "Some tracks haven't uploaded yet — check your network and retry.",
+        ),
+      ).toBeTruthy();
+    } finally {
+      vi.useRealTimers();
+    }
   });
 });

--- a/tests/helpers/studio-page.ts
+++ b/tests/helpers/studio-page.ts
@@ -7,11 +7,30 @@ type AuthMeResponse =
   | { role: "guest"; name: string }
   | { role: "host" };
 
+export type RemoteParticipantStub = {
+  identity: string;
+  name?: string;
+  metadata?: string;
+};
+
 const studioPageHarness = vi.hoisted(() => ({
   authMeResponse: { role: "guest", name: "Guest Alice" } as AuthMeResponse,
   route: {
     sessionId: "session-guest",
   },
+  // Backing store for the useRemoteParticipants mock. Tests mutate it through
+  // setRemoteParticipants (wrapped in act) — the listeners let the mocked hook
+  // re-render subscribers exactly like the real LiveKit hook would.
+  remoteParticipants: [] as Array<{
+    identity: string;
+    name?: string;
+    metadata?: string;
+  }>,
+  remoteParticipantsListeners: new Set<() => void>(),
+  // Result of the mocked isHostSender — tests that drive guest recording via
+  // control messages flip this to true so the page honors the host's message.
+  isHostSenderResult: false,
+  navigationGuard: vi.fn(),
   getToken: vi.fn(async () => "livekit-token"),
   sendControlMessage: vi.fn(async (_message: { type: string }) => undefined),
   onControlMessage: vi.fn(() => vi.fn()),
@@ -61,8 +80,9 @@ vi.mock("@livekit/components-react", () => {
   // mocked module first loads). The real LiveKit hooks memoize these, and
   // studio effects depend on them — returning fresh objects/arrays each render
   // turns those effects into re-render loops once any synchronous setState
-  // fires.
-  const remoteParticipants: unknown[] = [];
+  // fires. useRemoteParticipants reads the harness store through
+  // useSyncExternalStore: the snapshot is the same array reference until a
+  // test replaces it via setRemoteParticipants, so it stays just as stable.
   const localParticipant = {
     localParticipant: {
       republishAllTracks: studioPageHarness.republishAllTracks,
@@ -72,7 +92,16 @@ vi.mock("@livekit/components-react", () => {
     LiveKitRoom: ({ children }: { children: ReactNode }) =>
       React.createElement("div", { "data-testid": "livekit-room" }, children),
     RoomAudioRenderer: () => null,
-    useRemoteParticipants: () => remoteParticipants,
+    useRemoteParticipants: () =>
+      React.useSyncExternalStore(
+        (listener) => {
+          studioPageHarness.remoteParticipantsListeners.add(listener);
+          return () => {
+            studioPageHarness.remoteParticipantsListeners.delete(listener);
+          };
+        },
+        () => studioPageHarness.remoteParticipants,
+      ),
     useLocalParticipant: () => localParticipant,
   };
 });
@@ -89,7 +118,7 @@ vi.mock("@/lib/transport", () => {
   };
   return {
     useTransport: () => transport,
-    isHostSender: () => false,
+    isHostSender: () => studioPageHarness.isHostSenderResult,
     parseParticipantMetadata: () => null,
   };
 });
@@ -174,7 +203,8 @@ vi.mock("@/hooks/useTimingDiagnostics", () => ({
 }));
 
 vi.mock("@/hooks/useNavigationGuard", () => ({
-  useNavigationGuard: vi.fn(),
+  useNavigationGuard: (options: { when: boolean; message: string }) =>
+    studioPageHarness.navigationGuard(options),
 }));
 
 function mediaStream(): MediaStream {
@@ -225,6 +255,10 @@ function audioInput(deviceId: string, label: string): MediaDeviceInfo {
 beforeEach(() => {
   studioPageHarness.authMeResponse = { role: "guest", name: "Guest Alice" };
   studioPageHarness.route.sessionId = "session-guest";
+  studioPageHarness.remoteParticipants = [];
+  studioPageHarness.remoteParticipantsListeners.clear();
+  studioPageHarness.isHostSenderResult = false;
+  studioPageHarness.navigationGuard.mockClear();
   studioPageHarness.getToken.mockClear();
   studioPageHarness.sendControlMessage.mockReset().mockResolvedValue(undefined);
   studioPageHarness.onControlMessage.mockReset().mockReturnValue(vi.fn());
@@ -322,6 +356,20 @@ afterEach(() => {
   vi.unstubAllGlobals();
 });
 
+/**
+ * Replace the mocked room's remote participant list and notify the
+ * useRemoteParticipants subscribers, mirroring a LiveKit join/leave. Call
+ * inside act(): `act(() => setRemoteParticipants([...]))`.
+ */
+export function setRemoteParticipants(
+  participants: RemoteParticipantStub[],
+): void {
+  studioPageHarness.remoteParticipants = participants;
+  for (const listener of studioPageHarness.remoteParticipantsListeners) {
+    listener();
+  }
+}
+
 export function renderGuestStudioPage({
   name = "Guest Alice",
   sessionId = "session-guest",
@@ -351,6 +399,7 @@ export function renderGuestStudioPage({
       });
     },
     screen,
+    harness: studioPageHarness,
   };
 }
 

--- a/tests/studio-exit-guard.test.ts
+++ b/tests/studio-exit-guard.test.ts
@@ -1,0 +1,130 @@
+import { fireEvent, waitFor } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import {
+  renderGuestStudioPage,
+  renderHostStudioPage,
+} from "./helpers/studio-page";
+
+const RECORDING_MESSAGE =
+  "Recording is in progress and may be lost if you leave. Leave anyway?";
+const UPLOADING_MESSAGE =
+  "Your audio hasn't finished uploading and may be lost if you leave. Leave anyway?";
+
+function lastGuardCall(harness: {
+  navigationGuard: { mock: { calls: unknown[][] } };
+}): { when: boolean; message: string } {
+  const calls = harness.navigationGuard.mock.calls;
+  return calls[calls.length - 1][0] as { when: boolean; message: string };
+}
+
+describe("StudioPage exit guard", () => {
+  it("uses the recording wording while a take is active", async () => {
+    const studio = renderHostStudioPage();
+    await studio.join();
+
+    fireEvent.click(
+      studio.screen.getByRole("button", { name: "Start recording" }),
+    );
+    await studio.screen.findByRole("button", { name: "Stop recording" });
+
+    const guard = lastGuardCall(studio.harness);
+    expect(guard.when).toBe(true);
+    expect(guard.message).toBe(RECORDING_MESSAGE);
+  });
+
+  it("disarms after a clean stop and shows the all-clear", async () => {
+    const studio = renderHostStudioPage();
+    await studio.join();
+
+    fireEvent.click(
+      studio.screen.getByRole("button", { name: "Start recording" }),
+    );
+    await studio.screen.findByRole("button", { name: "Stop recording" });
+    fireEvent.click(
+      studio.screen.getByRole("button", { name: "Stop recording" }),
+    );
+    await studio.screen.findByRole("button", { name: "Start recording" });
+
+    expect(await studio.screen.findByText("All audio uploaded")).toBeTruthy();
+    const guard = lastGuardCall(studio.harness);
+    expect(guard.when).toBe(false);
+  });
+
+  it("stays armed with upload wording when a track fails to complete", async () => {
+    const studio = renderHostStudioPage();
+    await studio.join();
+
+    fireEvent.click(
+      studio.screen.getByRole("button", { name: "Start recording" }),
+    );
+    await studio.screen.findByRole("button", { name: "Stop recording" });
+
+    // Fail the server-side completion: the slot never confirms, the lifecycle
+    // keeps the local backup (marked failed), and the page must keep the exit
+    // guard armed off that surfaced state.
+    studio.harness.completeUpload.mockRejectedValue(
+      new Error("complete failed"),
+    );
+    studio.harness.recordingBackupStore.markBackupFailed.mockResolvedValue({
+      id: "session-host:track-1",
+      sessionId: "session-host",
+      trackId: "track-1",
+      segmentId: "segment-1",
+      participantName: "Pasha",
+      state: "failed",
+      chunks: [{ index: 0, byteSize: 5, uploadStatus: "failed" }],
+    });
+
+    fireEvent.click(
+      studio.screen.getByRole("button", { name: "Stop recording" }),
+    );
+    await studio.screen.findByRole("button", { name: "Start recording" });
+
+    await waitFor(() => {
+      const guard = lastGuardCall(studio.harness);
+      expect(guard.when).toBe(true);
+      expect(guard.message).toBe(UPLOADING_MESSAGE);
+    });
+    expect(studio.screen.queryByText("All audio uploaded")).toBeNull();
+  });
+
+  it("tells guests it is safe to close the tab once uploads confirm", async () => {
+    const studio = renderGuestStudioPage();
+    await studio.join();
+
+    studio.harness.isHostSenderResult = true;
+    const handlers = (
+      studio.harness.onControlMessage.mock.calls as unknown as Array<
+        [(message: unknown, sender: unknown) => void]
+      >
+    ).map((call) => call[0]);
+    const sender = { identity: "host", metadata: "host-metadata" };
+
+    for (const handler of handlers) {
+      handler(
+        {
+          type: "recording_start",
+          sessionStartedAt: "2026-07-12T10:00:00.000Z",
+          takeId: "take-1",
+        },
+        sender,
+      );
+    }
+    await waitFor(() => {
+      expect(studio.harness.recorderStart).toHaveBeenCalled();
+    });
+
+    for (const handler of handlers) {
+      handler({ type: "recording_stop" }, sender);
+    }
+    await waitFor(() => {
+      expect(studio.harness.completeUpload).toHaveBeenCalled();
+    });
+
+    expect(
+      await studio.screen.findByText(
+        "All audio uploaded — safe to close this tab",
+      ),
+    ).toBeTruthy();
+  });
+});

--- a/tests/studio-presence.test.ts
+++ b/tests/studio-presence.test.ts
@@ -1,0 +1,195 @@
+import { act, fireEvent, waitFor } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import {
+  renderHostStudioPage,
+  setRemoteParticipants,
+} from "./helpers/studio-page";
+
+const BOB = { identity: "guest-bob", name: "Bob" };
+
+describe("StudioPage presence notifications", () => {
+  it("toasts a departure outside recording", async () => {
+    const studio = renderHostStudioPage();
+    await studio.join();
+
+    act(() => setRemoteParticipants([BOB]));
+    act(() => setRemoteParticipants([]));
+
+    expect(await studio.screen.findByText("Bob left the session")).toBeTruthy();
+    expect(
+      studio.screen.queryByText(/left during recording/),
+    ).toBeNull();
+  });
+
+  it("toasts a rejoin and forgets the departure", async () => {
+    const studio = renderHostStudioPage();
+    await studio.join();
+
+    act(() => setRemoteParticipants([BOB]));
+    act(() => setRemoteParticipants([]));
+    await studio.screen.findByText("Bob left the session");
+
+    act(() => setRemoteParticipants([BOB]));
+
+    expect(await studio.screen.findByText("Bob rejoined")).toBeTruthy();
+  });
+
+  it("does not toast when a participant first joins", async () => {
+    const studio = renderHostStudioPage();
+    await studio.join();
+
+    act(() => setRemoteParticipants([BOB]));
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    expect(studio.screen.queryByText("Bob joined")).toBeNull();
+    expect(studio.screen.queryByText("Bob rejoined")).toBeNull();
+    expect(studio.screen.queryByText("Bob left the session")).toBeNull();
+  });
+
+  it("shows a persistent banner when a participant leaves mid-recording", async () => {
+    const studio = renderHostStudioPage();
+    await studio.join();
+    act(() => setRemoteParticipants([BOB]));
+
+    fireEvent.click(
+      studio.screen.getByRole("button", { name: "Start recording" }),
+    );
+    await studio.screen.findByRole("button", { name: "Stop recording" });
+
+    act(() => setRemoteParticipants([]));
+
+    expect(
+      await studio.screen.findByText(
+        "Bob left during recording — their track may be incomplete.",
+      ),
+    ).toBeTruthy();
+    // Banner, not toast: no plain departure toast for mid-recording exits.
+    expect(studio.screen.queryByText("Bob left the session")).toBeNull();
+
+    fireEvent.click(studio.screen.getByRole("button", { name: "dismiss" }));
+    expect(
+      studio.screen.queryByText(
+        "Bob left during recording — their track may be incomplete.",
+      ),
+    ).toBeNull();
+  });
+
+  it("clears the banner and toasts when the participant rejoins mid-recording", async () => {
+    const studio = renderHostStudioPage();
+    await studio.join();
+    act(() => setRemoteParticipants([BOB]));
+
+    fireEvent.click(
+      studio.screen.getByRole("button", { name: "Start recording" }),
+    );
+    await studio.screen.findByRole("button", { name: "Stop recording" });
+
+    act(() => setRemoteParticipants([]));
+    await studio.screen.findByText(
+      "Bob left during recording — their track may be incomplete.",
+    );
+
+    act(() => setRemoteParticipants([BOB]));
+
+    expect(await studio.screen.findByText("Bob rejoined")).toBeTruthy();
+    expect(
+      studio.screen.queryByText(
+        "Bob left during recording — their track may be incomplete.",
+      ),
+    ).toBeNull();
+  });
+
+  it("clears the banner when the take stops", async () => {
+    const studio = renderHostStudioPage();
+    await studio.join();
+    act(() => setRemoteParticipants([BOB]));
+
+    fireEvent.click(
+      studio.screen.getByRole("button", { name: "Start recording" }),
+    );
+    await studio.screen.findByRole("button", { name: "Stop recording" });
+
+    act(() => setRemoteParticipants([]));
+    await studio.screen.findByText(
+      "Bob left during recording — their track may be incomplete.",
+    );
+
+    fireEvent.click(
+      studio.screen.getByRole("button", { name: "Stop recording" }),
+    );
+    await studio.screen.findByRole("button", { name: "Start recording" });
+
+    expect(
+      studio.screen.queryByText(
+        "Bob left during recording — their track may be incomplete.",
+      ),
+    ).toBeNull();
+  });
+
+  it("feeds departed names into the finalize flow", async () => {
+    const studio = renderHostStudioPage();
+    await studio.join();
+    act(() => setRemoteParticipants([BOB]));
+
+    fireEvent.click(
+      studio.screen.getByRole("button", { name: "Start recording" }),
+    );
+    await studio.screen.findByRole("button", { name: "Stop recording" });
+
+    act(() => setRemoteParticipants([]));
+
+    fireEvent.click(
+      studio.screen.getByRole("button", { name: "Stop recording" }),
+    );
+    const finish = await studio.screen.findByRole("button", {
+      name: "Finish recording",
+    });
+
+    // Re-route fetch: finalize stays blocked on Bob's stuck track; every other
+    // request keeps the harness auth-me behavior.
+    const authMe = studio.harness.authMeResponse;
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (input: RequestInfo | URL) => {
+        const url = String(input);
+        if (url.includes("/finalize")) {
+          return Response.json(
+            {
+              pending: [
+                {
+                  trackId: "track-bob",
+                  participantName: "Bob",
+                  status: "uploading",
+                },
+              ],
+            },
+            { status: 409 },
+          );
+        }
+        return Response.json(authMe);
+      }),
+    );
+
+    fireEvent.click(finish);
+
+    expect(
+      await studio.screen.findByText(
+        "Bob left the session — recovering their uploaded audio…",
+      ),
+    ).toBeTruthy();
+  });
+});
+
+describe("StudioPage departure toast names", () => {
+  it("falls back to the identity when the participant has no display name", async () => {
+    const studio = renderHostStudioPage();
+    await studio.join();
+
+    act(() => setRemoteParticipants([{ identity: "guest-7" }]));
+    act(() => setRemoteParticipants([]));
+
+    expect(
+      await studio.screen.findByText("guest-7 left the session"),
+    ).toBeTruthy();
+  });
+});


### PR DESCRIPTION
## What this is

The incident: an invited co-host left the studio silently, nobody in the room was told, and the host's **Finish recording** poll 409'd for 30s before blaming the network (their track was stuck server-side). Design was agreed in-session; this PR implements the three layers that are client-side today.

### 1. Protection for the departing participant
- **Exit-guard hole closed**: a failed upload settles the in-flight counter, so the navigation guard disarmed exactly when leaving would strand audio. It now also arms on surfaced backup-failure state (`backupError` / recoverable manifest) — guaranteed by `handleSlotFailure` for any slot that never confirmed, and it survives a page refresh.
- **Phase-accurate wording**: "Your audio hasn't finished uploading…" once recording has stopped (the old message claimed recording was still in progress during upload drain).
- **Positive all-clear**: "All audio uploaded" (host) / "All audio uploaded — safe to close this tab" (guest) once every local track confirms, so guests stop guessing when it's safe to go.

### 2. Awareness for everyone remaining
- Toasts: "X left the session" (departures outside a take) and "X rejoined" (pairs with the reconnect flow, #75 / #158). Joins stay silent by design.
- Mid-take departures get a **persistent dismissible banner** ("X left during recording — their track may be incomplete.") instead of a missable 4s toast; clears on rejoin or take stop.

### 3. Honest finalize flow
- When the finalize poll is stuck on a departed participant's track: "X left the session — recovering their uploaded audio…", and on timeout "X left before their track finished uploading — retry to recover what they already uploaded." (Retry genuinely helps via the issue-#56 server-side chunk recovery — the old message told you to check your network.)

## Deliberately out of scope
- Server-side cleanup of abandoned tracks — that's the heartbeat/sweeper (#154, stack 5 phase B); it will supersede the client-side departed-names plumbing.
- Guest-facing "session ended" notice on finalize and host-gating the Finish button — both belong to the role-aware studio view (#72).

## Testing
- 271 unit tests pass; 16 new ones (presence toasts/banner, exit guard arming/wording, all-clear, Finish labels). Existing test cases untouched; the studio harness gained a controllable `useRemoteParticipants` store + inspectable navigation-guard mock (additive).
- Full Playwright browser smoke vs the real local stack (Postgres/MinIO/LiveKit): 5/5, including multi-guest recording and failed-final-upload recovery.
- Typecheck + lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)